### PR TITLE
Translate JavaDoc comments from Japanese to English

### DIFF
--- a/src/main/java/org/codelibs/core/beans/impl/BeanDescImpl.java
+++ b/src/main/java/org/codelibs/core/beans/impl/BeanDescImpl.java
@@ -66,38 +66,38 @@ import org.codelibs.core.lang.StringUtil;
  */
 public class BeanDescImpl implements BeanDesc {
 
-    /** 空のオブジェクト配列 */
+    /** Empty object array */
     protected static final Object[] EMPTY_ARGS = new Object[0];
 
-    /** 空のクラス配列 */
+    /** Empty class array */
     protected static final Class<?>[] EMPTY_PARAM_TYPES = new Class<?>[0];
 
-    /** Beanのクラス */
+    /** The class of the bean */
     protected final Class<?> beanClass;
 
-    /** 型引数と型変数のマップ */
+    /** Map of type arguments and type variables */
     protected final Map<TypeVariable<?>, Type> typeVariables;
 
-    /** プロパティ名から{@link PropertyDesc}へのマップ */
+    /** Map from property name to {@link PropertyDesc} */
     protected final CaseInsensitiveMap<PropertyDesc> propertyDescCache = new CaseInsensitiveMap<>();
 
-    /** フィールド名から{@link FieldDescImpl}へのマップ */
+    /** Map from field name to {@link FieldDescImpl} */
     protected final ArrayMap<String, FieldDesc> fieldDescCache = new ArrayMap<>();
 
-    /** {@link ConstructorDesc}の配列 */
+    /** Array of {@link ConstructorDesc} */
     protected final List<ConstructorDesc> constructorDescs = newArrayList();
 
-    /** メソッド名から{@link MethodDesc}配列へのマップ */
+    /** Map from method name to array of {@link MethodDesc} */
     protected final Map<String, MethodDesc[]> methodDescsCache = newHashMap();
 
-    /** 不正なプロパティ名のセット */
+    /** Set of invalid property names */
     protected final Set<String> invalidPropertyNames = newHashSet();
 
     /**
-     * {@link BeanDescImpl}を作成します。
+     * Creates a {@link BeanDescImpl}.
      *
      * @param beanClass
-     *            ビーンのクラス。{@literal null}であってはいけません
+     *            the class of the bean. Must not be {@literal null}
      */
     public BeanDescImpl(final Class<?> beanClass) {
         assertArgumentNotNull("beanClass", beanClass);
@@ -302,22 +302,22 @@ public class BeanDescImpl implements BeanDesc {
     }
 
     /**
-     * {@link PropertyDesc}を返します。
+     * Returns the {@link PropertyDesc} for the specified property name.
      *
      * @param propertyName
-     *            プロパティ名
-     * @return {@link PropertyDesc}。プロパティが存在しない場合は{@literal null}
+     *            the property name
+     * @return the {@link PropertyDesc}, or {@literal null} if the property does not exist
      */
     protected PropertyDesc getPropertyDescNoException(final String propertyName) {
         return propertyDescCache.get(propertyName);
     }
 
     /**
-     * 引数に適合する{@link ConstructorDesc}を返します。
+     * Returns a {@link ConstructorDesc} that matches the given arguments.
      *
      * @param args
-     *            コンストラクタ引数の並び
-     * @return 引数に適合する{@link ConstructorDesc}。存在しない場合は{@literal null}
+     *            the constructor arguments
+     * @return a {@link ConstructorDesc} that matches the arguments, or {@literal null} if none exists
      */
     protected ConstructorDesc findSuitableConstructorDesc(final Object... args) {
         for (final ConstructorDesc constructorDesc : constructorDescs) {
@@ -329,14 +329,14 @@ public class BeanDescImpl implements BeanDesc {
     }
 
     /**
-     * 引数に適合する{@link ConstructorDesc}を返します。
+     * Returns a {@link ConstructorDesc} that matches the given arguments.
      * <p>
-     * 引数の型が数値の場合、引数を数値に変換することが出来れば適合するとみなします。
+     * If the parameter type is a number, it is considered a match if the argument can be converted to the number type.
      * </p>
      *
      * @param args
-     *            コンストラクタ引数の並び
-     * @return 引数に適合する{@link ConstructorDesc}。存在しない場合は{@literal null}
+     *            the constructor arguments
+     * @return a {@link ConstructorDesc} that matches the arguments, or {@literal null} if none exists
      */
     protected ConstructorDesc findSuitableConstructorDescAdjustNumber(final Object... args) {
         for (final ConstructorDesc constructorDesc : constructorDescs) {
@@ -348,13 +348,13 @@ public class BeanDescImpl implements BeanDesc {
     }
 
     /**
-     * 引数に適合する{@link MethodDesc}を返します。
+     * Returns a {@link MethodDesc} that matches the given arguments.
      *
      * @param methodDescs
-     *            メソッドの配列
+     *            array of methods
      * @param args
-     *            メソッド引数の並び
-     * @return 引数に適合する{@link MethodDesc}。存在しない場合は{@literal null}
+     *            array of method arguments
+     * @return a {@link MethodDesc} that matches the arguments, or {@literal null} if none exists
      */
     protected MethodDesc findSuitableMethod(final MethodDesc[] methodDescs, final Object[] args) {
         for (final MethodDesc methodDesc : methodDescs) {
@@ -366,16 +366,16 @@ public class BeanDescImpl implements BeanDesc {
     }
 
     /**
-     * 引数に適合する{@link MethodDesc}を返します。
+     * Returns a {@link MethodDesc} that matches the given arguments.
      * <p>
-     * 引数の型が数値の場合、引数を数値に変換することが出来れば適合するとみなします。
+     * If the parameter type is a number, it is considered a match if the argument can be converted to the number type.
      * </p>
      *
      * @param methodDescs
-     *            メソッドの配列
+     *            array of methods
      * @param args
-     *            メソッド引数の並び
-     * @return 引数に適合する{@link MethodDesc}。存在しない場合は{@literal null}
+     *            array of method arguments
+     * @return a {@link MethodDesc} that matches the arguments, or {@literal null} if none exists
      */
     protected MethodDesc findSuitableMethodDescAdjustNumber(final MethodDesc[] methodDescs, final Object[] args) {
         for (final MethodDesc methodDesc : methodDescs) {
@@ -387,15 +387,15 @@ public class BeanDescImpl implements BeanDesc {
     }
 
     /**
-     * 引数が引数型に適合するかチェックします。
+     * Checks whether the arguments are suitable for the parameter types.
      *
      * @param paramTypes
-     *            引数型の並び
+     *            array of parameter types
      * @param args
-     *            引数の並び
+     *            array of arguments
      * @param adjustNumber
-     *            引数型が数値型の場合に引数を適合するように変換する場合は{@literal true}
-     * @return 引数が引数型に適合する場合は{@literal true}
+     *            if {@literal true}, converts arguments to match number types if necessary
+     * @return {@literal true} if the arguments are suitable for the parameter types
      */
     protected boolean isSuitable(final Class<?>[] paramTypes, final Object[] args, final boolean adjustNumber) {
         if (args == null) {
@@ -420,15 +420,15 @@ public class BeanDescImpl implements BeanDesc {
     }
 
     /**
-     * 指定された位置の引数型が数値の場合、引数を適合するように変換します。
+     * If the argument type at the specified position is a number, converts the argument to match the type.
      *
      * @param paramTypes
-     *            引数型の並び
+     *            array of parameter types
      * @param args
-     *            引数の並び
+     *            array of arguments
      * @param index
-     *            操作対象となる引数のインデックス
-     * @return 引数を適合するように変換した場合は{@literal true}
+     *            index of the argument to operate on
+     * @return {@literal true} if the argument was converted to match the type
      */
     protected static boolean adjustNumber(final Class<?>[] paramTypes, final Object[] args, final int index) {
         if (paramTypes[index].isPrimitive()) {

--- a/src/main/java/org/codelibs/core/collection/ArrayIterator.java
+++ b/src/main/java/org/codelibs/core/collection/ArrayIterator.java
@@ -23,9 +23,9 @@ import java.util.NoSuchElementException;
 import org.codelibs.core.exception.ClUnsupportedOperationException;
 
 /**
- * 配列を{@link Iterator}にするAdaptorです。
+ * Adaptor that makes an array into an {@link Iterator}.
  * <p>
- * 次のように使います．
+ * Usage example:
  * </p>
  *
  * <pre>
@@ -38,25 +38,22 @@ import org.codelibs.core.exception.ClUnsupportedOperationException;
  * </pre>
  *
  * @author shot
- * @param <T>
- *            配列の要素の型
+ * @param <T> the type of array elements
  */
 public class ArrayIterator<T> implements Iterator<T> {
 
-    /** イテレートする要素の配列 */
+    /** The array of elements to iterate over */
     protected final T[] items;
 
-    /** 現在参照している要素のインデックス */
+    /** The index of the currently referenced element */
     protected int index = 0;
 
     /**
-     * for each構文で使用するために配列をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps the array for use in a for-each statement.
      *
-     * @param <T>
-     *            列挙する要素の型
-     * @param items
-     *            イテレートする要素の並び。{@literal null}であってはいけません
-     * @return 配列をラップした{@link Iterable}
+     * @param <T> the type of elements
+     * @param items the array of elements to iterate (must not be {@literal null})
+     * @return an {@link Iterable} wrapping the array
      */
     public static <T> Iterable<T> iterable(final T... items) {
         assertArgumentNotNull("items", items);
@@ -65,10 +62,9 @@ public class ArrayIterator<T> implements Iterator<T> {
     }
 
     /**
-     * {@link ArrayIterator}を作成します。
+     * Creates an {@link ArrayIterator}.
      *
-     * @param items
-     *            イテレートする要素の並び。{@literal null}であってはいけません
+     * @param items the array of elements to iterate (must not be {@literal null})
      */
     public ArrayIterator(final T... items) {
         this.items = items;

--- a/src/main/java/org/codelibs/core/collection/ArrayMap.java
+++ b/src/main/java/org/codelibs/core/collection/ArrayMap.java
@@ -32,52 +32,49 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
- * 配列の性質を併せ持つ {@link Map}です。
+ * A {@link Map} that combines the characteristics of an array.
  *
  * @author higa
- * @param <K>
- *            キーの型
- * @param <V>
- *            値の型
+ * @param <K> the type of keys
+ * @param <V> the type of values
  *
  */
 public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Cloneable, Externalizable {
 
     private static final long serialVersionUID = 1L;
 
-    /** 初期容量のデフォルト値 */
+    /** The default value of the initial capacity */
     public static final int INITIAL_CAPACITY = 17;
 
-    /** 負荷係数のデフォルト値 */
+    /** The default value of the load factor */
     public static final float LOAD_FACTOR = 0.75f;
 
-    /** 負荷係数 */
+    /** Load factor */
     protected transient int threshold;
 
-    /** マップとしてのエントリ */
+    /** Entry as a map */
     protected transient Entry<K, V>[] mapTable;
 
-    /** 配列としてのエントリ */
+    /** Entry as an array */
     protected transient Entry<K, V>[] listTable;
 
-    /** 要素数 */
+    /** Number of elements */
     protected transient int size = 0;
 
-    /** {@link Set}としてのビュー */
+    /** View as a {@link Set} */
     protected transient Set<? extends Map.Entry<K, V>> entrySet = null;
 
     /**
-     * デフォルトの初期容量を持つインスタンスを構築します。
+     * Constructs an instance with the default initial capacity.
      */
     public ArrayMap() {
         this(INITIAL_CAPACITY);
     }
 
     /**
-     * 指定された初期容量を持つインスタンスを構築します。
+     * Constructs an instance with the specified initial capacity.
      *
-     * @param initialCapacity
-     *            初期容量
+     * @param initialCapacity the initial capacity
      */
     @SuppressWarnings("unchecked")
     public ArrayMap(int initialCapacity) {
@@ -90,10 +87,10 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * 指定された{@link Map}と同じマッピングでインスタンスを構築します。
+     * Constructs an instance with the same mappings as the specified {@link Map}.
      *
      * @param map
-     *            マッピングがこのマップに配置されるマップ
+     *            the map whose mappings are to be placed in this map
      */
     public ArrayMap(final Map<? extends K, ? extends V> map) {
         this((int) (map.size() / LOAD_FACTOR) + 1);
@@ -116,11 +113,11 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * 値に対するインデックスを返します。
+     * Returns the index for the specified value.
      *
      * @param value
-     *            値
-     * @return 値に対するインデックス。値が含まれていない場合は{@literal -1}
+     *            the value
+     * @return the index for the value, or {@literal -1} if the value is not contained
      */
     public int indexOf(final Object value) {
         if (value != null) {
@@ -182,33 +179,33 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * インデックスで指定された位置の値を返します。
+     * Returns the value at the specified index.
      *
      * @param index
-     *            インデックス
-     * @return インデックスで指定された位置の値
+     *            the index
+     * @return the value at the specified index
      */
     public V getAt(final int index) {
         return getEntryAt(index).getValue();
     }
 
     /**
-     * インデックスで指定された位置のキーを返します。
+     * Returns the key at the specified index.
      *
      * @param index
-     *            インデックス
-     * @return インデックスで指定された位置のキー
+     *            the index
+     * @return the key at the specified index
      */
     public K getKeyAt(final int index) {
         return getEntryAt(index).getKey();
     }
 
     /**
-     * インデックスで指定された位置の{@link java.util.Map.Entry}を返します。
+     * Returns the {@link java.util.Map.Entry} at the specified index.
      *
      * @param index
-     *            インデックス
-     * @return インデックスで指定された位置の{@link java.util.Map.Entry}
+     *            the index
+     * @return the {@link java.util.Map.Entry} at the specified index
      */
     public Map.Entry<K, V> getEntryAt(final int index) {
         assertIndex(index < size, "Index:" + index + ", Size:" + size);
@@ -244,12 +241,12 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * インデックスで指定された位置に値を設定します。
+     * Sets the value at the specified index.
      *
      * @param index
-     *            インデックス
+     *            the index
      * @param value
-     *            値
+     *            the value
      */
     public void setAt(final int index, final V value) {
         getEntryAt(index).setValue(value);
@@ -268,11 +265,11 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * インデックスで指定された位置のエントリを削除します。
+     * Removes the entry at the specified index.
      *
      * @param index
-     *            インデックス
-     * @return インデックスで指定された位置にあったエントリの値
+     *            the index
+     * @return the value of the entry at the specified index
      */
     public V removeAt(final int index) {
         final Entry<K, V> e = removeList(index);
@@ -301,9 +298,9 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * 配列に変換します。
+     * Converts this map to an array.
      *
-     * @return 配列
+     * @return the array
      */
     public Object[] toArray() {
         final Object[] array = new Object[size];
@@ -314,11 +311,11 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * 配列に変換します。
+     * Converts this map to an array.
      *
      * @param proto
-     *            要素の格納先の配列。配列のサイズが十分でない場合は、同じ実行時の型で新しい配列が格納用として割り当てられる
-     * @return 配列
+     *            the array into which the elements of this map are to be stored, if it is big enough; otherwise, a new array of the same runtime type is allocated for this purpose.
+     * @return the array containing the values of this map
      */
     public V[] toArray(final V[] proto) {
         @SuppressWarnings("unchecked")
@@ -443,11 +440,11 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * エントリのインデックスを返します。
+     * Returns the index of the entry.
      *
      * @param entry
-     *            エントリ
-     * @return エントリのインデックス
+     *            the entry
+     * @return the index of the entry
      */
     protected int entryIndexOf(final Entry<K, V> entry) {
         for (int i = 0; i < size; i++) {
@@ -459,11 +456,11 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * キーで指定されたエントリをマップのエントリから削除します。
+     * Removes the entry corresponding to the specified key from the map entries.
      *
      * @param key
-     *            キー
-     * @return 削除されたエントリ。キーに対応するエントリがなかった場合は{@literal null}
+     *            the key
+     * @return the removed entry, or {@literal null} if there was no entry for the key
      */
     protected Entry<K, V> removeMap(final Object key) {
         int hashCode = 0;
@@ -498,11 +495,11 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * インデックスで指定されたエントリをリストのエントリから削除します。
+     * Removes the entry at the specified index from the list entries.
      *
      * @param index
-     *            削除するエントリのインデックス
-     * @return 削除されたエントリ
+     *            the index of the entry to remove
+     * @return the removed entry
      */
     protected Entry<K, V> removeList(final int index) {
         final Entry<K, V> e = listTable[index];
@@ -515,7 +512,7 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * サイズが閾値を超えた場合に容量を確保します。
+     * Ensures capacity when the size exceeds the threshold.
      */
     protected void ensureCapacity() {
         if (size >= threshold) {
@@ -541,13 +538,13 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * エントリの値を新しい値で置き換えます。
+     * Replaces the value of the entry with a new value.
      *
      * @param entry
-     *            エントリ
+     *            the entry
      * @param value
-     *            エントリの新しい値
-     * @return エントリの置き換えられる前の値
+     *            the new value for the entry
+     * @return the previous value of the entry
      */
     protected V swapValue(final Entry<K, V> entry, final V value) {
         final V old = entry.value;
@@ -556,14 +553,14 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * {@link ArrayMap}用の{@link Iterator}です。
+     * {@link Iterator} for {@link ArrayMap}.
      */
     protected class ArrayMapIterator implements Iterator<Entry<K, V>> {
 
-        /** 現在のインデックス */
+        /** Current index */
         protected int current = 0;
 
-        /** 最後にアクセスした要素のインデックス */
+        /** Index of the last accessed element */
         protected int last = -1;
 
         @Override
@@ -594,46 +591,46 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
     }
 
     /**
-     * {@link ArrayMap}の{@link Map.Entry}です。
+     * {@link Map.Entry} implementation for {@link ArrayMap}.
      *
      * @param <K>
-     *            キーの型
+     *            the type of keys
      * @param <V>
-     *            キーの値
+     *            the type of values
      */
     protected static class Entry<K, V> implements Map.Entry<K, V>, Externalizable {
 
         private static final long serialVersionUID = -6625980241350717177L;
 
-        /** ハッシュ値 */
+        /** Hash value */
         protected transient int hashCode;
 
-        /** キー */
+        /** Key */
         protected transient K key;
 
-        /** 値 */
+        /** Value */
         protected transient V value;
 
-        /** 次のエントリ */
+        /** Next entry */
         protected transient Entry<K, V> next;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          */
         public Entry() {
         }
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param hashCode
-         *            ハッシュ値
+         *            the hash value
          * @param key
-         *            キー
+         *            the key
          * @param value
-         *            値
+         *            the value
          * @param next
-         *            次のエントリ
+         *            the next entry
          */
         public Entry(final int hashCode, final K key, final V value, final Entry<K, V> next) {
             this.hashCode = hashCode;
@@ -660,7 +657,7 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
         }
 
         /**
-         * 状態をクリアします。
+         * Clears the state.
          */
         public void clear() {
             key = null;

--- a/src/main/java/org/codelibs/core/collection/ArrayUtil.java
+++ b/src/main/java/org/codelibs/core/collection/ArrayUtil.java
@@ -28,242 +28,222 @@ import java.util.List;
 import org.codelibs.core.message.MessageFormatter;
 
 /**
- * 配列に対するユーティリティクラスです。
+ * Utility class for array operations.
  *
  * @author higa
  */
 public abstract class ArrayUtil {
 
     /**
-     * {@literal boolean}の配列を返します。
+     * Returns an array of {@literal boolean}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static boolean[] asBooleanArray(final boolean... elements) {
         return elements;
     }
 
     /**
-     * {@literal char}の配列を返します。
+     * Returns an array of {@literal char}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static char[] asCharArray(final char... elements) {
         return elements;
     }
 
     /**
-     * {@literal byte}の配列を返します。
+     * Returns an array of {@literal byte}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static byte[] asByteArray(final byte... elements) {
         return elements;
     }
 
     /**
-     * {@literal short}の配列を返します。
+     * Returns an array of {@literal short}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static short[] asShortArray(final short... elements) {
         return elements;
     }
 
     /**
-     * {@literal int}の配列を返します。
+     * Returns an array of {@literal int}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static int[] asIntArray(final int... elements) {
         return elements;
     }
 
     /**
-     * {@literal long}の配列を返します。
+     * Returns an array of {@literal long}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static long[] asLongArray(final long... elements) {
         return elements;
     }
 
     /**
-     * {@literal float}の配列を返します。
+     * Returns an array of {@literal float}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static float[] asFloatArray(final float... elements) {
         return elements;
     }
 
     /**
-     * {@literal double}の配列を返します。
+     * Returns an array of {@literal double}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static double[] asDoubleArray(final double... elements) {
         return elements;
     }
 
     /**
-     * {@literal Object}の配列を返します。
+     * Returns an array of {@literal Object}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Object[] asArray(final Object... elements) {
         return elements;
     }
 
     /**
-     * {@literal String}の配列を返します。
+     * Returns an array of {@literal String}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static String[] asStringArray(final String... elements) {
         return elements;
     }
 
     /**
-     * {@literal Boolean}の配列を返します。
+     * Returns an array of {@literal Boolean}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Boolean[] asArray(final Boolean... elements) {
         return elements;
     }
 
     /**
-     * {@literal Character}の配列を返します。
+     * Returns an array of {@literal Character}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Character[] asArray(final Character... elements) {
         return elements;
     }
 
     /**
-     * {@literal Byte}の配列を返します。
+     * Returns an array of {@literal Byte}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Byte[] asArray(final Byte... elements) {
         return elements;
     }
 
     /**
-     * {@literal Short}の配列を返します。
+     * Returns an array of {@literal Short}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Short[] asArray(final Short... elements) {
         return elements;
     }
 
     /**
-     * {@literal Integer}の配列を返します。
+     * Returns an array of {@literal Integer}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Integer[] asArray(final Integer... elements) {
         return elements;
     }
 
     /**
-     * {@literal Long}の配列を返します。
+     * Returns an array of {@literal Long}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Long[] asArray(final Long... elements) {
         return elements;
     }
 
     /**
-     * {@literal Float}の配列を返します。
+     * Returns an array of {@literal Float}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Float[] asArray(final Float... elements) {
         return elements;
     }
 
     /**
-     * {@literal Double}の配列を返します。
+     * Returns an array of {@literal Double}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static Double[] asArray(final Double... elements) {
         return elements;
     }
 
     /**
-     * {@literal BigInteger}の配列を返します。
+     * Returns an array of {@literal BigInteger}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static BigInteger[] asArray(final BigInteger... elements) {
         return elements;
     }
 
     /**
-     * {@literal BigDecimal}の配列を返します。
+     * Returns an array of {@literal BigDecimal}.
      *
-     * @param elements
-     *            配列の要素
-     * @return 配列
+     * @param elements the elements of the array
+     * @return the array
      */
     public static BigDecimal[] asArray(final BigDecimal... elements) {
         return elements;
     }
 
     /**
-     * 配列の末尾にオブジェクトを追加した配列を返します。
+     * Returns a new array with the specified object appended to the end.
      *
      * @param <T>
-     *            配列の要素型
+     *            the type of the array elements
      * @param array
-     *            配列。{@literal null}であってはいけません
+     *            the array. Must not be {@literal null}
      * @param obj
-     *            オブジェクト
-     * @return オブジェクトが追加された結果の配列
+     *            the object to add
+     * @return a new array with the object appended
      */
     public static <T> T[] add(final T[] array, final T obj) {
         assertArgumentNotNull("array", array);
@@ -277,13 +257,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * {@literal boolean}配列の末尾に{@literal boolean}の値を追加した配列を返します。
+     * Returns a new array with the specified boolean value appended to the end of the boolean array.
      *
      * @param array
-     *            配列。{@literal null}であってはいけません
+     *            the array. Must not be {@literal null}
      * @param value
-     *            値
-     * @return 値が追加された結果の配列
+     *            the value to add
+     * @return a new array with the value appended
      */
     public static boolean[] add(final boolean[] array, final boolean value) {
         assertArgumentNotNull("array", array);
@@ -294,13 +274,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * {@literal byte}配列の末尾に{@literal byte}の値を追加した配列を返します。
+     * Returns a new array with the specified byte value appended to the end of the byte array.
      *
      * @param array
-     *            配列
+     *            the array. Must not be {@literal null}
      * @param value
-     *            値
-     * @return 値が追加された結果の配列
+     *            the value to add
+     * @return a new array with the value appended
      */
     public static byte[] add(final byte[] array, final byte value) {
         assertArgumentNotNull("array", array);
@@ -312,13 +292,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * {@literal short}配列の末尾に{@literal short}の値を追加した配列を返します。
+     * Returns a new array with the specified short value appended to the end of the short array.
      *
      * @param array
-     *            配列。{@literal null}であってはいけません
+     *            the array. Must not be {@literal null}
      * @param value
-     *            値
-     * @return 値が追加された結果の配列
+     *            the value to add
+     * @return a new array with the value appended
      */
     public static short[] add(final short[] array, final short value) {
         assertArgumentNotNull("array", array);
@@ -330,13 +310,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * {@literal int}配列の末尾に{@literal int}の値を追加した配列を返します。
+     * Returns a new array with the specified int value appended to the end of the int array.
      *
      * @param array
-     *            配列。{@literal null}であってはいけません
+     *            the array. Must not be {@literal null}
      * @param value
-     *            値
-     * @return 値が追加された結果の配列
+     *            the value to add
+     * @return a new array with the value appended
      */
     public static int[] add(final int[] array, final int value) {
         assertArgumentNotNull("array", array);
@@ -348,13 +328,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * {@literal long}配列の末尾に{@literal long}の値を追加した配列を返します。
+     * Returns a new array with the specified long value appended to the end of the long array.
      *
      * @param array
-     *            配列。{@literal null}であってはいけません
+     *            the array. Must not be {@literal null}
      * @param value
-     *            値
-     * @return 値が追加された結果の配列
+     *            the value to add
+     * @return a new array with the value appended
      */
     public static long[] add(final long[] array, final long value) {
         assertArgumentNotNull("array", array);
@@ -366,13 +346,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * {@literal float}配列の末尾に{@literal float}の値を追加した配列を返します。
+     * Returns a new array with the specified float value appended to the end of the float array.
      *
      * @param array
-     *            配列。{@literal null}であってはいけません
+     *            the array. Must not be {@literal null}
      * @param value
-     *            値
-     * @return 値が追加された結果の配列
+     *            the value to add
+     * @return a new array with the value appended
      */
     public static float[] add(final float[] array, final float value) {
         assertArgumentNotNull("array", array);
@@ -384,13 +364,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * {@literal double}配列の末尾に{@literal double}の値を追加した配列を返します。
+     * Returns a new array with the specified double value appended to the end of the double array.
      *
      * @param array
-     *            配列。{@literal null}であってはいけません
+     *            the array. Must not be {@literal null}
      * @param value
-     *            値
-     * @return 値が追加された結果の配列
+     *            the value to add
+     * @return a new array with the value appended
      */
     public static double[] add(final double[] array, final double value) {
         assertArgumentNotNull("array", array);
@@ -402,19 +382,20 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static <T> T[] addAll(final T[] a, final T[] b) {
         if (a == null) {
@@ -437,17 +418,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static boolean[] addAll(final boolean[] a, final boolean[] b) {
         if (a == null) {
@@ -469,17 +451,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static byte[] addAll(final byte[] a, final byte[] b) {
         if (a == null) {
@@ -501,17 +484,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static short[] addAll(final short[] a, final short[] b) {
         if (a == null) {
@@ -533,17 +517,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static int[] addAll(final int[] a, final int[] b) {
         if (a == null) {
@@ -565,17 +550,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static long[] addAll(final long[] a, final long[] b) {
         if (a == null) {
@@ -597,17 +583,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static float[] addAll(final float[] a, final float[] b) {
         if (a == null) {
@@ -629,17 +616,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static double[] addAll(final double[] a, final double[] b) {
         if (a == null) {
@@ -661,17 +649,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 二つの配列を連結した配列を返します。
+     * Returns an array that is the concatenation of two arrays.
      * <p>
-     * どちらかあるいは両方の配列が{@literal null}の場合、他方の配列がそのまま返されます。 どちらかあるいは両方の配列の長さが
-     * {@literal 0}の場合、他方の配列がそのまま返されます。 いずれの場合も返される配列は引数に渡された配列そのものでコピーはされません。
+     * If either or both arrays are {@literal null}, the other array is returned as is.
+     * If either or both arrays have a length of {@literal 0}, the other array is returned as is.
+     * In any case, the returned array is the same instance as the argument array and is not copied.
      * </p>
      *
      * @param a
-     *            配列1
+     *            first array
      * @param b
-     *            配列2
-     * @return 配列が連結された結果の配列
+     *            second array
+     * @return the concatenated result array
      */
     public static char[] addAll(final char[] a, final char[] b) {
         if (a == null) {
@@ -693,32 +682,32 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中からオジェクトが最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified object in the array.
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param array
-     *            配列
+     *            the array
      * @param obj
-     *            検索するオブジェクト
-     * @return 配列中からオジェクトが最初に見つかったインデックス
+     *            the object to search for
+     * @return the index of the first occurrence of the object in the array
      */
     public static <T> int indexOf(final T[] array, final T obj) {
         return indexOf(array, obj, 0);
     }
 
     /**
-     * 配列中からオジェクトが最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified object in the array, starting the search at the specified index.
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param array
-     *            配列
+     *            the array
      * @param obj
-     *            検索するオブジェクト
+     *            the object to search for
      * @param fromIndex
-     *            検索を始めるインデックス
-     * @return 配列中からオジェクトが最初に見つかったインデックス。見つからなかった場合は{@literal -1}
+     *            the index to start the search from
+     * @return the index of the first occurrence of the object in the array, or {@literal -1} if not found
      */
     public static <T> int indexOf(final T[] array, final T obj, final int fromIndex) {
         if (array != null) {
@@ -738,13 +727,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中から値が最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified value in the array.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列中から値が最初に見つかったインデックス
+     *            the value to search for
+     * @return the index of the first occurrence of the value in the array
      */
     public static int indexOf(final boolean[] array, final boolean value) {
         if (array != null) {
@@ -758,13 +747,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中から値が最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified value in the array.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列中から値が最初に見つかったインデックス
+     *            the value to search for
+     * @return the index of the first occurrence of the value in the array
      */
     public static int indexOf(final byte[] array, final byte value) {
         if (array != null) {
@@ -778,13 +767,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中から値が最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified value in the array.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列中から値が最初に見つかったインデックス
+     *            the value to search for
+     * @return the index of the first occurrence of the value in the array
      */
     public static int indexOf(final short[] array, final short value) {
         if (array != null) {
@@ -798,13 +787,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中から値が最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified value in the array.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列中から値が最初に見つかったインデックス
+     *            the value to search for
+     * @return the index of the first occurrence of the value in the array
      */
     public static int indexOf(final int[] array, final int value) {
         if (array != null) {
@@ -818,13 +807,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中から値が最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified value in the array.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列中から値が最初に見つかったインデックス
+     *            the value to search for
+     * @return the index of the first occurrence of the value in the array
      */
     public static int indexOf(final long[] array, final long value) {
         if (array != null) {
@@ -838,13 +827,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中から値が最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified value in the array.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列中から値が最初に見つかったインデックス
+     *            the value to search for
+     * @return the index of the first occurrence of the value in the array
      */
     public static int indexOf(final float[] array, final float value) {
         if (array != null) {
@@ -858,13 +847,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中から値が最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified value in the array.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列中から値が最初に見つかったインデックス
+     *            the value to search for
+     * @return the index of the first occurrence of the value in the array
      */
     public static int indexOf(final double[] array, final double value) {
         if (array != null) {
@@ -878,13 +867,13 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列中から値が最初に見つかったインデックスを返します。
+     * Returns the index of the first occurrence of the specified value in the array.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列中から値が最初に見つかったインデックス
+     *            the value to search for
+     * @return the index of the first occurrence of the value in the array
      */
     public static int indexOf(final char[] array, final char value) {
         if (array != null) {
@@ -898,18 +887,18 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列から最初に見つかったオブジェクトを削除した結果の配列を返します。
+     * Returns a new array with the first occurrence of the specified object removed.
      * <p>
-     * 配列にオブジェクトが含まれていない場合は引数で渡された配列をそのまま返します。
+     * If the array does not contain the object, the original array is returned as is.
      * </p>
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param array
-     *            配列
+     *            the array
      * @param obj
-     *            配列から削除する要素
-     * @return 削除後の配列
+     *            the element to remove from the array
+     * @return the array after removal
      */
     public static <T> T[] remove(final T[] array, final T obj) {
         final int index = indexOf(array, obj);
@@ -928,336 +917,336 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static <T> boolean isEmpty(final T[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}でも長さが0でもない場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static <T> boolean isNotEmpty(final T[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static boolean isEmpty(final boolean[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static boolean isNotEmpty(final boolean[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static boolean isEmpty(final byte[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}でも長さが0でもない場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static boolean isNotEmpty(final byte[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static boolean isEmpty(final short[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}でも長さが0でもない場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static boolean isNotEmpty(final short[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static boolean isEmpty(final int[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}でも長さが0でもない場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static boolean isNotEmpty(final int[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static boolean isEmpty(final long[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}でも長さが0でもない場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static boolean isNotEmpty(final long[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static boolean isEmpty(final float[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}でも長さが0でもない場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static boolean isNotEmpty(final float[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static boolean isEmpty(final double[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}でも長さが0でもない場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static boolean isNotEmpty(final double[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列が{@literal null}または長さが0の場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is {@literal null} or has a length of 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}または長さが0の場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is {@literal null} or has a length of 0
      */
     public static boolean isEmpty(final char[] arrays) {
         return arrays == null || arrays.length == 0;
     }
 
     /**
-     * 配列が{@literal null}でも長さが0でもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the array is not {@literal null} and its length is not 0.
      *
      * @param arrays
-     *            配列
-     * @return 配列が{@literal null}でも長さが0でもない場合は{@literal true}
+     *            the array
+     * @return {@literal true} if the array is not {@literal null} and its length is not 0
      */
     public static boolean isNotEmpty(final char[] arrays) {
         return arrays != null && arrays.length != 0;
     }
 
     /**
-     * 配列にオブジェクトが含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified object.
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param array
-     *            配列
+     *            the array
      * @param obj
-     *            オブジェクト
-     * @return 配列にオブジェクトが含まれていれば{@literal true}
+     *            the object to search for
+     * @return {@literal true} if the array contains the specified object
      */
     public static <T> boolean contains(final T[] array, final T obj) {
         return indexOf(array, obj) > -1;
     }
 
     /**
-     * 配列に値が含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified value.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列に値が含まれていれば{@literal true}
+     *            the value to search for
+     * @return {@literal true} if the array contains the specified value
      */
     public static boolean contains(final boolean[] array, final boolean value) {
         return indexOf(array, value) > -1;
     }
 
     /**
-     * 配列に値が含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified value.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列に値が含まれていれば{@literal true}
+     *            the value to search for
+     * @return {@literal true} if the array contains the specified value
      */
     public static boolean contains(final byte[] array, final byte value) {
         return indexOf(array, value) > -1;
     }
 
     /**
-     * 配列に値が含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified value.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列に値が含まれていれば{@literal true}
+     *            the value to search for
+     * @return {@literal true} if the array contains the specified value
      */
     public static boolean contains(final short[] array, final short value) {
         return indexOf(array, value) > -1;
     }
 
     /**
-     * 配列に値が含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified value.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列に値が含まれていれば{@literal true}
+     *            the value to search for
+     * @return {@literal true} if the array contains the specified value
      */
     public static boolean contains(final int[] array, final int value) {
         return indexOf(array, value) > -1;
     }
 
     /**
-     * 配列に値が含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified value.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列に値が含まれていれば{@literal true}
+     *            the value to search for
+     * @return {@literal true} if the array contains the specified value
      */
     public static boolean contains(final long[] array, final long value) {
         return indexOf(array, value) > -1;
     }
 
     /**
-     * 配列に値が含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified value.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列に値が含まれていれば{@literal true}
+     *            the value to search for
+     * @return {@literal true} if the array contains the specified value
      */
     public static boolean contains(final float[] array, final float value) {
         return indexOf(array, value) > -1;
     }
 
     /**
-     * 配列に値が含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified value.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列に値が含まれていれば{@literal true}
+     *            the value to search for
+     * @return {@literal true} if the array contains the specified value
      */
     public static boolean contains(final double[] array, final double value) {
         return indexOf(array, value) > -1;
     }
 
     /**
-     * 配列に値が含まれていれば{@literal true}を返します。
+     * Returns {@literal true} if the array contains the specified value.
      *
      * @param array
-     *            配列
+     *            the array
      * @param value
-     *            値
-     * @return 配列に文字が含まれていれば{@literal true}
+     *            the value to search for
+     * @return {@literal true} if the array contains the specified character
      */
     public static boolean contains(final char[] array, final char value) {
         return indexOf(array, value) > -1;
     }
 
     /**
-     * 順番は無視して2つの配列が等しければ{@literal true}を返します。
+     * Returns {@literal true} if the two arrays are equal, ignoring the order of elements.
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param array1
-     *            配列1
+     *            the first array
      * @param array2
-     *            配列2
-     * @return 順番は無視して2つの配列が等しければ{@literal true}
+     *            the second array
+     * @return {@literal true} if the two arrays are equal, ignoring the order of elements
      */
     public static <T> boolean equalsIgnoreSequence(final T[] array1, final T[] array2) {
         if (array1 == null && array2 == null) {
@@ -1285,14 +1274,14 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列をオブジェクトの配列({@literal Object[]})に変換します。
+     * Converts an array to an object array ({@literal Object[]}).
      * <p>
-     * 変換元の配列にはプリミティブ型の配列を渡すことができます。 その場合、変換された配列の要素型はプリミティブ型に対応するラッパー型の配列となります。
+     * The source array can be a primitive array. In that case, the resulting array will contain the corresponding wrapper types.
      * </p>
      *
      * @param array
-     *            配列
-     * @return オブジェクトの配列
+     *            the array
+     * @return the object array
      */
     public static Object[] toObjectArray(final Object array) {
         assertArgumentNotNull("array", array);
@@ -1307,16 +1296,16 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * 配列をリストに変換します。
+     * Converts an array to a list.
      * <p>
-     * 変換元の配列にはプリミティブ型の配列を渡すことができます。その場合、変換されたリストの要素型はプリミティブ型に対応するラッパー型の配列となります。
+     * The source array can be a primitive array. In that case, the resulting list will contain the corresponding wrapper types.
      * </p>
      *
      * @param <T>
-     *            配列の要素の型
+     *            the type of the array elements
      * @param array
-     *            配列
-     * @return リスト
+     *            the array
+     * @return the list
      */
     @SuppressWarnings("unchecked")
     public static <T> List<T> toList(final Object array) {
@@ -1332,24 +1321,22 @@ public abstract class ArrayUtil {
     }
 
     /**
-     * オブジェクトが配列の場合は{@literal true}を返します。{@literal null}の場合は{@literal false}
-     * を返します。
+     * Returns {@literal true} if the object is an array. Returns {@literal false} if the object is {@literal null}.
      *
      * @param object
-     *            オブジェクト
-     * @return オブジェクトが配列の場合は{@literal true}。{@literal null}の場合は{@literal false}
+     *            the object
+     * @return {@literal true} if the object is an array; {@literal false} if the object is {@literal null}
      */
     public static boolean isArray(final Object object) {
         return object != null && object.getClass().isArray();
     }
 
     /**
-     * オブジェクトが配列でない場合は{@literal true}を返します。{@literal null}の場合は{@literal true}
-     * を返します。
+     * Returns {@literal true} if the object is not an array. Returns {@literal true} if the object is {@literal null}.
      *
      * @param object
-     *            オブジェクト
-     * @return オブジェクトが配列でない場合は{@literal true}。{@literal null}の場合は{@literal true}
+     *            the object
+     * @return {@literal true} if the object is not an array, or if the object is {@literal null}
      */
     public static boolean isNotArray(final Object object) {
         return !isArray(object);

--- a/src/main/java/org/codelibs/core/collection/CaseInsensitiveMap.java
+++ b/src/main/java/org/codelibs/core/collection/CaseInsensitiveMap.java
@@ -18,38 +18,35 @@ package org.codelibs.core.collection;
 import java.util.Map;
 
 /**
- * キーで大文字小文字を気にしない {@link ArrayMap}です。
+ * {@link ArrayMap} that is case-insensitive for keys.
  *
- * @author higa 値の型
- * @param <V>
- *            値の型
+ * @author higa
+ * @param <V> the type of values
  */
 public class CaseInsensitiveMap<V> extends ArrayMap<String, V> {
 
     private static final long serialVersionUID = 1L;
 
     /**
-     * {@link CaseInsensitiveMap}を作成します。
+     * Creates a {@link CaseInsensitiveMap}.
      */
     public CaseInsensitiveMap() {
     }
 
     /**
-     * {@link CaseInsensitiveMap}を作成します。
+     * Creates a {@link CaseInsensitiveMap}.
      *
-     * @param capacity
-     *            初期容量
+     * @param capacity the initial capacity
      */
     public CaseInsensitiveMap(final int capacity) {
         super(capacity);
     }
 
     /**
-     * キーが含まれているかどうかを返します。
+     * Returns whether the key is contained.
      *
-     * @param key
-     *            キー
-     * @return キーが含まれているかどうか
+     * @param key the key
+     * @return whether the key is contained
      */
     public boolean containsKey(final String key) {
         return super.containsKey(convertKey(key));

--- a/src/main/java/org/codelibs/core/collection/CaseInsensitiveSet.java
+++ b/src/main/java/org/codelibs/core/collection/CaseInsensitiveSet.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * 大文字小文字を気にしない {@link Set}です。
+ * {@link Set} that is case-insensitive.
  *
  * @author higa
  */
@@ -36,17 +36,16 @@ public class CaseInsensitiveSet extends AbstractSet<String> implements Set<Strin
     private static final Object PRESENT = new Object();
 
     /**
-     * {@link CaseInsensitiveSet}を作成します。
+     * Creates a {@link CaseInsensitiveSet}.
      */
     public CaseInsensitiveSet() {
         map = new CaseInsensitiveMap<>();
     }
 
     /**
-     * {@link CaseInsensitiveSet}を作成します。
+     * Creates a {@link CaseInsensitiveSet}.
      *
-     * @param c
-     *            コピー元のコレクション
+     * @param c the collection to copy from
      */
     public CaseInsensitiveSet(final Collection<String> c) {
         map = new CaseInsensitiveMap<>(Math.max((int) (c.size() / .75f) + 1, 16));
@@ -54,10 +53,9 @@ public class CaseInsensitiveSet extends AbstractSet<String> implements Set<Strin
     }
 
     /**
-     * {@link CaseInsensitiveSet}を作成します。
+     * Creates a {@link CaseInsensitiveSet}.
      *
-     * @param initialCapacity
-     *            初期容量
+     * @param initialCapacity the initial capacity
      */
     public CaseInsensitiveSet(final int initialCapacity) {
         map = new CaseInsensitiveMap<>(initialCapacity);

--- a/src/main/java/org/codelibs/core/collection/CollectionsUtil.java
+++ b/src/main/java/org/codelibs/core/collection/CollectionsUtil.java
@@ -52,20 +52,18 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 
 /**
- * コレクションのためのユーティリティです。
+ * Utility class for collections.
  *
  * @author koichik
  */
 public abstract class CollectionsUtil {
 
     /**
-     * {@link ArrayBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayBlockingQueue}.
      *
-     * @param <E>
-     *            {@link ArrayBlockingQueue}の要素型
-     * @param capacity
-     *            キューの容量
-     * @return {@link ArrayBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayBlockingQueue}
+     * @param capacity the queue capacity
+     * @return a new instance of {@link ArrayBlockingQueue}
      * @see ArrayBlockingQueue#ArrayBlockingQueue(int)
      */
     public static <E> ArrayBlockingQueue<E> newArrayBlockingQueue(final int capacity) {
@@ -73,15 +71,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ArrayBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayBlockingQueue}.
      *
-     * @param <E>
-     *            {@link ArrayBlockingQueue}の要素型
-     * @param capacity
-     *            キューの容量
-     * @param fair
-     *            {@code true}の場合、挿入または削除時にブロックされたスレッドに対するキューアクセス
-     * @return {@link ArrayBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayBlockingQueue}
+     * @param capacity the queue capacity
+     * @param fair whether the queue is fair
+     * @return a new instance of {@link ArrayBlockingQueue}
      * @see ArrayBlockingQueue#ArrayBlockingQueue(int, boolean)
      */
     public static <E> ArrayBlockingQueue<E> newArrayBlockingQueue(final int capacity, final boolean fair) {
@@ -89,17 +84,13 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ArrayBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayBlockingQueue}.
      *
-     * @param <E>
-     *            {@link ArrayBlockingQueue}の要素型
-     * @param capacity
-     *            キューの容量
-     * @param fair
-     *            {@code true}の場合、挿入または削除時にブロックされたスレッドに対するキューアクセス
-     * @param c
-     *            最初に含む要素のコレクション
-     * @return {@link ArrayBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayBlockingQueue}
+     * @param capacity the queue capacity
+     * @param fair whether the queue is fair
+     * @param c the collection of initial elements
+     * @return a new instance of {@link ArrayBlockingQueue}
      * @see ArrayBlockingQueue#ArrayBlockingQueue(int, boolean, Collection)
      */
     public static <E> ArrayBlockingQueue<E> newArrayBlockingQueue(final int capacity, final boolean fair, final Collection<? extends E> c) {
@@ -107,11 +98,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ArrayDeque}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayDeque}.
      *
-     * @param <E>
-     *            {@link ArrayDeque}の要素型
-     * @return {@link ArrayDeque}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayDeque}
+     * @return a new instance of {@link ArrayDeque}
      * @see ArrayDeque#ArrayDeque()
      */
     public static <E> ArrayDeque<E> newArrayDeque() {
@@ -119,13 +109,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ArrayDeque}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayDeque}.
      *
-     * @param <E>
-     *            {@link ArrayDeque}の要素型
-     * @param c
-     *            要素が両端キューに配置されるコレクション
-     * @return {@link ArrayDeque}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayDeque}
+     * @param c the collection of elements to be placed in the deque
+     * @return a new instance of {@link ArrayDeque}
      * @see ArrayDeque#ArrayDeque(Collection)
      */
     public static <E> ArrayDeque<E> newArrayDeque(final Collection<? extends E> c) {
@@ -133,13 +121,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ArrayDeque}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayDeque}.
      *
-     * @param <E>
-     *            {@link ArrayDeque}の要素型
-     * @param numElements
-     *            両端キューの初期容量の範囲の下限
-     * @return {@link ArrayDeque}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayDeque}
+     * @param numElements the lower bound of the initial capacity range for the deque
+     * @return a new instance of {@link ArrayDeque}
      * @see ArrayDeque#ArrayDeque(int)
      */
     public static <E> ArrayDeque<E> newArrayDeque(final int numElements) {
@@ -147,11 +133,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ArrayList}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayList}.
      *
-     * @param <E>
-     *            {@link ArrayList}の要素型
-     * @return {@link ArrayList}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayList}
+     * @return a new instance of {@link ArrayList}
      * @see ArrayList#ArrayList()
      */
     public static <E> ArrayList<E> newArrayList() {
@@ -159,13 +144,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ArrayList}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayList}.
      *
-     * @param <E>
-     *            {@link ArrayList}の要素型
-     * @param c
-     *            要素がリストに配置されるコレクション
-     * @return {@link ArrayList}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayList}
+     * @param c the collection of elements to be placed in the list
+     * @return a new instance of {@link ArrayList}
      * @see ArrayList#ArrayList(Collection)
      */
     public static <E> ArrayList<E> newArrayList(final Collection<? extends E> c) {
@@ -173,13 +156,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ArrayList}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ArrayList}.
      *
-     * @param <E>
-     *            {@link ArrayList}の要素型
-     * @param initialCapacity
-     *            リストの初期容量
-     * @return {@link ArrayList}の新しいインスタンス
+     * @param <E> the element type of {@link ArrayList}
+     * @param initialCapacity the initial capacity of the list
+     * @return a new instance of {@link ArrayList}
      * @see ArrayList#ArrayList(int)
      */
     public static <E> ArrayList<E> newArrayList(final int initialCapacity) {
@@ -187,13 +168,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentHashMap}.
      *
-     * @param <K>
-     *            {@link ConcurrentHashMap}のキーの型
-     * @param <V>
-     *            {@link ConcurrentHashMap}の値の型
-     * @return {@link ConcurrentHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link ConcurrentHashMap}
+     * @param <V> the value type of {@link ConcurrentHashMap}
+     * @return a new instance of {@link ConcurrentHashMap}
      * @see ConcurrentHashMap#ConcurrentHashMap()
      */
     public static <K, V> ConcurrentHashMap<K, V> newConcurrentHashMap() {
@@ -201,15 +180,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentHashMap}.
      *
-     * @param <K>
-     *            {@link ConcurrentHashMap}のキーの型
-     * @param <V>
-     *            {@link ConcurrentHashMap}の値の型
-     * @param initialCapacity
-     *            初期容量
-     * @return {@link ConcurrentHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link ConcurrentHashMap}
+     * @param <V> the value type of {@link ConcurrentHashMap}
+     * @param initialCapacity the initial capacity
+     * @return a new instance of {@link ConcurrentHashMap}
      * @see ConcurrentHashMap#ConcurrentHashMap(int)
      */
     public static <K, V> ConcurrentHashMap<K, V> newConcurrentHashMap(final int initialCapacity) {
@@ -217,19 +193,14 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentHashMap}.
      *
-     * @param <K>
-     *            {@link ConcurrentHashMap}のキーの型
-     * @param <V>
-     *            {@link ConcurrentHashMap}の値の型
-     * @param initialCapacity
-     *            初期容量
-     * @param loadFactor
-     *            サイズ変更の制御に使用される負荷係数のしきい値
-     * @param concurrencyLevel
-     *            同時更新を行うスレッドの推定数
-     * @return {@link ConcurrentHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link ConcurrentHashMap}
+     * @param <V> the value type of {@link ConcurrentHashMap}
+     * @param initialCapacity the initial capacity
+     * @param loadFactor the load factor threshold for resizing
+     * @param concurrencyLevel the estimated number of threads for concurrent updates
+     * @return a new instance of {@link ConcurrentHashMap}
      * @see ConcurrentHashMap#ConcurrentHashMap(int, float, int)
      */
     public static <K, V> ConcurrentHashMap<K, V> newConcurrentHashMap(final int initialCapacity, final float loadFactor,
@@ -238,15 +209,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentHashMap}.
      *
-     * @param <K>
-     *            {@link ConcurrentHashMap}のキーの型
-     * @param <V>
-     *            {@link ConcurrentHashMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link ConcurrentHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link ConcurrentHashMap}
+     * @param <V> the value type of {@link ConcurrentHashMap}
+     * @param m the map to be placed in the created map
+     * @return a new instance of {@link ConcurrentHashMap}
      * @see ConcurrentHashMap#ConcurrentHashMap(Map)
      */
     public static <K, V> ConcurrentHashMap<K, V> newConcurrentHashMap(final Map<? extends K, ? extends V> m) {
@@ -254,11 +222,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentLinkedQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentLinkedQueue}.
      *
-     * @param <E>
-     *            {@link ConcurrentLinkedQueue}の要素型
-     * @return {@link ConcurrentLinkedQueue}の新しいインスタンス
+     * @param <E> the element type of {@link ConcurrentLinkedQueue}
+     * @return a new instance of {@link ConcurrentLinkedQueue}
      * @see ConcurrentLinkedQueue#ConcurrentLinkedQueue()
      */
     public static <E> ConcurrentLinkedQueue<E> newConcurrentLinkedQueue() {
@@ -266,13 +233,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentLinkedQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentLinkedQueue}.
      *
-     * @param <E>
-     *            {@link ConcurrentLinkedQueue}の要素型
-     * @param c
-     *            最初に含む要素のコレクション
-     * @return {@link ConcurrentLinkedQueue}の新しいインスタンス
+     * @param <E> the element type of {@link ConcurrentLinkedQueue}
+     * @param c the collection of initial elements
+     * @return a new instance of {@link ConcurrentLinkedQueue}
      * @see ConcurrentLinkedQueue#ConcurrentLinkedQueue(Collection)
      */
     public static <E> ConcurrentLinkedQueue<E> newConcurrentLinkedQueue(final Collection<? extends E> c) {
@@ -280,13 +245,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentSkipListMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentSkipListMap}.
      *
-     * @param <K>
-     *            {@link ConcurrentSkipListMap}のキーの型
-     * @param <V>
-     *            {@link ConcurrentSkipListMap}の値の型
-     * @return {@link ConcurrentSkipListMap}の新しいインスタンス
+     * @param <K> the key type of {@link ConcurrentSkipListMap}
+     * @param <V> the value type of {@link ConcurrentSkipListMap}
+     * @return a new instance of {@link ConcurrentSkipListMap}
      * @see ConcurrentSkipListMap#ConcurrentSkipListMap()
      */
     public static <K, V> ConcurrentSkipListMap<K, V> newConcurrentSkipListMap() {
@@ -294,15 +257,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentSkipListMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentSkipListMap}.
      *
-     * @param <K>
-     *            {@link ConcurrentSkipListMap}のキーの型
-     * @param <V>
-     *            {@link ConcurrentSkipListMap}の値の型
-     * @param c
-     *            {@link Comparator}
-     * @return {@link ConcurrentSkipListMap}の新しいインスタンス
+     * @param <K> the key type of {@link ConcurrentSkipListMap}
+     * @param <V> the value type of {@link ConcurrentSkipListMap}
+     * @param c the comparator for sorting the map
+     * @return a new instance of {@link ConcurrentSkipListMap}
      * @see ConcurrentSkipListMap#ConcurrentSkipListMap(Comparator)
      */
     public static <K, V> ConcurrentSkipListMap<K, V> newConcurrentSkipListMap(final Comparator<? super K> c) {
@@ -310,15 +270,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentSkipListMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentSkipListMap}.
      *
-     * @param <K>
-     *            {@link ConcurrentSkipListMap}のキーの型
-     * @param <V>
-     *            {@link ConcurrentSkipListMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link ConcurrentSkipListMap}の新しいインスタンス
+     * @param <K> the key type of {@link ConcurrentSkipListMap}
+     * @param <V> the value type of {@link ConcurrentSkipListMap}
+     * @param m the map to be placed in the created map
+     * @return a new instance of {@link ConcurrentSkipListMap}
      * @see ConcurrentSkipListMap#ConcurrentSkipListMap(Map)
      */
     public static <K, V> ConcurrentSkipListMap<K, V> newConcurrentSkipListMap(final Map<? extends K, ? extends V> m) {
@@ -326,15 +283,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentSkipListMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentSkipListMap}.
      *
-     * @param <K>
-     *            {@link ConcurrentSkipListMap}のキーの型
-     * @param <V>
-     *            {@link ConcurrentSkipListMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link ConcurrentSkipListMap}の新しいインスタンス
+     * @param <K> the key type of {@link ConcurrentSkipListMap}
+     * @param <V> the value type of {@link ConcurrentSkipListMap}
+     * @param m the sorted map to be placed in the created map
+     * @return a new instance of {@link ConcurrentSkipListMap}
      * @see ConcurrentSkipListMap#ConcurrentSkipListMap(SortedMap)
      */
     public static <K, V> ConcurrentSkipListMap<K, V> newConcurrentSkipListMap(final SortedMap<K, ? extends V> m) {
@@ -342,11 +296,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentSkipListSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentSkipListSet}.
      *
-     * @param <E>
-     *            {@link ConcurrentSkipListSet}の要素型
-     * @return {@link ConcurrentSkipListSet}の新しいインスタンス
+     * @param <E> the element type of {@link ConcurrentSkipListSet}
+     * @return a new instance of {@link ConcurrentSkipListSet}
      * @see ConcurrentSkipListSet#ConcurrentSkipListSet()
      */
     public static <E> ConcurrentSkipListSet<E> newConcurrentSkipListSet() {
@@ -354,13 +307,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentSkipListSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentSkipListSet}.
      *
-     * @param <E>
-     *            {@link ConcurrentSkipListSet}の要素型
-     * @param c
-     *            要素がセットに配置されるコレクション
-     * @return {@link ConcurrentSkipListSet}の新しいインスタンス
+     * @param <E> the element type of {@link ConcurrentSkipListSet}
+     * @param c the collection of elements to be placed in the set
+     * @return a new instance of {@link ConcurrentSkipListSet}
      * @see ConcurrentSkipListSet#ConcurrentSkipListSet(Collection)
      */
     public static <E> ConcurrentSkipListSet<E> newConcurrentSkipListSet(final Collection<? extends E> c) {
@@ -368,13 +319,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentSkipListSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentSkipListSet}.
      *
-     * @param <E>
-     *            {@link ConcurrentSkipListSet}の要素型
-     * @param c
-     *            このセットをソートするために使用されるコンパレータ
-     * @return {@link ConcurrentSkipListSet}の新しいインスタンス
+     * @param <E> the element type of {@link ConcurrentSkipListSet}
+     * @param c the comparator for sorting the set
+     * @return a new instance of {@link ConcurrentSkipListSet}
      * @see ConcurrentSkipListSet#ConcurrentSkipListSet(Comparator)
      */
     public static <E> ConcurrentSkipListSet<E> newConcurrentSkipListSet(final Comparator<? super E> c) {
@@ -382,13 +331,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link ConcurrentSkipListSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link ConcurrentSkipListSet}.
      *
-     * @param <E>
-     *            {@link ConcurrentSkipListSet}の要素型
-     * @param s
-     *            要素がセットに配置されるコレクション
-     * @return {@link ConcurrentSkipListSet}の新しいインスタンス
+     * @param <E> the element type of {@link ConcurrentSkipListSet}
+     * @param s the sorted set to be placed in the created set
+     * @return a new instance of {@link ConcurrentSkipListSet}
      * @see ConcurrentSkipListSet#ConcurrentSkipListSet(SortedSet)
      */
     public static <E> ConcurrentSkipListSet<E> newConcurrentSkipListSet(final SortedSet<? extends E> s) {
@@ -396,11 +343,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link CopyOnWriteArrayList}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link CopyOnWriteArrayList}.
      *
-     * @param <E>
-     *            {@link CopyOnWriteArrayList}の要素型
-     * @return {@link CopyOnWriteArrayList}の新しいインスタンス
+     * @param <E> the element type of {@link CopyOnWriteArrayList}
+     * @return a new instance of {@link CopyOnWriteArrayList}
      * @see CopyOnWriteArrayList#CopyOnWriteArrayList()
      */
     public static <E> CopyOnWriteArrayList<E> newCopyOnWriteArrayList() {
@@ -408,13 +354,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link CopyOnWriteArrayList}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link CopyOnWriteArrayList}.
      *
-     * @param <E>
-     *            {@link CopyOnWriteArrayList}の要素型
-     * @param c
-     *            最初に保持していた要素のコレクション
-     * @return {@link CopyOnWriteArrayList}の新しいインスタンス
+     * @param <E> the element type of {@link CopyOnWriteArrayList}
+     * @param c the collection of initial elements
+     * @return a new instance of {@link CopyOnWriteArrayList}
      * @see CopyOnWriteArrayList#CopyOnWriteArrayList(Collection)
      */
     public static <E> CopyOnWriteArrayList<E> newCopyOnWriteArrayList(final Collection<? extends E> c) {
@@ -422,13 +366,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link CopyOnWriteArrayList}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link CopyOnWriteArrayList}.
      *
-     * @param <E>
-     *            {@link CopyOnWriteArrayList}の要素型
-     * @param toCopyIn
-     *            配列 (この配列のコピーは内部配列として使用される)
-     * @return {@link CopyOnWriteArrayList}の新しいインスタンス
+     * @param <E> the element type of {@link CopyOnWriteArrayList}
+     * @param toCopyIn the array to be used as the internal array
+     * @return a new instance of {@link CopyOnWriteArrayList}
      * @see CopyOnWriteArrayList#CopyOnWriteArrayList(Object[])
      */
     public static <E> CopyOnWriteArrayList<E> newCopyOnWriteArrayList(final E[] toCopyIn) {
@@ -436,11 +378,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link CopyOnWriteArraySet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link CopyOnWriteArraySet}.
      *
-     * @param <E>
-     *            {@link CopyOnWriteArraySet}の要素型
-     * @return {@link CopyOnWriteArraySet}の新しいインスタンス
+     * @param <E> the element type of {@link CopyOnWriteArraySet}
+     * @return a new instance of {@link CopyOnWriteArraySet}
      * @see CopyOnWriteArraySet#CopyOnWriteArraySet()
      */
     public static <E> CopyOnWriteArraySet<E> newCopyOnWriteArraySet() {
@@ -448,13 +389,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link CopyOnWriteArraySet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link CopyOnWriteArraySet}.
      *
-     * @param <E>
-     *            {@link CopyOnWriteArraySet}の要素型
-     * @param c
-     *            コレクション
-     * @return {@link CopyOnWriteArraySet}の新しいインスタンス
+     * @param <E> the element type of {@link CopyOnWriteArraySet}
+     * @param c the collection of initial elements
+     * @return a new instance of {@link CopyOnWriteArraySet}
      * @see CopyOnWriteArraySet#CopyOnWriteArraySet(Collection)
      */
     public static <E> CopyOnWriteArraySet<E> newCopyOnWriteArraySet(final Collection<? extends E> c) {
@@ -462,11 +401,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link DelayQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link DelayQueue}.
      *
-     * @param <E>
-     *            {@link CopyOnWriteArraySet}の要素型
-     * @return {@link DelayQueue}の新しいインスタンス
+     * @param <E> the element type of {@link CopyOnWriteArraySet}
+     * @return a new instance of {@link DelayQueue}
      * @see DelayQueue#DelayQueue()
      */
     public static <E extends Delayed> DelayQueue<E> newDelayQueue() {
@@ -474,13 +412,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link DelayQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link DelayQueue}.
      *
-     * @param <E>
-     *            {@link CopyOnWriteArraySet}の要素型
-     * @param c
-     *            コレクション
-     * @return {@link DelayQueue}の新しいインスタンス
+     * @param <E> the element type of {@link CopyOnWriteArraySet}
+     * @param c the collection of initial elements
+     * @return a new instance of {@link DelayQueue}
      * @see DelayQueue#DelayQueue(Collection)
      */
     public static <E extends Delayed> DelayQueue<E> newDelayQueue(final Collection<? extends E> c) {
@@ -488,15 +424,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link EnumMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link EnumMap}.
      *
-     * @param <K>
-     *            {@link EnumMap}のキーの型
-     * @param <V>
-     *            {@link EnumMap}の値の型
-     * @param keyType
-     *            この {@literal enum} マップ用のキー型のクラスオブジェクト
-     * @return {@link EnumMap}の新しいインスタンス
+     * @param <K> the key type of {@link EnumMap}
+     * @param <V> the value type of {@link EnumMap}
+     * @param keyType the class object of the key type for this {@literal enum} map
+     * @return a new instance of {@link EnumMap}
      * @see EnumMap#EnumMap(Class)
      */
     public static <K extends Enum<K>, V> EnumMap<K, V> newEnumMap(final Class<K> keyType) {
@@ -504,15 +437,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link EnumMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link EnumMap}.
      *
-     * @param <K>
-     *            {@link EnumMap}のキーの型
-     * @param <V>
-     *            {@link EnumMap}の値の型
-     * @param m
-     *            この {@literal enum} マップの初期化元の {@literal enum} マップ
-     * @return {@link EnumMap}の新しいインスタンス
+     * @param <K> the key type of {@link EnumMap}
+     * @param <V> the value type of {@link EnumMap}
+     * @param m the {@literal enum} map to be used for initialization
+     * @return a new instance of {@link EnumMap}
      * @see EnumMap#EnumMap(EnumMap)
      */
     public static <K extends Enum<K>, V> EnumMap<K, V> newEnumMap(final EnumMap<K, ? extends V> m) {
@@ -520,15 +450,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link EnumMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link EnumMap}.
      *
-     * @param <K>
-     *            {@link EnumMap}のキーの型
-     * @param <V>
-     *            {@link EnumMap}の値の型
-     * @param m
-     *            この {@literal enum} マップの初期化元のマップ
-     * @return {@link EnumMap}の新しいインスタンス
+     * @param <K> the key type of {@link EnumMap}
+     * @param <V> the value type of {@link EnumMap}
+     * @param m the map to be used for initialization
+     * @return a new instance of {@link EnumMap}
      * @see EnumMap#EnumMap(Map)
      */
     public static <K extends Enum<K>, V> EnumMap<K, V> newEnumMap(final Map<K, ? extends V> m) {
@@ -536,13 +463,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link HashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link HashMap}.
      *
-     * @param <K>
-     *            {@link HashMap}のキーの型
-     * @param <V>
-     *            {@link HashMap}の値の型
-     * @return {@link HashMap}の新しいインスタンス
+     * @param <K> the key type of {@link HashMap}
+     * @param <V> the value type of {@link HashMap}
+     * @return a new instance of {@link HashMap}
      * @see HashMap#HashMap()
      */
     public static <K, V> HashMap<K, V> newHashMap() {
@@ -550,15 +475,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link HashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link HashMap}.
      *
-     * @param <K>
-     *            {@link HashMap}のキーの型
-     * @param <V>
-     *            {@link HashMap}の値の型
-     * @param initialCapacity
-     *            初期容量
-     * @return {@link HashMap}の新しいインスタンス
+     * @param <K> the key type of {@link HashMap}
+     * @param <V> the value type of {@link HashMap}
+     * @param initialCapacity the initial capacity
+     * @return a new instance of {@link HashMap}
      * @see HashMap#HashMap(int)
      */
     public static <K, V> HashMap<K, V> newHashMap(final int initialCapacity) {
@@ -566,17 +488,13 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link HashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link HashMap}.
      *
-     * @param <K>
-     *            {@link HashMap}のキーの型
-     * @param <V>
-     *            {@link HashMap}の値の型
-     * @param initialCapacity
-     *            初期容量
-     * @param loadFactor
-     *            サイズ変更の制御に使用される負荷係数のしきい値
-     * @return {@link HashMap}の新しいインスタンス
+     * @param <K> the key type of {@link HashMap}
+     * @param <V> the value type of {@link HashMap}
+     * @param initialCapacity the initial capacity
+     * @param loadFactor the load factor
+     * @return a new instance of {@link HashMap}
      * @see HashMap#HashMap(int, float)
      */
     public static <K, V> HashMap<K, V> newHashMap(final int initialCapacity, final float loadFactor) {
@@ -584,15 +502,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link HashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link HashMap}.
      *
-     * @param <K>
-     *            {@link HashMap}のキーの型
-     * @param <V>
-     *            {@link HashMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link HashMap}の新しいインスタンス
+     * @param <K> the key type of {@link HashMap}
+     * @param <V> the value type of {@link HashMap}
+     * @param m the map to be placed in the created map
+     * @return a new instance of {@link HashMap}
      * @see HashMap#HashMap(int, float)
      */
     public static <K, V> HashMap<K, V> newHashMap(final Map<? extends K, ? extends V> m) {
@@ -600,11 +515,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link HashSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link HashSet}.
      *
-     * @param <E>
-     *            {@link HashSet}の要素型
-     * @return {@link HashSet}の新しいインスタンス
+     * @param <E> the element type of {@link HashSet}
+     * @return a new instance of {@link HashSet}
      * @see HashSet#HashSet()
      */
     public static <E> HashSet<E> newHashSet() {
@@ -612,13 +526,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link HashSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link HashSet}.
      *
-     * @param <E>
-     *            {@link HashSet}の要素型
-     * @param c
-     *            要素がセットに配置されるコレクション
-     * @return {@link HashSet}の新しいインスタンス
+     * @param <E> the element type of {@link HashSet}
+     * @param c the collection of elements to be placed in the set
+     * @return a new instance of {@link HashSet}
      * @see HashSet#HashSet()
      */
     public static <E> HashSet<E> newHashSet(final Collection<? extends E> c) {
@@ -626,13 +538,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link HashSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link HashSet}.
      *
-     * @param <E>
-     *            {@link HashSet}の要素型
-     * @param initialCapacity
-     *            初期容量
-     * @return {@link HashSet}の新しいインスタンス
+     * @param <E> the element type of {@link HashSet}
+     * @param initialCapacity the initial capacity
+     * @return a new instance of {@link HashSet}
      * @see HashSet#HashSet()
      */
     public static <E> HashSet<E> newHashSet(final int initialCapacity) {
@@ -640,15 +550,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link HashSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link HashSet}.
      *
-     * @param <E>
-     *            {@link HashSet}の要素型
-     * @param initialCapacity
-     *            初期容量
-     * @param loadFactor
-     *            負荷係数
-     * @return {@link HashSet}の新しいインスタンス
+     * @param <E> the element type of {@link HashSet}
+     * @param initialCapacity the initial capacity
+     * @param loadFactor the load factor
+     * @return a new instance of {@link HashSet}
      * @see HashSet#HashSet()
      */
     public static <E> HashSet<E> newHashSet(final int initialCapacity, final float loadFactor) {
@@ -656,13 +563,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Hashtable}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Hashtable}.
      *
-     * @param <K>
-     *            {@link Hashtable}のキーの型
-     * @param <V>
-     *            {@link Hashtable}の値の型
-     * @return {@link Hashtable}の新しいインスタンス
+     * @param <K> the key type of {@link Hashtable}
+     * @param <V> the value type of {@link Hashtable}
+     * @return a new instance of {@link Hashtable}
      * @see Hashtable#Hashtable()
      */
     public static <K, V> Hashtable<K, V> newHashtable() {
@@ -670,15 +575,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Hashtable}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Hashtable}.
      *
-     * @param <K>
-     *            {@link Hashtable}のキーの型
-     * @param <V>
-     *            {@link Hashtable}の値の型
-     * @param initialCapacity
-     *            ハッシュテーブルの初期容量
-     * @return {@link Hashtable}の新しいインスタンス
+     * @param <K> the key type of {@link Hashtable}
+     * @param <V> the value type of {@link Hashtable}
+     * @param initialCapacity the initial capacity
+     * @return a new instance of {@link Hashtable}
      * @see Hashtable#Hashtable(int)
      */
     public static <K, V> Hashtable<K, V> newHashtable(final int initialCapacity) {
@@ -686,17 +588,13 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Hashtable}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Hashtable}.
      *
-     * @param <K>
-     *            {@link Hashtable}のキーの型
-     * @param <V>
-     *            {@link Hashtable}の値の型
-     * @param initialCapacity
-     *            ハッシュテーブルの初期容量
-     * @param loadFactor
-     *            ハッシュテーブルの負荷係数
-     * @return {@link Hashtable}の新しいインスタンス
+     * @param <K> the key type of {@link Hashtable}
+     * @param <V> the value type of {@link Hashtable}
+     * @param initialCapacity the initial capacity
+     * @param loadFactor the load factor
+     * @return a new instance of {@link Hashtable}
      * @see Hashtable#Hashtable(int, float)
      */
     public static <K, V> Hashtable<K, V> newHashtable(final int initialCapacity, final float loadFactor) {
@@ -704,15 +602,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Hashtable}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Hashtable}.
      *
-     * @param <K>
-     *            {@link Hashtable}のキーの型
-     * @param <V>
-     *            {@link Hashtable}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link Hashtable}の新しいインスタンス
+     * @param <K> the key type of {@link Hashtable}
+     * @param <V> the value type of {@link Hashtable}
+     * @param m the map to be placed in the created map
+     * @return a new instance of {@link Hashtable}
      * @see Hashtable#Hashtable(Map)
      */
     public static <K, V> Hashtable<K, V> newHashtable(final Map<? extends K, ? extends V> m) {
@@ -720,13 +615,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link IdentityHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link IdentityHashMap}.
      *
-     * @param <K>
-     *            {@link IdentityHashMap}のキーの型
-     * @param <V>
-     *            {@link IdentityHashMap}の値の型
-     * @return {@link IdentityHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link IdentityHashMap}
+     * @param <V> the value type of {@link IdentityHashMap}
+     * @return a new instance of {@link IdentityHashMap}
      * @see IdentityHashMap#IdentityHashMap()
      */
     public static <K, V> IdentityHashMap<K, V> newIdentityHashMap() {
@@ -734,15 +627,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link IdentityHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link IdentityHashMap}.
      *
-     * @param <K>
-     *            {@link IdentityHashMap}のキーの型
-     * @param <V>
-     *            {@link IdentityHashMap}の値の型
-     * @param expectedMaxSize
-     *            マップの予想最大サイズ
-     * @return {@link IdentityHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link IdentityHashMap}
+     * @param <V> the value type of {@link IdentityHashMap}
+     * @param expectedMaxSize the expected maximum size of the map
+     * @return a new instance of {@link IdentityHashMap}
      * @see IdentityHashMap#IdentityHashMap(int)
      */
     public static <K, V> IdentityHashMap<K, V> newIdentityHashMap(final int expectedMaxSize) {
@@ -750,15 +640,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link IdentityHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link IdentityHashMap}.
      *
-     * @param <K>
-     *            {@link IdentityHashMap}のキーの型
-     * @param <V>
-     *            {@link IdentityHashMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link IdentityHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link IdentityHashMap}
+     * @param <V> the value type of {@link IdentityHashMap}
+     * @param m the map to be placed in the created map
+     * @return a new instance of {@link IdentityHashMap}
      * @see IdentityHashMap#IdentityHashMap(Map)
      */
     public static <K, V> IdentityHashMap<K, V> newIdentityHashMap(final Map<? extends K, ? extends V> m) {
@@ -766,11 +653,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedBlockingDeque}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedBlockingDeque}.
      *
-     * @param <E>
-     *            {@link LinkedBlockingDeque}の要素型
-     * @return {@link LinkedBlockingDeque}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedBlockingDeque}
+     * @return a new instance of {@link LinkedBlockingDeque}
      * @see LinkedBlockingDeque#LinkedBlockingDeque()
      */
     public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque() {
@@ -778,13 +664,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedBlockingDeque}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedBlockingDeque}.
      *
-     * @param <E>
-     *            {@link LinkedBlockingDeque}の要素型
-     * @param c
-     *            要素がリストに配置されるコレクション
-     * @return {@link LinkedBlockingDeque}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedBlockingDeque}
+     * @param c the collection of elements to be placed in the deque
+     * @return a new instance of {@link LinkedBlockingDeque}
      * @see LinkedBlockingDeque#LinkedBlockingDeque(Collection)
      */
     public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque(final Collection<? extends E> c) {
@@ -792,13 +676,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedBlockingDeque}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedBlockingDeque}.
      *
-     * @param <E>
-     *            {@link LinkedBlockingDeque}の要素型
-     * @param initialCapacity
-     *            リストの初期容量
-     * @return {@link LinkedBlockingDeque}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedBlockingDeque}
+     * @param initialCapacity the initial capacity of the deque
+     * @return a new instance of {@link LinkedBlockingDeque}
      * @see LinkedBlockingDeque#LinkedBlockingDeque(int)
      */
     public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque(final int initialCapacity) {
@@ -806,11 +688,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedBlockingQueue}.
      *
-     * @param <E>
-     *            {@link LinkedBlockingQueue}の要素型
-     * @return {@link LinkedBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedBlockingQueue}
+     * @return a new instance of {@link LinkedBlockingQueue}
      * @see LinkedBlockingQueue#LinkedBlockingQueue()
      */
     public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue() {
@@ -818,13 +699,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedBlockingQueue}.
      *
-     * @param <E>
-     *            {@link LinkedBlockingQueue}の要素型
-     * @param c
-     *            最初に含む要素のコレクション
-     * @return {@link LinkedBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedBlockingQueue}
+     * @param c the collection of initial elements
+     * @return a new instance of {@link LinkedBlockingQueue}
      * @see LinkedBlockingQueue#LinkedBlockingQueue(Collection)
      */
     public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue(final Collection<? extends E> c) {
@@ -832,13 +711,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedBlockingQueue}.
      *
-     * @param <E>
-     *            {@link LinkedBlockingQueue}の要素型
-     * @param initialCapacity
-     *            このキューの容量
-     * @return {@link LinkedBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedBlockingQueue}
+     * @param initialCapacity the capacity of the queue
+     * @return a new instance of {@link LinkedBlockingQueue}
      * @see LinkedBlockingQueue#LinkedBlockingQueue(int)
      */
     public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue(final int initialCapacity) {
@@ -846,13 +723,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedHashMap}.
      *
-     * @param <K>
-     *            {@link LinkedHashMap}のキーの型
-     * @param <V>
-     *            {@link LinkedHashMap}の値の型
-     * @return {@link LinkedHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link LinkedHashMap}
+     * @param <V> the value type of {@link LinkedHashMap}
+     * @return a new instance of {@link LinkedHashMap}
      * @see LinkedHashMap#LinkedHashMap()
      */
     public static <K, V> LinkedHashMap<K, V> newLinkedHashMap() {
@@ -860,15 +735,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedHashMap}.
      *
-     * @param <K>
-     *            {@link LinkedHashMap}のキーの型
-     * @param <V>
-     *            {@link LinkedHashMap}の値の型
-     * @param initialCapacity
-     *            初期容量
-     * @return {@link LinkedHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link LinkedHashMap}
+     * @param <V> the value type of {@link LinkedHashMap}
+     * @param initialCapacity the initial capacity
+     * @return a new instance of {@link LinkedHashMap}
      * @see LinkedHashMap#LinkedHashMap(int)
      */
     public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(final int initialCapacity) {
@@ -876,17 +748,13 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedHashMap}.
      *
-     * @param <K>
-     *            {@link LinkedHashMap}のキーの型
-     * @param <V>
-     *            {@link LinkedHashMap}の値の型
-     * @param initialCapacity
-     *            初期容量
-     * @param loadFactor
-     *            負荷係数
-     * @return {@link LinkedHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link LinkedHashMap}
+     * @param <V> the value type of {@link LinkedHashMap}
+     * @param initialCapacity the initial capacity
+     * @param loadFactor the load factor
+     * @return a new instance of {@link LinkedHashMap}
      * @see LinkedHashMap#LinkedHashMap(int, float)
      */
     public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(final int initialCapacity, final float loadFactor) {
@@ -894,15 +762,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedHashMap}.
      *
-     * @param <K>
-     *            {@link LinkedHashMap}のキーの型
-     * @param <V>
-     *            {@link LinkedHashMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link LinkedHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link LinkedHashMap}
+     * @param <V> the value type of {@link LinkedHashMap}
+     * @param m the map to be placed in the created map
+     * @return a new instance of {@link LinkedHashMap}
      * @see LinkedHashMap#LinkedHashMap(Map)
      */
     public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(final Map<? extends K, ? extends V> m) {
@@ -910,11 +775,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedHashSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedHashSet}.
      *
-     * @param <E>
-     *            {@link LinkedHashSet}の要素型
-     * @return {@link LinkedHashSet}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedHashSet}
+     * @return a new instance of {@link LinkedHashSet}
      * @see LinkedHashSet#LinkedHashSet()
      */
     public static <E> LinkedHashSet<E> newLinkedHashSet() {
@@ -922,13 +786,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedHashSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedHashSet}.
      *
-     * @param <E>
-     *            {@link LinkedHashSet}の要素型
-     * @param c
-     *            要素がセットに配置されるコレクション
-     * @return {@link LinkedHashSet}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedHashSet}
+     * @param c the collection of elements to be placed in the set
+     * @return a new instance of {@link LinkedHashSet}
      * @see LinkedHashSet#LinkedHashSet(Collection)
      */
     public static <E> LinkedHashSet<E> newLinkedHashSet(final Collection<? extends E> c) {
@@ -936,13 +798,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedHashSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedHashSet}.
      *
-     * @param <E>
-     *            {@link LinkedHashSet}の要素型
-     * @param initialCapacity
-     *            初期容量
-     * @return {@link LinkedHashSet}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedHashSet}
+     * @param initialCapacity the initial capacity
+     * @return a new instance of {@link LinkedHashSet}
      * @see LinkedHashSet#LinkedHashSet(int)
      */
     public static <E> LinkedHashSet<E> newLinkedHashSet(final int initialCapacity) {
@@ -950,15 +810,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedHashSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedHashSet}.
      *
-     * @param <E>
-     *            {@link LinkedHashSet}の要素型
-     * @param initialCapacity
-     *            初期容量
-     * @param loadFactor
-     *            負荷係数
-     * @return {@link LinkedHashSet}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedHashSet}
+     * @param initialCapacity the initial capacity
+     * @param loadFactor the load factor
+     * @return a new instance of {@link LinkedHashSet}
      * @see LinkedHashSet#LinkedHashSet(int, float)
      */
     public static <E> LinkedHashSet<E> newLinkedHashSet(final int initialCapacity, final float loadFactor) {
@@ -966,11 +823,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedList}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedList}.
      *
-     * @param <E>
-     *            {@link LinkedList}の要素型
-     * @return {@link LinkedList}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedList}
+     * @return a new instance of {@link LinkedList}
      * @see LinkedList#LinkedList()
      */
     public static <E> LinkedList<E> newLinkedList() {
@@ -978,13 +834,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link LinkedList}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link LinkedList}.
      *
-     * @param <E>
-     *            {@link LinkedList}の要素型
-     * @param c
-     *            要素がリストに配置されるコレクション
-     * @return {@link LinkedList}の新しいインスタンス
+     * @param <E> the element type of {@link LinkedList}
+     * @param c the collection of elements to be placed in the list
+     * @return a new instance of {@link LinkedList}
      * @see LinkedList#LinkedList(Collection)
      */
     public static <E> LinkedList<E> newLinkedList(final Collection<? extends E> c) {
@@ -992,11 +846,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityBlockingQueue}.
      *
-     * @param <E>
-     *            {@link PriorityBlockingQueue}の要素型
-     * @return {@link PriorityBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityBlockingQueue}
+     * @return a new instance of {@link PriorityBlockingQueue}
      * @see PriorityBlockingQueue#PriorityBlockingQueue()
      */
     public static <E> PriorityBlockingQueue<E> newPriorityBlockingQueue() {
@@ -1004,13 +857,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityBlockingQueue}.
      *
-     * @param <E>
-     *            {@link PriorityBlockingQueue}の要素型
-     * @param c
-     *            最初に含む要素のコレクション
-     * @return {@link PriorityBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityBlockingQueue}
+     * @param c the collection of initial elements
+     * @return a new instance of {@link PriorityBlockingQueue}
      * @see PriorityBlockingQueue#PriorityBlockingQueue(Collection)
      */
     public static <E> PriorityBlockingQueue<E> newPriorityBlockingQueue(final Collection<? extends E> c) {
@@ -1018,13 +869,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityBlockingQueue}.
      *
-     * @param <E>
-     *            {@link PriorityBlockingQueue}の要素型
-     * @param initialCapacity
-     *            この優先度キューの初期容量
-     * @return {@link PriorityBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityBlockingQueue}
+     * @param initialCapacity the initial capacity of the priority queue
+     * @return a new instance of {@link PriorityBlockingQueue}
      * @see PriorityBlockingQueue#PriorityBlockingQueue(int)
      */
     public static <E> PriorityBlockingQueue<E> newPriorityBlockingQueue(final int initialCapacity) {
@@ -1032,15 +881,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityBlockingQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityBlockingQueue}.
      *
-     * @param <E>
-     *            {@link PriorityBlockingQueue}の要素型
-     * @param initialCapacity
-     *            この優先度キューの初期容量
-     * @param comparator
-     *            この優先度キューの順序付けに使用するコンパレータ
-     * @return {@link PriorityBlockingQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityBlockingQueue}
+     * @param initialCapacity the initial capacity of the priority queue
+     * @param comparator the comparator for ordering the elements in the priority queue
+     * @return a new instance of {@link PriorityBlockingQueue}
      * @see PriorityBlockingQueue#PriorityBlockingQueue(int, Comparator)
      */
     public static <E> PriorityBlockingQueue<E> newPriorityBlockingQueue(final int initialCapacity, final Comparator<? super E> comparator) {
@@ -1048,11 +894,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityQueue}.
      *
-     * @param <E>
-     *            {@link PriorityQueue}の要素型
-     * @return {@link PriorityQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityQueue}
+     * @return a new instance of {@link PriorityQueue}
      * @see PriorityQueue#PriorityQueue()
      */
     public static <E> PriorityQueue<E> newPriorityQueue() {
@@ -1060,13 +905,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityQueue}.
      *
-     * @param <E>
-     *            {@link PriorityQueue}の要素型
-     * @param c
-     *            要素が優先度キューに配置されるコレクション
-     * @return {@link PriorityQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityQueue}
+     * @param c the collection of elements to be placed in the priority queue
+     * @return a new instance of {@link PriorityQueue}
      * @see PriorityQueue#PriorityQueue(Collection)
      */
     public static <E> PriorityQueue<E> newPriorityQueue(final Collection<? extends E> c) {
@@ -1074,13 +917,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityQueue}.
      *
-     * @param <E>
-     *            {@link PriorityQueue}の要素型
-     * @param initialCapacity
-     *            この優先度キューの初期容量
-     * @return {@link PriorityQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityQueue}
+     * @param initialCapacity the initial capacity of the priority queue
+     * @return a new instance of {@link PriorityQueue}
      * @see PriorityQueue#PriorityQueue(int)
      */
     public static <E> PriorityQueue<E> newPriorityQueue(final int initialCapacity) {
@@ -1088,15 +929,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityQueue}.
      *
-     * @param <E>
-     *            {@link PriorityQueue}の要素型
-     * @param initialCapacity
-     *            この優先度キューの初期容量
-     * @param comparator
-     *            この優先度キューの順序付けに使用するコンパレータ
-     * @return {@link PriorityQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityQueue}
+     * @param initialCapacity the initial capacity of the priority queue
+     * @param comparator the comparator for ordering the elements in the priority queue
+     * @return a new instance of {@link PriorityQueue}
      * @see PriorityQueue#PriorityQueue(int, Comparator)
      */
     public static <E> PriorityQueue<E> newPriorityQueue(final int initialCapacity, final Comparator<? super E> comparator) {
@@ -1104,13 +942,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityQueue}.
      *
-     * @param <E>
-     *            {@link PriorityQueue}の要素型
-     * @param c
-     *            要素が優先度キューに配置されるコレクション
-     * @return {@link PriorityQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityQueue}
+     * @param c the collection of elements to be placed in the priority queue
+     * @return a new instance of {@link PriorityQueue}
      * @see PriorityQueue#PriorityQueue(PriorityQueue)
      */
     public static <E> PriorityQueue<E> newPriorityQueue(final PriorityQueue<? extends E> c) {
@@ -1118,13 +954,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link PriorityQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link PriorityQueue}.
      *
-     * @param <E>
-     *            {@link PriorityQueue}の要素型
-     * @param c
-     *            要素が優先度キューに配置されるコレクション
-     * @return {@link PriorityQueue}の新しいインスタンス
+     * @param <E> the element type of {@link PriorityQueue}
+     * @param c the collection of elements to be placed in the priority queue
+     * @return a new instance of {@link PriorityQueue}
      * @see PriorityQueue#PriorityQueue(SortedSet)
      */
     public static <E> PriorityQueue<E> newPriorityQueue(final SortedSet<? extends E> c) {
@@ -1132,11 +966,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Stack}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Stack}.
      *
-     * @param <E>
-     *            {@link Stack}の要素型
-     * @return {@link Stack}の新しいインスタンス
+     * @param <E> the element type of {@link Stack}
+     * @return a new instance of {@link Stack}
      * @see Stack#Stack()
      */
     public static <E> Stack<E> newStack() {
@@ -1144,11 +977,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link SynchronousQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link SynchronousQueue}.
      *
-     * @param <E>
-     *            {@link SynchronousQueue}の要素型
-     * @return {@link SynchronousQueue}の新しいインスタンス
+     * @param <E> the element type of {@link SynchronousQueue}
+     * @return a new instance of {@link SynchronousQueue}
      * @see SynchronousQueue#SynchronousQueue()
      */
     public static <E> SynchronousQueue<E> newSynchronousQueue() {
@@ -1156,14 +988,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link SynchronousQueue}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link SynchronousQueue}.
      *
-     * @param <E>
-     *            {@link SynchronousQueue}の要素型
-     * @param fair
-     *            {@literal true} の場合、待機中のスレッドは FIFO
-     *            の順序でアクセスが決定される。そうでない場合、順序は未指定
-     * @return {@link SynchronousQueue}の新しいインスタンス
+     * @param <E> the element type of {@link SynchronousQueue}
+     * @param fair whether the access order is FIFO for waiting threads
+     * @return a new instance of {@link SynchronousQueue}
      * @see SynchronousQueue#SynchronousQueue()
      */
     public static <E> SynchronousQueue<E> newSynchronousQueue(final boolean fair) {
@@ -1171,13 +1000,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link TreeMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link TreeMap}.
      *
-     * @param <K>
-     *            {@link TreeMap}のキーの型
-     * @param <V>
-     *            {@link TreeMap}の値の型
-     * @return {@link TreeMap}の新しいインスタンス
+     * @param <K> the key type of {@link TreeMap}
+     * @param <V> the value type of {@link TreeMap}
+     * @return a new instance of {@link TreeMap}
      * @see TreeMap#TreeMap()
      */
     public static <K, V> TreeMap<K, V> newTreeMap() {
@@ -1185,15 +1012,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link TreeMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link TreeMap}.
      *
-     * @param <K>
-     *            {@link TreeMap}のキーの型
-     * @param <V>
-     *            {@link TreeMap}の値の型
-     * @param c
-     *            {@link Comparator}
-     * @return {@link TreeMap}の新しいインスタンス
+     * @param <K> the key type of {@link TreeMap}
+     * @param <V> the value type of {@link TreeMap}
+     * @param c the comparator for sorting the map
+     * @return a new instance of {@link TreeMap}
      * @see TreeMap#TreeMap(Comparator)
      */
     public static <K, V> TreeMap<K, V> newTreeMap(final Comparator<? super K> c) {
@@ -1201,15 +1025,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link TreeMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link TreeMap}.
      *
-     * @param <K>
-     *            {@link TreeMap}のキーの型
-     * @param <V>
-     *            {@link TreeMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link TreeMap}の新しいインスタンス
+     * @param <K> the key type of {@link TreeMap}
+     * @param <V> the value type of {@link TreeMap}
+     * @param m the map to be placed in the created map
+     * @return a new instance of {@link TreeMap}
      * @see TreeMap#TreeMap(Map)
      */
     public static <K, V> TreeMap<K, V> newTreeMap(final Map<? extends K, ? extends V> m) {
@@ -1217,15 +1038,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link TreeMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link TreeMap}.
      *
-     * @param <K>
-     *            {@link TreeMap}のキーの型
-     * @param <V>
-     *            {@link TreeMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link TreeMap}の新しいインスタンス
+     * @param <K> the key type of {@link TreeMap}
+     * @param <V> the value type of {@link TreeMap}
+     * @param m the sorted map to be placed in the created map
+     * @return a new instance of {@link TreeMap}
      * @see TreeMap#TreeMap(SortedMap)
      */
     public static <K, V> TreeMap<K, V> newTreeMap(final SortedMap<K, ? extends V> m) {
@@ -1233,11 +1051,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link TreeSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link TreeSet}.
      *
-     * @param <E>
-     *            {@link TreeSet}の要素型
-     * @return {@link TreeSet}の新しいインスタンス
+     * @param <E> the element type of {@link TreeSet}
+     * @return a new instance of {@link TreeSet}
      * @see TreeSet#TreeSet()
      */
     public static <E> TreeSet<E> newTreeSet() {
@@ -1245,13 +1062,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link TreeSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link TreeSet}.
      *
-     * @param <E>
-     *            {@link TreeSet}の要素型
-     * @param c
-     *            要素がセットに配置されるコレクション
-     * @return {@link TreeSet}の新しいインスタンス
+     * @param <E> the element type of {@link TreeSet}
+     * @param c the collection of elements to be placed in the set
+     * @return a new instance of {@link TreeSet}
      * @see TreeSet#TreeSet(Collection)
      */
     public static <E> TreeSet<E> newTreeSet(final Collection<? extends E> c) {
@@ -1259,13 +1074,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link TreeSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link TreeSet}.
      *
-     * @param <E>
-     *            {@link TreeSet}の要素型
-     * @param c
-     *            このセットをソートするために使用されるコンパレータ
-     * @return {@link TreeSet}の新しいインスタンス
+     * @param <E> the element type of {@link TreeSet}
+     * @param c the comparator for sorting the set
+     * @return a new instance of {@link TreeSet}
      * @see TreeSet#TreeSet(Comparator)
      */
     public static <E> TreeSet<E> newTreeSet(final Comparator<? super E> c) {
@@ -1273,13 +1086,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link TreeSet}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link TreeSet}.
      *
-     * @param <E>
-     *            {@link TreeSet}の要素型
-     * @param s
-     *            要素がセットに配置されるコレクション
-     * @return {@link TreeSet}の新しいインスタンス
+     * @param <E> the element type of {@link TreeSet}
+     * @param s the sorted set to be placed in the created set
+     * @return a new instance of {@link TreeSet}
      * @see TreeSet#TreeSet(SortedSet)
      */
     public static <E> TreeSet<E> newTreeSet(final SortedSet<? extends E> s) {
@@ -1287,11 +1098,10 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Vector}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Vector}.
      *
-     * @param <E>
-     *            {@link Vector}の要素型
-     * @return {@link Vector}の新しいインスタンス
+     * @param <E> the element type of {@link Vector}
+     * @return a new instance of {@link Vector}
      * @see Vector#Vector()
      */
     public static <E> Vector<E> newVector() {
@@ -1299,13 +1109,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Vector}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Vector}.
      *
-     * @param <E>
-     *            {@link Vector}の要素型
-     * @param c
-     *            要素がセットに配置されるコレクション
-     * @return {@link Vector}の新しいインスタンス
+     * @param <E> the element type of {@link Vector}
+     * @param c the collection of elements to be placed in the vector
+     * @return a new instance of {@link Vector}
      * @see Vector#Vector(Collection)
      */
     public static <E> Vector<E> newVector(final Collection<? extends E> c) {
@@ -1313,13 +1121,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Vector}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Vector}.
      *
-     * @param <E>
-     *            {@link Vector}の要素型
-     * @param initialCapacity
-     *            {@link Vector}の初期容量
-     * @return {@link Vector}の新しいインスタンス
+     * @param <E> the element type of {@link Vector}
+     * @param initialCapacity the initial capacity of the vector
+     * @return a new instance of {@link Vector}
      * @see Vector#Vector(int)
      */
     public static <E> Vector<E> newVector(final int initialCapacity) {
@@ -1327,15 +1133,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Vector}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link Vector}.
      *
-     * @param <E>
-     *            {@link Vector}の要素型
-     * @param initialCapacity
-     *            {@link Vector}の初期容量
-     * @param capacityIncrement
-     *            {@link Vector}があふれたときに増加される容量
-     * @return {@link Vector}の新しいインスタンス
+     * @param <E> the element type of {@link Vector}
+     * @param initialCapacity the initial capacity of the vector
+     * @param capacityIncrement the capacity increment when the vector overflows
+     * @return a new instance of {@link Vector}
      * @see Vector#Vector(int, int)
      */
     public static <E> Vector<E> newVector(final int initialCapacity, final int capacityIncrement) {
@@ -1343,13 +1146,11 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link WeakHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link WeakHashMap}.
      *
-     * @param <K>
-     *            {@link WeakHashMap}のキーの型
-     * @param <V>
-     *            {@link WeakHashMap}の値の型
-     * @return {@link WeakHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link WeakHashMap}
+     * @param <V> the value type of {@link WeakHashMap}
+     * @return a new instance of {@link WeakHashMap}
      * @see WeakHashMap#WeakHashMap()
      */
     public static <K, V> WeakHashMap<K, V> newWeakHashMap() {
@@ -1357,15 +1158,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link WeakHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link WeakHashMap}.
      *
-     * @param <K>
-     *            {@link WeakHashMap}のキーの型
-     * @param <V>
-     *            {@link WeakHashMap}の値の型
-     * @param initialCapacity
-     *            初期容量
-     * @return {@link WeakHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link WeakHashMap}
+     * @param <V> the value type of {@link WeakHashMap}
+     * @param initialCapacity the initial capacity
+     * @return a new instance of {@link WeakHashMap}
      * @see WeakHashMap#WeakHashMap(int)
      */
     public static <K, V> WeakHashMap<K, V> newWeakHashMap(final int initialCapacity) {
@@ -1373,17 +1171,13 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link WeakHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link WeakHashMap}.
      *
-     * @param <K>
-     *            {@link WeakHashMap}のキーの型
-     * @param <V>
-     *            {@link WeakHashMap}の値の型
-     * @param initialCapacity
-     *            初期容量
-     * @param loadFactor
-     *            サイズ変更の制御に使用される負荷係数のしきい値
-     * @return {@link WeakHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link WeakHashMap}
+     * @param <V> the value type of {@link WeakHashMap}
+     * @param initialCapacity the initial capacity
+     * @param loadFactor the load factor
+     * @return a new instance of {@link WeakHashMap}
      * @see WeakHashMap#WeakHashMap(int, float)
      */
     public static <K, V> WeakHashMap<K, V> newWeakHashMap(final int initialCapacity, final float loadFactor) {
@@ -1391,15 +1185,12 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link WeakHashMap}の新しいインスタンスを作成して返します。
+     * Creates and returns a new instance of {@link WeakHashMap}.
      *
-     * @param <K>
-     *            {@link WeakHashMap}のキーの型
-     * @param <V>
-     *            {@link WeakHashMap}の値の型
-     * @param m
-     *            作成されるマップに配置されるマップ
-     * @return {@link WeakHashMap}の新しいインスタンス
+     * @param <K> the key type of {@link WeakHashMap}
+     * @param <V> the value type of {@link WeakHashMap}
+     * @param m the map to be placed in the created map
+     * @return a new instance of {@link WeakHashMap}
      * @see WeakHashMap#WeakHashMap(Map)
      */
     public static <K, V> WeakHashMap<K, V> newWeakHashMap(final Map<? extends K, ? extends V> m) {
@@ -1407,24 +1198,19 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * マップが指定されたキーを含んでいない場合は、キーを指定された値に関連付けます。
+     * Associates the specified value with the specified key in the map if the map does not already contain the key.
      * <p>
-     * マップがすでに指定されたキーを含んでいる場合は、 キーに関連づけられている値を返します。 マップは変更されず、 指定された値は使われません。
-     * マップがまだ指定されたキーを含んでいない場合は、 指定された値を値を返します。 マップは変更され、指定されたキーと指定された値が関連づけられます。
-     * いずれの場合も、返される値はマップがその時点でキーと関連づけている値です。
+     * If the map already contains the key, the value associated with the key is returned and the map is unchanged.
+     * If the map does not contain the key, the specified value is associated with the key and the value is returned.
+     * In either case, the returned value is the value currently associated with the key in the map.
      * </p>
      *
-     * @param <K>
-     *            {@link HashMap}のキーの型
-     * @param <V>
-     *            {@link HashMap}の値の型
-     * @param map
-     *            マップ
-     * @param key
-     *            指定される値が関連付けられるキー
-     * @param value
-     *            指定されるキーに関連付けられる値
-     * @return 指定されたキーと関連付けられていた以前の値または、キーに関連付けられる値
+     * @param <K> the key type of {@link HashMap}
+     * @param <V> the value type of {@link HashMap}
+     * @param map the map
+     * @param key the key with which the specified value is to be associated
+     * @param value the value to be associated with the specified key
+     * @return the previous value associated with the specified key, or the specified value if the key was not present
      * @see ConcurrentHashMap#putIfAbsent(Object, Object)
      */
     public static <K, V> V putIfAbsent(final ConcurrentMap<K, V> map, final K key, final V value) {
@@ -1436,44 +1222,40 @@ public abstract class CollectionsUtil {
     }
 
     /**
-     * {@link Collection}が{@literal null}または要素が無い場合は{@literal true}を返します。
+     * Returns {@literal true} if the given {@link Collection} is {@literal null} or empty.
      *
-     * @param collection
-     *            コレクション
-     * @return コレクションが{@literal null}または要素が無い場合は{@literal true}
+     * @param collection the collection
+     * @return {@literal true} if the collection is {@literal null} or empty
      */
     public static boolean isEmpty(final Collection<?> collection) {
         return collection == null || collection.isEmpty();
     }
 
     /**
-     * {@link Collection}が{@literal null}でも要素が無いわけでもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the given {@link Collection} is not {@literal null} and not empty.
      *
-     * @param collection
-     *            コレクション
-     * @return コレクションが{@literal null}でも要素が無いわけでもない場合は{@literal true}
+     * @param collection the collection
+     * @return {@literal true} if the collection is not {@literal null} and not empty
      */
     public static boolean isNotEmpty(final Collection<?> collection) {
         return !isEmpty(collection);
     }
 
     /**
-     * {@link Map}が{@literal null}または要素が無い場合は{@literal true}を返します。
+     * Returns {@literal true} if the given {@link Map} is {@literal null} or empty.
      *
-     * @param map
-     *            マップ
-     * @return マップが{@literal null}または要素が無い場合は{@literal true}
+     * @param map the map
+     * @return {@literal true} if the map is {@literal null} or empty
      */
     public static boolean isEmpty(final Map<?, ?> map) {
         return map == null || map.isEmpty();
     }
 
     /**
-     * {@link Map}が{@literal null}でも要素が無いわけでもない場合は{@literal true}を返します。
+     * Returns {@literal true} if the given {@link Map} is not {@literal null} and not empty.
      *
-     * @param map
-     *            マップ
-     * @return マップが{@literal null}でも要素が無いわけでもない場合は{@literal true}
+     * @param map the map
+     * @return {@literal true} if the map is not {@literal null} and not empty
      */
     public static boolean isNotEmpty(final Map<?, ?> map) {
         return !isEmpty(map);

--- a/src/main/java/org/codelibs/core/collection/EmptyEnumeration.java
+++ b/src/main/java/org/codelibs/core/collection/EmptyEnumeration.java
@@ -18,16 +18,15 @@ package org.codelibs.core.collection;
 import java.util.Enumeration;
 
 /**
- * 空の {@link Enumeration}です。
+ * An empty {@link Enumeration}.
  *
  * @author higa
- * @param <T>
- *            列挙する要素の型
+ * @param <T> the type of elements
  */
 public class EmptyEnumeration<T> extends IteratorEnumeration<T> {
 
     /**
-     * {@link EmptyEnumeration}を作成します。
+     * Creates an {@link EmptyEnumeration}.
      */
     public EmptyEnumeration() {
         super(new EmptyIterator<T>());

--- a/src/main/java/org/codelibs/core/collection/EmptyIterator.java
+++ b/src/main/java/org/codelibs/core/collection/EmptyIterator.java
@@ -20,16 +20,15 @@ import java.util.Iterator;
 import org.codelibs.core.exception.ClUnsupportedOperationException;
 
 /**
- * 空の {@link Iterator}です。
+ * An empty {@link Iterator}.
  *
  * @author higa
- * @param <T>
- *            反復する要素の型
+ * @param <T> the element type
  */
 public class EmptyIterator<T> implements Iterator<T> {
 
     /**
-     * {@link EmptyIterator}を作成します。
+     * Creates an {@link EmptyIterator}.
      */
     public EmptyIterator() {
     }

--- a/src/main/java/org/codelibs/core/collection/EnumerationIterator.java
+++ b/src/main/java/org/codelibs/core/collection/EnumerationIterator.java
@@ -23,24 +23,21 @@ import java.util.Iterator;
 import org.codelibs.core.exception.ClUnsupportedOperationException;
 
 /**
- * {@link Enumeration}を {@link Iterator}にするためのアダブタです。
+ * Adapter to convert an {@link Enumeration} to an {@link Iterator}.
  *
  * @author shot
- * @param <T>
- *            列挙する要素の型
+ * @param <T> the element type
  */
 public class EnumerationIterator<T> implements Iterator<T> {
 
     private Enumeration<T> enumeration = null;
 
     /**
-     * for each構文で使用するために{@link Enumeration}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps an {@link Enumeration} for use in a for-each statement.
      *
-     * @param <T>
-     *            列挙する要素の型
-     * @param enumeration
-     *            {@link Enumeration}。{@literal null}であってはいけません
-     * @return {@link Enumeration}をラップした{@link Iterable}
+     * @param <T> the element type
+     * @param enumeration the enumeration (must not be {@literal null})
+     * @return an {@link Iterable} wrapping the enumeration
      */
     public static <T> Iterable<T> iterable(final Enumeration<T> enumeration) {
         assertArgumentNotNull("enumeration", enumeration);
@@ -49,10 +46,9 @@ public class EnumerationIterator<T> implements Iterator<T> {
     }
 
     /**
-     * {@link Enumeration}をラップした{@link Iterator}のインスタンスを構築します。
+     * Constructs an instance of an {@link Iterator} wrapping an {@link Enumeration}.
      *
-     * @param enumeration
-     *            {@link Enumeration}。{@literal null}であってはいけません
+     * @param enumeration the enumeration (must not be {@literal null})
      */
     public EnumerationIterator(final Enumeration<T> enumeration) {
         assertArgumentNotNull("enumeration", enumeration);

--- a/src/main/java/org/codelibs/core/collection/Indexed.java
+++ b/src/main/java/org/codelibs/core/collection/Indexed.java
@@ -16,28 +16,25 @@
 package org.codelibs.core.collection;
 
 /**
- * {@link IndexedIterator}でイテレートする要素です。
+ * Element to be iterated by {@link IndexedIterator}.
  *
  * @author wyukawa
- * @param <T>
- *            要素の型
+ * @param <T> the element type
  * @see IndexedIterator
  */
 public class Indexed<T> {
 
-    /** 要素 */
+    /** The element. */
     private final T element;
 
-    /** 要素のインデックス */
+    /** The index of the element. */
     private final int index;
 
     /**
-     * コンストラクタ
+     * Constructor.
      *
-     * @param element
-     *            要素
-     * @param index
-     *            要素のインデックス
+     * @param element the element
+     * @param index the index of the element
      */
     public Indexed(final T element, final int index) {
         this.element = element;
@@ -45,18 +42,18 @@ public class Indexed<T> {
     }
 
     /**
-     * 要素を返します。
+     * Returns the element.
      *
-     * @return 要素
+     * @return the element
      */
     public T getElement() {
         return element;
     }
 
     /**
-     * インデックスを返します。
+     * Returns the index.
      *
-     * @return インデックス
+     * @return the index
      */
     public int getIndex() {
         return index;

--- a/src/main/java/org/codelibs/core/collection/IndexedIterator.java
+++ b/src/main/java/org/codelibs/core/collection/IndexedIterator.java
@@ -22,17 +22,17 @@ import java.util.Iterator;
 import org.codelibs.core.exception.ClUnsupportedOperationException;
 
 /**
- * インデックス付きの{@link Iterator}です。インデックスは{@literal 0}から始まります。
+ * {@link Iterator} with index. The index starts from {@literal 0}.
  *
  * <p>
- * 次のように使います．
+ * Usage example:
  * </p>
  *
  * <pre>
  * import static org.codelibs.core.collection.IndexedIterator.*;
  *
- * List&lt;String&gt; list = ...;
- * for (Indexed&lt;String%gt; indexed : indexed(list)) {
+ * List<String> list = ...;
+ * for (Indexed<String> indexed : indexed(list)) {
  *     System.out.println(indexed.getIndex());
  *     System.out.println(indexed.getElement());
  * }
@@ -43,15 +43,14 @@ import org.codelibs.core.exception.ClUnsupportedOperationException;
  * import static org.codelibs.core.io.LineIterator.*;
  *
  * BufferedReader reader = ...;
- * for (Indexed&lt;String%gt; indexed : indexed(iterable(reader))) {
+ * for (Indexed<String> indexed : indexed(iterable(reader))) {
  *     System.out.println(indexed.getIndex());
  *     System.out.println(indexed.getElement());
  * }
  * </pre>
  *
  * @author wyukawa
- * @param <T>
- *            イテレートする要素の型
+ * @param <T> the element type
  * @see Indexed
  */
 public class IndexedIterator<T> implements Iterator<Indexed<T>> {
@@ -59,17 +58,15 @@ public class IndexedIterator<T> implements Iterator<Indexed<T>> {
     /** {@link Iterator} */
     protected final Iterator<T> iterator;
 
-    /** イテレータのインデックス */
+    /** The index of the iterator. */
     protected int index;
 
     /**
-     * for each構文で使用するために{@link IndexedIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps an {@link IndexedIterator} for use in a for-each statement.
      *
-     * @param <T>
-     *            {@link Iterable}の要素型
-     * @param iterable
-     *            {@link Iterable}。{@literal null}であってはいけません
-     * @return {@link IndexedIterator}をラップした{@link Iterable}
+     * @param <T> the element type
+     * @param iterable the iterable (must not be {@literal null})
+     * @return an {@link Iterable} wrapping an {@link IndexedIterator}
      */
     public static <T> Iterable<Indexed<T>> indexed(final Iterable<T> iterable) {
         assertArgumentNotNull("iterable", iterable);
@@ -77,13 +74,11 @@ public class IndexedIterator<T> implements Iterator<Indexed<T>> {
     }
 
     /**
-     * for each構文で使用するために{@link IndexedIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps an {@link IndexedIterator} for use in a for-each statement.
      *
-     * @param <T>
-     *            {@link Iterable}の要素型
-     * @param iterator
-     *            {@link Iterator}。{@literal null}であってはいけません
-     * @return {@link IndexedIterator}をラップした{@link Iterable}
+     * @param <T> the element type
+     * @param iterator the iterator (must not be {@literal null})
+     * @return an {@link Iterable} wrapping an {@link IndexedIterator}
      */
     public static <T> Iterable<Indexed<T>> indexed(final Iterator<T> iterator) {
         assertArgumentNotNull("iterator", iterator);
@@ -92,11 +87,9 @@ public class IndexedIterator<T> implements Iterator<Indexed<T>> {
     }
 
     /**
+     * Constructs an instance.
      *
-     * インスタンスを構築します。
-     *
-     * @param iterator
-     *            イテレータ。{@literal null}であってはいけません
+     * @param iterator the iterator (must not be {@literal null})
      */
     public IndexedIterator(final Iterator<T> iterator) {
         assertArgumentNotNull("iterator", iterator);

--- a/src/main/java/org/codelibs/core/collection/IndexedIterator.java
+++ b/src/main/java/org/codelibs/core/collection/IndexedIterator.java
@@ -31,8 +31,8 @@ import org.codelibs.core.exception.ClUnsupportedOperationException;
  * <pre>
  * import static org.codelibs.core.collection.IndexedIterator.*;
  *
- * List<String> list = ...;
- * for (Indexed<String> indexed : indexed(list)) {
+ * List&lt;String&gt; list = ...;
+ * for (Indexed&lt;String&gt; indexed : indexed(list)) {
  *     System.out.println(indexed.getIndex());
  *     System.out.println(indexed.getElement());
  * }
@@ -43,7 +43,7 @@ import org.codelibs.core.exception.ClUnsupportedOperationException;
  * import static org.codelibs.core.io.LineIterator.*;
  *
  * BufferedReader reader = ...;
- * for (Indexed<String> indexed : indexed(iterable(reader))) {
+ * for (Indexed&lt;String&gt; indexed : indexed(iterable(reader))) {
  *     System.out.println(indexed.getIndex());
  *     System.out.println(indexed.getElement());
  * }

--- a/src/main/java/org/codelibs/core/collection/IteratorEnumeration.java
+++ b/src/main/java/org/codelibs/core/collection/IteratorEnumeration.java
@@ -21,11 +21,10 @@ import java.util.Enumeration;
 import java.util.Iterator;
 
 /**
- * {@link Iterator}を {@link Enumeration}にするためのアダブタです。
+ * Adapter to convert an {@link Iterator} to an {@link Enumeration}.
  *
  * @author higa
- * @param <T>
- *            列挙する要素の型
+ * @param <T> the element type
  */
 public class IteratorEnumeration<T> implements Enumeration<T> {
 
@@ -33,10 +32,9 @@ public class IteratorEnumeration<T> implements Enumeration<T> {
     protected final Iterator<T> iterator;
 
     /**
-     * {@link IteratorEnumeration}を作成します。
+     * Creates an {@link IteratorEnumeration}.
      *
-     * @param iterator
-     *            反復子。{@literal null}であってはいけません
+     * @param iterator the iterator (must not be {@literal null})
      */
     public IteratorEnumeration(final Iterator<T> iterator) {
         assertArgumentNotNull("iterator", iterator);
@@ -44,10 +42,9 @@ public class IteratorEnumeration<T> implements Enumeration<T> {
     }
 
     /**
-     * {@link IteratorEnumeration}を作成します。
+     * Creates an {@link IteratorEnumeration}.
      *
-     * @param iterable
-     *            反復可能なオブジェクト。{@literal null}であってはいけません
+     * @param iterable the iterable object (must not be {@literal null})
      */
     public IteratorEnumeration(final Iterable<T> iterable) {
         assertArgumentNotNull("iterable", iterable);

--- a/src/main/java/org/codelibs/core/collection/LruHashMap.java
+++ b/src/main/java/org/codelibs/core/collection/LruHashMap.java
@@ -20,52 +20,46 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * エントリ数の上限を持ち、新しいエントリが追加されるとLRUで古いエントリを破棄する{@link HashMap}です。
+ * {@link HashMap} with an upper limit on the number of entries. When a new entry is added, the oldest entry is discarded using LRU if the limit is exceeded.
  *
  * @author koichik
- * @param <K>
- *            キーの型
- * @param <V>
- *            値の型
+ * @param <K> the key type
+ * @param <V> the value type
  */
 public class LruHashMap<K, V> extends LinkedHashMap<K, V> {
 
     private static final long serialVersionUID = 1L;
 
     /**
-     * デフォルトの初期容量です。
+     * Default initial capacity.
      */
     protected static final int DEFAULT_INITIAL_CAPACITY = 16;
 
     /**
-     * デフォルトのロードファクタです。
+     * Default load factor.
      */
     protected static final float DEFAULT_LOAD_FACTOR = 0.75f;
 
     /**
-     * 上限サイズです。
+     * Upper limit on the number of entries.
      */
     protected final int limitSize;
 
     /**
-     * {@link LruHashMap}を作成します。
+     * Creates an {@link LruHashMap}.
      *
-     * @param limitSize
-     *            エントリ数の上限
+     * @param limitSize the upper limit on the number of entries
      */
     public LruHashMap(final int limitSize) {
         this(limitSize, DEFAULT_INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR);
     }
 
     /**
-     * {@link LruHashMap}を作成します。
+     * Creates an {@link LruHashMap}.
      *
-     * @param limitSize
-     *            エントリ数の上限
-     * @param initialCapacity
-     *            初期容量
-     * @param loadFactor
-     *            負荷係数
+     * @param limitSize the upper limit on the number of entries
+     * @param initialCapacity the initial capacity
+     * @param loadFactor the load factor
      */
     public LruHashMap(final int limitSize, final int initialCapacity, final float loadFactor) {
         super(initialCapacity, loadFactor, true);
@@ -73,9 +67,9 @@ public class LruHashMap<K, V> extends LinkedHashMap<K, V> {
     }
 
     /**
-     * エントリ数の上限を返します。
+     * Returns the upper limit on the number of entries.
      *
-     * @return エントリ数の上限
+     * @return the upper limit on the number of entries
      */
     public int getLimitSize() {
         return limitSize;

--- a/src/main/java/org/codelibs/core/collection/Maps.java
+++ b/src/main/java/org/codelibs/core/collection/Maps.java
@@ -25,9 +25,9 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * 簡潔な記述で{@link Map}のインスタンスを生成して値を設定するためのユーティリティクラスです。
+ * Utility class for easily creating and setting values in {@link Map} instances.
  * <p>
- * 本クラスをstatic importすることにより、次のように{@literal Map}のインスタンスを簡潔に初期化することができます。
+ * By statically importing this class, you can easily initialize {@literal Map} instances as follows:
  * </p>
  *
  * <pre>
@@ -37,170 +37,133 @@ import java.util.concurrent.ConcurrentHashMap;
  * </pre>
  *
  * @author koichik
- * @param <K>
- *            {@literal Map}のキーの型
- * @param <V>
- *            {@literal Map}の値の型
+ * @param <K> the key type of the {@literal Map}
+ * @param <V> the value type of the {@literal Map}
  */
 public class Maps<K, V> {
 
-    /** 作成対象の<code>Map</code> */
+    /** The target <code>Map</code> to be created. */
     protected Map<K, V> map;
 
     /**
-     * 指定されたキーと値を持つ{@link Map}を構築するための{@literal Maps}を返します。
+     * Returns a {@literal Maps} for constructing a {@link Map} with the specified key and value.
      *
-     * @param <KEY>
-     *            <code>Map</code>のキーの型
-     * @param <VALUE>
-     *            <code>Map</code>の値ーの型
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return 指定されたキーと値を持つ{@link Map}を構築するための{@literal Maps}
+     * @param <KEY> the key type of the <code>Map</code>
+     * @param <VALUE> the value type of the <code>Map</code>
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return a {@literal Maps} for constructing a {@link Map} with the specified key and value
      */
     public static <KEY, VALUE> Maps<KEY, VALUE> map(final KEY key, final VALUE value) {
         return linkedHashMap(key, value);
     }
 
     /**
-     * 指定されたキーと値を持つ{@link ConcurrentHashMap}を構築するための{@literal Maps}を返します。
+     * Returns a {@literal Maps} for constructing a {@link ConcurrentHashMap} with the specified key and value.
      *
-     * @param <KEY>
-     *            <code>Map</code>のキーの型
-     * @param <VALUE>
-     *            <code>Map</code>の値ーの型
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return 指定されたキーと値を持つ{@link ConcurrentHashMap}を構築するための{@literal Maps}
+     * @param <KEY> the key type of the <code>Map</code>
+     * @param <VALUE> the value type of the <code>Map</code>
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return a {@literal Maps} for constructing a {@link ConcurrentHashMap} with the specified key and value
      */
     public static <KEY, VALUE> Maps<KEY, VALUE> concurrentHashMap(final KEY key, final VALUE value) {
         return new Maps<>(new ConcurrentHashMap<KEY, VALUE>()).$(key, value);
     }
 
     /**
-     * 指定されたキーと値を持つ{@link HashMap}を構築するための{@literal Maps}を返します。
+     * Returns a {@literal Maps} for constructing a {@link HashMap} with the specified key and value.
      *
-     * @param <KEY>
-     *            <code>Map</code>のキーの型
-     * @param <VALUE>
-     *            <code>Map</code>の値ーの型
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return 指定されたキーと値を持つ{@link HashMap}を構築するための{@literal Maps}
+     * @param <KEY> the key type of the <code>Map</code>
+     * @param <VALUE> the value type of the <code>Map</code>
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return a {@literal Maps} for constructing a {@link HashMap} with the specified key and value
      */
     public static <KEY, VALUE> Maps<KEY, VALUE> hashMap(final KEY key, final VALUE value) {
         return new Maps<>(new HashMap<KEY, VALUE>()).$(key, value);
     }
 
     /**
-     * 指定されたキーと値を持つ{@link Hashtable}を構築するための{@literal Maps}を返します。
+     * Returns a {@literal Maps} for constructing a {@link Hashtable} with the specified key and value.
      *
-     * @param <KEY>
-     *            <code>Map</code>のキーの型
-     * @param <VALUE>
-     *            <code>Map</code>の値ーの型
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return 指定されたキーと値を持つ{@link Hashtable}を構築するための{@literal Maps}
+     * @param <KEY> the key type of the <code>Map</code>
+     * @param <VALUE> the value type of the <code>Map</code>
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return a {@literal Maps} for constructing a {@link Hashtable} with the specified key and value
      */
     public static <KEY, VALUE> Maps<KEY, VALUE> hashtable(final KEY key, final VALUE value) {
         return new Maps<>(new Hashtable<KEY, VALUE>()).$(key, value);
     }
 
     /**
-     * 指定されたキーと値を持つ{@link IdentityHashMap}を構築するための{@literal Maps}を返します。
+     * Returns a {@literal Maps} for constructing a {@link IdentityHashMap} with the specified key and value.
      *
-     * @param <KEY>
-     *            <code>Map</code>のキーの型
-     * @param <VALUE>
-     *            <code>Map</code>の値ーの型
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return 指定されたキーと値を持つ{@link IdentityHashMap}を構築するための{@literal Maps}
+     * @param <KEY> the key type of the <code>Map</code>
+     * @param <VALUE> the value type of the <code>Map</code>
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return a {@literal Maps} for constructing a {@link IdentityHashMap} with the specified key and value
      */
     public static <KEY, VALUE> Maps<KEY, VALUE> identityHashMap(final KEY key, final VALUE value) {
         return new Maps<>(new IdentityHashMap<KEY, VALUE>()).$(key, value);
     }
 
     /**
-     * 指定されたキーと値を持つ{@link LinkedHashMap}を構築するための{@literal Maps}を返します。
+     * Returns a {@literal Maps} for constructing a {@link LinkedHashMap} with the specified key and value.
      *
-     * @param <KEY>
-     *            <code>Map</code>のキーの型
-     * @param <VALUE>
-     *            <code>Map</code>の値ーの型
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return 指定されたキーと値を持つ{@link LinkedHashMap}を構築するための{@literal Maps}
+     * @param <KEY> the key type of the <code>Map</code>
+     * @param <VALUE> the value type of the <code>Map</code>
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return a {@literal Maps} for constructing a {@link LinkedHashMap} with the specified key and value
      */
     public static <KEY, VALUE> Maps<KEY, VALUE> linkedHashMap(final KEY key, final VALUE value) {
         return new Maps<>(new LinkedHashMap<KEY, VALUE>()).$(key, value);
     }
 
     /**
-     * 指定されたキーと値を持つ{@link TreeMap}を構築するための{@literal Maps}を返します。
+     * Returns a {@literal Maps} for constructing a {@link TreeMap} with the specified key and value.
      *
-     * @param <KEY>
-     *            <code>Map</code>のキーの型
-     * @param <VALUE>
-     *            <code>Map</code>の値ーの型
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return 指定されたキーと値を持つ{@link TreeMap}を構築するための{@literal Maps}
+     * @param <KEY> the key type of the <code>Map</code>
+     * @param <VALUE> the value type of the <code>Map</code>
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return a {@literal Maps} for constructing a {@link TreeMap} with the specified key and value
      */
     public static <KEY, VALUE> Maps<KEY, VALUE> treeMap(final KEY key, final VALUE value) {
         return new Maps<>(new TreeMap<KEY, VALUE>()).$(key, value);
     }
 
     /**
-     * 指定されたキーと値を持つ{@link WeakHashMap}を構築するための{@literal Maps}を返します。
+     * Returns a {@literal Maps} for constructing a {@link WeakHashMap} with the specified key and value.
      *
-     * @param <KEY>
-     *            <code>Map</code>のキーの型
-     * @param <VALUE>
-     *            <code>Map</code>の値ーの型
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return 指定されたキーと値を持つ{@link WeakHashMap}を構築するための{@literal Maps}
+     * @param <KEY> the key type of the <code>Map</code>
+     * @param <VALUE> the value type of the <code>Map</code>
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return a {@literal Maps} for constructing a {@link WeakHashMap} with the specified key and value
      */
     public static <KEY, VALUE> Maps<KEY, VALUE> weakHashMap(final KEY key, final VALUE value) {
         return new Maps<>(new WeakHashMap<KEY, VALUE>()).$(key, value);
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
-     * @param map
-     *            キーと値を追加する対象の<code>Map</code>
+     * @param map the <code>Map</code> to which keys and values are added
      */
     protected Maps(final Map<K, V> map) {
         this.map = map;
     }
 
     /**
-     * {@link Map}にキーと値を追加します。
+     * Adds a key and value to the {@link Map}.
      *
-     * @param key
-     *            <code>Map</code>に追加されるキー
-     * @param value
-     *            <code>Map</code>に追加される値
-     * @return このインスタンス自身
+     * @param key the key to be added to the <code>Map</code>
+     * @param value the value to be added to the <code>Map</code>
+     * @return this instance
      */
     public Maps<K, V> $(final K key, final V value) {
         map.put(key, value);
@@ -208,9 +171,9 @@ public class Maps<K, V> {
     }
 
     /**
-     * <code>Map</code>を返します。
+     * Returns the <code>Map</code>.
      *
-     * @return キーと値が追加された<code>Map</code>
+     * @return the <code>Map</code> with the added keys and values
      */
     public Map<K, V> $() {
         return map;

--- a/src/main/java/org/codelibs/core/collection/MultiIterator.java
+++ b/src/main/java/org/codelibs/core/collection/MultiIterator.java
@@ -23,9 +23,9 @@ import java.util.NoSuchElementException;
 import org.codelibs.core.exception.ClUnsupportedOperationException;
 
 /**
- * 複数の{@link Iterator}を一つの{@link Iterator}のように反復するための{@link Iterator}です。
+ * An {@link Iterator} that iterates over multiple {@link Iterator}s as if they were a single {@link Iterator}.
  * <p>
- * 次のように使います．
+ * Usage example:
  * </p>
  *
  * <pre>
@@ -40,25 +40,22 @@ import org.codelibs.core.exception.ClUnsupportedOperationException;
  * </pre>
  *
  * @author koichik
- * @param <E>
- *            要素の型
+ * @param <E> the element type
  */
 public class MultiIterator<E> implements Iterator<E> {
 
-    /** {@link Iterator}の配列 */
+    /** Array of {@link Iterator}s. */
     protected final Iterator<E>[] iterators;
 
-    /** 現在反復中の{@link Iterator}のインデックス */
+    /** Index of the currently iterated {@link Iterator}. */
     protected int index;
 
     /**
-     * for each構文で使用するために{@link MultiIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps a {@link MultiIterator} for use in a for-each statement.
      *
-     * @param <E>
-     *            要素の型
-     * @param iterables
-     *            {@link Iterable}の並び。{@literal null}であってはいけません
-     * @return {@link MultiIterator}をラップした{@link Iterable}
+     * @param <E> the element type
+     * @param iterables the array of {@link Iterable} (must not be {@literal null})
+     * @return an {@link Iterable} wrapping a {@link MultiIterator}
      */
     public static <E> Iterable<E> iterable(final Iterable<E>... iterables) {
         assertArgumentNotNull("iterables", iterables);
@@ -72,13 +69,11 @@ public class MultiIterator<E> implements Iterator<E> {
     }
 
     /**
-     * for each構文で使用するために{@link MultiIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps a {@link MultiIterator} for use in a for-each statement.
      *
-     * @param <E>
-     *            要素の型
-     * @param iterators
-     *            {@link Iterator}の並び。{@literal null}であってはいけません
-     * @return {@link MultiIterator}をラップした{@link Iterable}
+     * @param <E> the element type
+     * @param iterators the array of {@link Iterator} (must not be {@literal null})
+     * @return an {@link Iterable} wrapping a {@link MultiIterator}
      */
     public static <E> Iterable<E> iterable(final Iterator<E>... iterators) {
         assertArgumentNotNull("iterators", iterators);
@@ -87,10 +82,9 @@ public class MultiIterator<E> implements Iterator<E> {
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
-     * @param iterators
-     *            {@link Iterator}の並び。{@literal null}であってはいけません
+     * @param iterators the array of {@link Iterator}s (must not be {@literal null})
      */
     public MultiIterator(final Iterator<E>... iterators) {
         assertArgumentNotNull("iterators", iterators);

--- a/src/main/java/org/codelibs/core/collection/SLinkedList.java
+++ b/src/main/java/org/codelibs/core/collection/SLinkedList.java
@@ -25,12 +25,10 @@ import java.lang.reflect.Array;
 import java.util.NoSuchElementException;
 
 /**
- * Seasar2用の連結リストです。
+ * Linked list for Seasar2.
  *
  * @author higa
- * @param <E>
- *            要素の型
- *
+ * @param <E> the element type
  */
 public class SLinkedList<E> implements Cloneable, Externalizable {
 
@@ -41,7 +39,7 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     private transient int size = 0;
 
     /**
-     * {@link SLinkedList}を作成します。
+     * Creates an {@link SLinkedList}.
      */
     public SLinkedList() {
         header.next = header;
@@ -49,9 +47,9 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 最初の要素を返します。
+     * Returns the first element.
      *
-     * @return 最初の要素
+     * @return the first element
      */
     public E getFirst() {
         if (isEmpty()) {
@@ -61,9 +59,9 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 最後の要素を返します。
+     * Returns the last element.
      *
-     * @return 最後の要素
+     * @return the last element
      */
     public E getLast() {
         if (isEmpty()) {
@@ -73,9 +71,9 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 最初のエントリを返します。
+     * Returns the first entry.
      *
-     * @return 最初のエントリ
+     * @return the first entry
      */
     public Entry getFirstEntry() {
         if (isEmpty()) {
@@ -85,9 +83,9 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 最後のエントリを返します。
+     * Returns the last entry.
      *
-     * @return 最後のエントリ
+     * @return the last entry
      */
     public Entry getLastEntry() {
         if (isEmpty()) {
@@ -97,9 +95,9 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 最初の要素を削除します。
+     * Removes the first element.
      *
-     * @return 最初の要素
+     * @return the first element
      */
     public E removeFirst() {
         if (isEmpty()) {
@@ -111,9 +109,9 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 最後の要素を削除します。
+     * Removes the last element.
      *
-     * @return 最後の要素
+     * @return the last element
      */
     public E removeLast() {
         if (isEmpty()) {
@@ -125,72 +123,66 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 先頭に追加します。
+     * Adds an element at the beginning.
      *
-     * @param element
-     *            追加するオブジェクト
+     * @param element the object to be added
      */
     public void addFirst(final E element) {
         header.next.addBefore(element);
     }
 
     /**
-     * 最後に追加します。
+     * Adds an element at the end.
      *
-     * @param element
-     *            追加するオブジェクト
+     * @param element the object to be added
      */
     public void addLast(final E element) {
         header.addBefore(element);
     }
 
     /**
-     * 指定した位置にオブジェクトを追加します。
+     * Inserts an object at the specified position.
      *
-     * @param index
-     *            位置
-     * @param element
-     *            要素
+     * @param index the position
+     * @param element the element
      */
     public void add(final int index, final E element) {
         getEntry(index).addBefore(element);
     }
 
     /**
-     * 要素の数を返します。
+     * Returns the number of elements.
      *
-     * @return 要素の数
+     * @return the number of elements
      */
     public int size() {
         return size;
     }
 
     /**
-     * 空かどうかを返します。
+     * Checks if the list is empty.
      *
-     * @return 空かどうか
+     * @return true if the list is empty, false otherwise
      */
     public boolean isEmpty() {
         return size == 0;
     }
 
     /**
-     * 要素が含まれているかどうかを返します。
+     * Checks if an element is contained in the list.
      *
-     * @param element
-     *            要素
-     * @return 要素が含まれているかどうか
+     * @param element the element
+     * @return true if the element is contained in the list, false otherwise
      */
     public boolean contains(final E element) {
         return indexOf(element) != -1;
     }
 
     /**
-     * 要素を削除します。
+     * Removes an element from the list.
      *
-     * @param element
-     *            要素
-     * @return 削除されたかどうか
+     * @param element the element
+     * @return true if the element was removed, false otherwise
      */
     public boolean remove(final E element) {
         if (element == null) {
@@ -212,11 +204,10 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 指定した位置の要素を削除します。
+     * Removes the element at the specified position.
      *
-     * @param index
-     *            位置
-     * @return 削除された要素
+     * @param index the position
+     * @return the removed element
      */
     public Object remove(final int index) {
         final Entry e = getEntry(index);
@@ -225,7 +216,7 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 要素を空にします。
+     * Empties the list.
      */
     public void clear() {
         header.next = header;
@@ -234,11 +225,10 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * インデックスで指定された位置のエントリを返します。
+     * Returns the entry at the specified position.
      *
-     * @param index
-     *            インデックス
-     * @return エントリ
+     * @param index the index
+     * @return the entry
      */
     public Entry getEntry(final int index) {
         assertIndex(0 <= index && index < size, "Index: " + index + ", Size: " + size);
@@ -256,24 +246,21 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * インデックスで指定された位置の要素を返します。
+     * Returns the element at the specified position.
      *
-     * @param index
-     *            インデックス
-     * @return 要素
+     * @param index the index
+     * @return the element
      */
     public E get(final int index) {
         return getEntry(index).element;
     }
 
     /**
-     * インデックスで指定された位置に要素を設定します。
+     * Sets the element at the specified position.
      *
-     * @param index
-     *            インデックス
-     * @param element
-     *            要素
-     * @return 元の要素
+     * @param index the index
+     * @param element the element
+     * @return the original element
      */
     public E set(final int index, final E element) {
         final Entry entry = getEntry(index);
@@ -283,11 +270,10 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 位置を返します。
+     * Returns the position of the element.
      *
-     * @param element
-     *            要素
-     * @return 位置
+     * @param element the element
+     * @return the position
      */
     public int indexOf(final E element) {
         int index = 0;
@@ -339,9 +325,9 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 配列に変換します。
+     * Converts the list to an array.
      *
-     * @return 配列
+     * @return the array
      */
     public Object[] toArray() {
         final Object[] result = new Object[size];
@@ -353,11 +339,10 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 配列に変換します。
+     * Converts the list to an array.
      *
-     * @param array
-     *            要素の格納先の配列。配列のサイズが十分でない場合は、同じ実行時の型で新しい配列が格納用として割り当てられる
-     * @return 配列
+     * @param array the array to store the elements. A new array of the same runtime type is allocated if the array is not large enough.
+     * @return the array
      */
     @SuppressWarnings("unchecked")
     public E[] toArray(E[] array) {
@@ -375,17 +360,17 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
     }
 
     /**
-     * 要素を格納するエントリです。
+     * An entry that stores an element.
      */
     public class Entry {
 
-        /** 要素 */
+        /** The element */
         protected E element;
 
-        /** 次のエントリ */
+        /** The next entry */
         protected Entry next;
 
-        /** 前のエントリ */
+        /** The previous entry */
         protected Entry previous;
 
         Entry(final E element, final Entry next, final Entry previous) {
@@ -395,18 +380,18 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
         }
 
         /**
-         * 要素を返します。
+         * Returns the element.
          *
-         * @return 要素
+         * @return the element
          */
         public E getElement() {
             return element;
         }
 
         /**
-         * 次のエントリを返します。
+         * Returns the next entry.
          *
-         * @return 次のエントリ
+         * @return the next entry
          */
         public Entry getNext() {
             if (next != SLinkedList.this.header) {
@@ -416,9 +401,9 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
         }
 
         /**
-         * 前のエントリを返します。
+         * Returns the previous entry.
          *
-         * @return 前のエントリ
+         * @return the previous entry
          */
         public Entry getPrevious() {
             if (previous != SLinkedList.this.header) {
@@ -428,7 +413,7 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
         }
 
         /**
-         * 要素を削除します。
+         * Removes the element.
          */
         public void remove() {
             previous.next = next;
@@ -437,11 +422,10 @@ public class SLinkedList<E> implements Cloneable, Externalizable {
         }
 
         /**
-         * 前に追加します。
+         * Adds an element before this entry.
          *
-         * @param o
-         *            要素
-         * @return 追加されたエントリ
+         * @param o the element
+         * @return the added entry
          */
         public Entry addBefore(final E o) {
             final Entry newEntry = new Entry(o, this, previous);

--- a/src/main/java/org/codelibs/core/collection/SingleValueIterator.java
+++ b/src/main/java/org/codelibs/core/collection/SingleValueIterator.java
@@ -21,38 +21,34 @@ import java.util.NoSuchElementException;
 import org.codelibs.core.exception.ClUnsupportedOperationException;
 
 /**
- * 一つの値を返す{@link Iterator}です。
+ * An {@link Iterator} that returns a single value.
  *
  * @author koichik
- * @param <E>
- *            要素の型
+ * @param <E> the element type
  */
 public class SingleValueIterator<E> implements Iterator<E> {
 
-    /** 反復子が返す唯一の値 */
+    /** The only value returned by the iterator. */
     protected final E value;
 
-    /** 反復子がさらに要素を持つ場合は{@literal true} */
+    /** {@literal true} if the iterator has more elements. */
     protected boolean hasNext = true;
 
     /**
-     * for each構文で使用するために{@link SingleValueIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps a {@link SingleValueIterator} for use in a for-each statement.
      *
-     * @param <E>
-     *            要素の型
-     * @param value
-     *            反復子が返す唯一の値
-     * @return {@link SingleValueIterator}をラップした{@link Iterable}
+     * @param <E> the element type
+     * @param value the single value returned by the iterator
+     * @return an {@link Iterable} wrapping a {@link SingleValueIterator}
      */
     public static <E> Iterable<E> iterable(final E value) {
         return () -> new SingleValueIterator<>(value);
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
-     * @param value
-     *            反復子が返す唯一の値
+     * @param value the single value returned by the iterator
      */
     public SingleValueIterator(final E value) {
         this.value = value;

--- a/src/main/java/org/codelibs/core/convert/BigDecimalConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BigDecimalConversionUtil.java
@@ -21,31 +21,31 @@ import java.text.SimpleDateFormat;
 import org.codelibs.core.lang.StringUtil;
 
 /**
- * {@link BigDecimal}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link BigDecimal}.
  *
  * @author higa
  */
 public abstract class BigDecimalConversionUtil {
 
     /**
-     * {@link BigDecimal}に変換します。
+     * Converts to {@link BigDecimal}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link BigDecimal}
+     *            The object to convert
+     * @return The converted {@link BigDecimal}
      */
     public static BigDecimal toBigDecimal(final Object o) {
         return toBigDecimal(o, null);
     }
 
     /**
-     * {@link BigDecimal}に変換します。
+     * Converts to {@link BigDecimal}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link BigDecimal}
+     *            The pattern string
+     * @return The converted {@link BigDecimal}
      */
     public static BigDecimal toBigDecimal(final Object o, final String pattern) {
         if (o == null) {
@@ -69,22 +69,22 @@ public abstract class BigDecimalConversionUtil {
     }
 
     /**
-     * {@link BigDecimal}を文字列に変換します。
+     * Converts a {@link BigDecimal} to a string.
      *
      * @param dec
-     *            変換元の{@link BigDecimal}
-     * @return 変換された文字列
+     *            The {@link BigDecimal} to convert
+     * @return The converted string
      */
     public static String toString(final BigDecimal dec) {
         return dec.toPlainString();
     }
 
     /**
-     * {@link BigDecimal}を正規化します。
+     * Normalizes a {@link BigDecimal}.
      *
      * @param dec
-     *            変換元の{@link BigDecimal}
-     * @return 正規化されたデータ
+     *            The {@link BigDecimal} to normalize
+     * @return The normalized data
      */
     private static BigDecimal normalize(final BigDecimal dec) {
         return new BigDecimal(dec.toPlainString());

--- a/src/main/java/org/codelibs/core/convert/BigIntegerConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BigIntegerConversionUtil.java
@@ -18,31 +18,31 @@ package org.codelibs.core.convert;
 import java.math.BigInteger;
 
 /**
- * {@link BigInteger}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link BigInteger}.
  *
  * @author higa
  */
 public abstract class BigIntegerConversionUtil {
 
     /**
-     * {@link BigInteger}に変換します。
+     * Converts to {@link BigInteger}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link BigInteger}
+     *            The object to convert
+     * @return The converted {@link BigInteger}
      */
     public static BigInteger toBigInteger(final Object o) {
         return toBigInteger(o, null);
     }
 
     /**
-     * {@link BigInteger}に変換します。
+     * Converts to {@link BigInteger}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link BigInteger}
+     *            The pattern string
+     * @return The converted {@link BigInteger}
      */
     public static BigInteger toBigInteger(final Object o, final String pattern) {
         if (o == null) {

--- a/src/main/java/org/codelibs/core/convert/BinaryConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BinaryConversionUtil.java
@@ -18,18 +18,18 @@ package org.codelibs.core.convert;
 import static org.codelibs.core.misc.AssertionUtil.assertArgument;
 
 /**
- * byte配列用の変換ユーティリティです。
+ * Utility class for conversions related to byte arrays.
  *
  * @author higa
  */
 public abstract class BinaryConversionUtil {
 
     /**
-     * {@literal byte}の配列に変換します。
+     * Converts to a {@literal byte} array.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return {@literal byte}の配列
+     *            The object to convert
+     * @return The {@literal byte} array
      */
     public static byte[] toBinary(final Object o) {
         if (o instanceof byte[]) {

--- a/src/main/java/org/codelibs/core/convert/BooleanConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BooleanConversionUtil.java
@@ -16,18 +16,18 @@
 package org.codelibs.core.convert;
 
 /**
- * {@link Boolean}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link Boolean}.
  *
  * @author higa
  */
 public abstract class BooleanConversionUtil {
 
     /**
-     * {@link Boolean}に変換します。
+     * Converts to {@link Boolean}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link Boolean}
+     *            The object to convert
+     * @return The converted {@link Boolean}
      */
     public static Boolean toBoolean(final Object o) {
         if (o == null) {
@@ -54,11 +54,11 @@ public abstract class BooleanConversionUtil {
     }
 
     /**
-     * {@literal boolean}に変換します。
+     * Converts to {@literal boolean}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@literal boolean}
+     *            The object to convert
+     * @return The converted {@literal boolean}
      */
     public static boolean toPrimitiveBoolean(final Object o) {
         final Boolean b = toBoolean(o);

--- a/src/main/java/org/codelibs/core/convert/ByteConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/ByteConversionUtil.java
@@ -21,31 +21,31 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.text.DecimalFormatUtil;
 
 /**
- * {@link Byte}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link Byte}.
  *
  * @author higa
  */
 public abstract class ByteConversionUtil {
 
     /**
-     * {@link Byte}に変換します。
+     * Converts to {@link Byte}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link Byte}
+     *            The object to convert
+     * @return The converted {@link Byte}
      */
     public static Byte toByte(final Object o) {
         return toByte(o, null);
     }
 
     /**
-     * {@link Byte}に変換します。
+     * Converts to {@link Byte}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Byte}
+     *            The pattern string
+     * @return The converted {@link Byte}
      */
     public static Byte toByte(final Object o, final String pattern) {
         if (o == null) {
@@ -76,24 +76,24 @@ public abstract class ByteConversionUtil {
     }
 
     /**
-     * {@literal byte}に変換します。
+     * Converts to {@literal byte}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@literal byte}
+     *            The object to convert
+     * @return The converted {@literal byte}
      */
     public static byte toPrimitiveByte(final Object o) {
         return toPrimitiveByte(o, null);
     }
 
     /**
-     * {@literal byte}に変換します。
+     * Converts to {@literal byte}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal byte}
+     *            The pattern string
+     * @return The converted {@literal byte}
      */
     public static byte toPrimitiveByte(final Object o, final String pattern) {
         if (o == null) {

--- a/src/main/java/org/codelibs/core/convert/CalendarConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/CalendarConversionUtil.java
@@ -22,31 +22,31 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 /**
- * {@link Calendar}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link Calendar}.
  *
  * @author higa
  */
 public abstract class CalendarConversionUtil {
 
     /**
-     * {@link Calendar}に変換します。
+     * Converts to {@link Calendar}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link Calendar}
+     *            The object to convert
+     * @return The converted {@link Calendar}
      */
     public static Calendar toCalendar(final Object o) {
         return toCalendar(o, null);
     }
 
     /**
-     * {@link Calendar}に変換します。
+     * Converts to {@link Calendar}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Calendar}
+     *            The pattern string
+     * @return The converted {@link Calendar}
      */
     public static Calendar toCalendar(final Object o, final String pattern) {
         if (o instanceof Calendar) {
@@ -62,11 +62,11 @@ public abstract class CalendarConversionUtil {
     }
 
     /**
-     * ローカルの{@link TimeZone}と{@link Locale}をもつ{@link Calendar}に変換します。
+     * Converts to a {@link Calendar} with the local {@link TimeZone} and {@link Locale}.
      *
      * @param calendar
      *            {@link Calendar}
-     * @return 変換された{@link Calendar}
+     * @return The converted {@link Calendar}
      */
     public static Calendar localize(final Calendar calendar) {
         assertArgumentNotNull("calendar", calendar);

--- a/src/main/java/org/codelibs/core/convert/DateConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/DateConversionUtil.java
@@ -39,64 +39,61 @@ import org.codelibs.core.exception.ParseRuntimeException;
 import org.codelibs.core.misc.LocaleUtil;
 
 /**
- * 日付だけを表現するオブジェクトから{@link Date}、{@link Calendar}、{@link java.sql.Date}
- * への変換ユーティリティです。
+ * Utility for converting objects that represent only dates to {@link Date}, {@link Calendar}, or {@link java.sql.Date}.
  * <p>
- * 時刻だけを表現するオブジェクトを変換する場合は {@link TimeConversionUtil}を、 日付と時刻を表現するオブジェクトを変換する場合は
- * {@link TimestampConversionUtil}を 参照してください。
+ * For objects that represent only time, see {@link TimeConversionUtil}. For objects that represent both date and time, see {@link TimestampConversionUtil}.
  * </p>
  * <p>
- * 変換元のオブジェクトが{@link Date}、{@link Calendar}、{@link java.sql.Date}の場合は、
- * それらの持つミリ秒単位の値を使って変換後のオブジェクトを作成します。
- * その他の型の場合は変換元オブジェクトの文字列表現から変換後のオブジェクトを作成します。
+ * If the source object is a {@link Date}, {@link Calendar}, or {@link java.sql.Date}, the converted object is created using the millisecond value of the source.
+ * For other types, the converted object is created from the string representation of the source object.
  * </p>
  * <p>
- * パターンを指定されなかった場合、変換に使用するパターンはロケールに依存して次のようになります。
+ * If no pattern is specified, the pattern used for conversion depends on the locale as follows:
  * </p>
  * <table border="1">
  * <caption>Conversion Patterns</caption>
  * <tr>
- * <th>カテゴリ</th>
- * <th>パターン</th>
- * <th>{@link Locale#JAPANESE}の例</th>
+ * <th>Category</th>
+ * <th>Pattern</th>
+ * <th>Example for {@link Locale#JAPANESE}</th>
  * </tr>
  * <tr>
- * <td rowspan="4">{@link DateFormat}の標準形式</td>
- * <td>{@link DateFormat#SHORT}の形式</td>
+ * <td rowspan="4">Standard formats of {@link DateFormat}</td>
+ * <td>{@link DateFormat#SHORT} format</td>
  * <td>{@literal yy/MM/dd}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#MEDIUM}の形式</td>
+ * <td>{@link DateFormat#MEDIUM} format</td>
  * <td>{@literal yyyy/MM/dd}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#LONG}の形式</td>
+ * <td>{@link DateFormat#LONG} format</td>
  * <td>{@literal yyyy/MM/dd}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#FULL}の形式</td>
- * <td>{@literal yyyy'年'M'月'd'日'}</td>
+ * <td>{@link DateFormat#FULL} format</td>
+ * <td>{@literal yyyy'nen'M'gatsu'd'nichi'}</td>
  * </tr>
  * <tr>
- * <td rowspan="4">プレーン形式</td>
- * <td>{@link DateFormat#SHORT}の区切り文字を除去した形式</td>
+ * <td rowspan="4">Plain formats</td>
+ * <td>{@link DateFormat#SHORT} format without delimiters</td>
  * <td>{@literal yyMMdd}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#MEDIUM}の区切り文字を除去した形式</td>
+ * <td>{@link DateFormat#MEDIUM} format without delimiters</td>
  * <td>{@literal yyyyMMdd}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#LONG}の区切り文字を除去した形式</td>
+ * <td>{@link DateFormat#LONG} format without delimiters</td>
  * <td>{@literal yyyyMMdd}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#FULL}の区切り文字を除去した形式</td>
+ * <td>{@link DateFormat#FULL} format without delimiters</td>
  * <td>{@literal yyyyMMdd}</td>
  * </tr>
  * <tr>
- * <td>その他</td>
- * <td>{@link java.sql.Date#valueOf(String) Jdbcエスケープ構文}形式</td>
+ * <td>Other</td>
+ * <td>{@link java.sql.Date#valueOf(String) Jdbc escape syntax} format</td>
  * <td>{@literal yyyy-MM-dd}</td>
  * </tr>
  * </table>
@@ -107,24 +104,23 @@ import org.codelibs.core.misc.LocaleUtil;
  */
 public abstract class DateConversionUtil {
 
-    /** {@link DateFormat}が持つスタイルの配列 */
+    /** Array of styles held by {@link DateFormat}. */
     protected static final int[] STYLES = new int[] { SHORT, MEDIUM, LONG, FULL };
 
     /**
-     * デフォルロケールで{@link DateFormat#SHORT}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#SHORT} style in the default locale.
      *
-     * @return {@link DateFormat#SHORT}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#SHORT} style
      */
     public static String getShortPattern() {
         return getShortPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#SHORT}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#SHORT} style in the specified locale.
      *
-     * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#SHORT}スタイルのパターン文字列
+     * @param locale the locale (must not be {@literal null})
+     * @return the pattern string for {@link DateFormat#SHORT} style
      */
     public static String getShortPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -132,20 +128,19 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#MEDIUM}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#MEDIUM} style in the default locale.
      *
-     * @return {@link DateFormat#MEDIUM}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#MEDIUM} style
      */
     public static String getMediumPattern() {
         return getMediumPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#MEDIUM}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#MEDIUM} style in the specified locale.
      *
-     * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#MEDIUM}スタイルのパターン文字列
+     * @param locale the locale (must not be {@literal null})
+     * @return the pattern string for {@link DateFormat#MEDIUM} style
      */
     public static String getMediumPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -153,20 +148,19 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#LONG}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#LONG} style in the default locale.
      *
-     * @return {@link DateFormat#LONG}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#LONG} style
      */
     public static String getLongPattern() {
         return getLongPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#LONG}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#LONG} style in the specified locale.
      *
-     * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#LONG}スタイルのパターン文字列
+     * @param locale the locale (must not be {@literal null})
+     * @return the pattern string for {@link DateFormat#LONG} style
      */
     public static String getLongPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -174,20 +168,19 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#FULL}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#FULL} style in the default locale.
      *
-     * @return {@link DateFormat#FULL}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#FULL} style
      */
     public static String getFullPattern() {
         return getFullPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#FULL}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#FULL} style in the specified locale.
      *
-     * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#FULL}スタイルのパターン文字列
+     * @param locale the locale (must not be {@literal null})
+     * @return the pattern string for {@link DateFormat#FULL} style
      */
     public static String getFullPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -195,37 +188,32 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts an object to {@link Date}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link Date}
+     * @param src the source object
+     * @return the converted {@link Date}
      */
     public static Date toDate(final Object src) {
         return toDate(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts an object to {@link Date}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Date}
+     * @param src the source object
+     * @param pattern the pattern string
+     * @return the converted {@link Date}
      */
     public static Date toDate(final Object src, final String pattern) {
         return toDate(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts an object to {@link Date}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link Date}
+     * @param src the source object
+     * @param locale the locale (must not be {@literal null})
+     * @return the converted {@link Date}
      */
     public static Date toDate(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -233,15 +221,12 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts an object to {@link Date}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param pattern
-     *            パターン文字列
-     * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     * @param src the source object
+     * @param pattern the pattern string
+     * @param locale the locale
+     * @return the converted {@link Date}
      */
     protected static Date toDate(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -279,37 +264,32 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts an object to {@link Calendar}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link Date}
+     * @param src the source object
+     * @return the converted {@link Date}
      */
     public static Calendar toCalendar(final Object src) {
         return toCalendar(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts an object to {@link Calendar}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Date}
+     * @param src the source object
+     * @param pattern the pattern string
+     * @return the converted {@link Date}
      */
     public static Calendar toCalendar(final Object src, final String pattern) {
         return toCalendar(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts an object to {@link Calendar}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link Date}
+     * @param src the source object
+     * @param locale the locale (must not be {@literal null})
+     * @return the converted {@link Date}
      */
     public static Calendar toCalendar(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -317,15 +297,12 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts an object to {@link Calendar}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param pattern
-     *            パターン文字列
-     * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     * @param src the source object
+     * @param pattern the pattern string
+     * @param locale the locale
+     * @return the converted {@link Date}
      */
     protected static Calendar toCalendar(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -360,37 +337,32 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link java.sql.Date}に変換します。
+     * Converts an object to {@link java.sql.Date}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link java.sql.Date}
+     * @param src the source object
+     * @return the converted {@link java.sql.Date}
      */
     public static java.sql.Date toSqlDate(final Object src) {
         return toSqlDate(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link java.sql.Date}に変換します。
+     * Converts an object to {@link java.sql.Date}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link java.sql.Date}
+     * @param src the source object
+     * @param pattern the pattern string
+     * @return the converted {@link java.sql.Date}
      */
     public static java.sql.Date toSqlDate(final Object src, final String pattern) {
         return toSqlDate(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link java.sql.Date}に変換します。
+     * Converts an object to {@link java.sql.Date}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link java.sql.Date}
+     * @param src the source object
+     * @param locale the locale (must not be {@literal null})
+     * @return the converted {@link java.sql.Date}
      */
     public static java.sql.Date toSqlDate(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -398,15 +370,12 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link java.sql.Date}に変換します。
+     * Converts an object to {@link java.sql.Date}.
      *
-     * @param src
-     *            変換元のオブジェクト
-     * @param pattern
-     *            パターン文字列
-     * @param locale
-     *            ロケール
-     * @return 変換された{@link java.sql.Date}
+     * @param src the source object
+     * @param pattern the pattern string
+     * @param locale the locale
+     * @return the converted {@link java.sql.Date}
      */
     protected static java.sql.Date toSqlDate(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -444,13 +413,11 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * 文字列を{@link Date}に変換します。
+     * Converts a string to a {@link Date}.
      *
-     * @param str
-     *            文字列
-     * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     * @param str the string
+     * @param locale the locale
+     * @return the converted {@link Date}
      */
     @SuppressWarnings("unchecked")
     protected static Date toDate(final String str, final Locale locale) {
@@ -467,13 +434,11 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * 文字列を{@link Date}に変換します。
+     * Converts a string to a {@link Date}.
      *
-     * @param str
-     *            文字列
-     * @param format
-     *            {@link DateFormat}
-     * @return 変換された{@link Date}
+     * @param str the string
+     * @param format the {@link DateFormat}
+     * @return the converted {@link Date}
      */
     protected static Date toDate(final String str, final DateFormat format) {
         final ParsePosition pos = new ParsePosition(0);
@@ -492,13 +457,11 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * {@link Date}を{@link Calendar}に変換します。
+     * Converts a {@link Date} to a {@link Calendar}.
      *
-     * @param date
-     *            {@link Date}
-     * @param locale
-     *            ロケール
-     * @return 変換された{@link Calendar}
+     * @param date the {@link Date}
+     * @param locale the locale
+     * @return the converted {@link Calendar}
      */
     protected static Calendar toCalendar(final Date date, final Locale locale) {
         final Calendar calendar;
@@ -512,11 +475,10 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * 文字列を{@link java.sql.Date}に変換します。
+     * Converts a string to a {@link java.sql.Date}.
      *
-     * @param str
-     *            文字列
-     * @return 変換された{@link java.sql.Date}
+     * @param str the string
+     * @return the converted {@link java.sql.Date}
      */
     protected static java.sql.Date toSqlDateJdbcEscape(final String str) {
         try {
@@ -527,11 +489,10 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * パターン文字列を区切り文字を含まないプレーンなパターン文字列に変換して返します。
+     * Converts a pattern string to a plain pattern string without delimiters.
      *
-     * @param pattern
-     *            パターン文字列
-     * @return 区切り文字を含まないプレーンなパターン文字列
+     * @param pattern the pattern string
+     * @return the plain pattern string without delimiters
      */
     protected static String toPlainPattern(final String pattern) {
         final StringBuilder buf = new StringBuilder(pattern.length());
@@ -563,23 +524,22 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * ロケールが持つスタイルに対応する{@link DateFormat}を反復する{@link Iterator}です。
+     * {@link Iterator} that iterates over {@link DateFormat}s corresponding to the styles held by the locale.
      *
      * @author koichik
      */
     protected static class DateFormatIterator implements Iterator<DateFormat> {
 
-        /** ロケール */
+        /** The locale. */
         protected final Locale locale;
 
-        /** 現在のスタイルを示すインデックス */
+        /** The index indicating the current style. */
         protected int index;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
-         * @param locale
-         *            ロケール
+         * @param locale the locale
          */
         public DateFormatIterator(final Locale locale) {
             this.locale = locale;
@@ -607,28 +567,26 @@ public abstract class DateConversionUtil {
     }
 
     /**
-     * ロケールが持つスタイルに対応する{@link DateFormat}を反復する{@link Iterator}です。
+     * {@link Iterator} that iterates over {@link DateFormat}s corresponding to the styles held by the locale.
      *
      * @author koichik
      */
     protected static class PlainDateFormatIterator implements Iterator<DateFormat> {
 
-        /** 変換元の文字列 */
+        /** The source string to convert. */
         protected final String src;
 
-        /** ロケール */
+        /** The locale. */
         protected final Locale locale;
 
-        /** 現在のスタイルを示すインデックス */
+        /** The index indicating the current style. */
         protected int index;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
-         * @param src
-         *            変換後の文字列
-         * @param locale
-         *            ロケール
+         * @param src the string after conversion
+         * @param locale the locale
          */
         public PlainDateFormatIterator(final String src, final Locale locale) {
             this.src = src;

--- a/src/main/java/org/codelibs/core/convert/DoubleConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/DoubleConversionUtil.java
@@ -21,31 +21,31 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.text.DecimalFormatUtil;
 
 /**
- * {@link Double}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link Double}.
  *
  * @author higa
  */
 public abstract class DoubleConversionUtil {
 
     /**
-     * {@link Double}に変換します。
+     * Converts to {@link Double}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link Double}
+     *            The object to convert
+     * @return The converted {@link Double}
      */
     public static Double toDouble(final Object o) {
         return toDouble(o, null);
     }
 
     /**
-     * {@link Double}に変換します。
+     * Converts to {@link Double}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Double}
+     *            The pattern string
+     * @return The converted {@link Double}
      */
     public static Double toDouble(final Object o, final String pattern) {
         if (o == null) {
@@ -74,24 +74,24 @@ public abstract class DoubleConversionUtil {
     }
 
     /**
-     * {@literal double}に変換します。
+     * Converts to {@literal double}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@literal double}
+     *            The object to convert
+     * @return The converted {@literal double}
      */
     public static double toPrimitiveDouble(final Object o) {
         return toPrimitiveDouble(o, null);
     }
 
     /**
-     * {@literal double}に変換します。
+     * Converts to {@literal double}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal double}
+     *            The pattern string
+     * @return The converted {@literal double}
      */
     public static double toPrimitiveDouble(final Object o, final String pattern) {
         if (o == null) {

--- a/src/main/java/org/codelibs/core/convert/FloatConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/FloatConversionUtil.java
@@ -21,31 +21,31 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.text.DecimalFormatUtil;
 
 /**
- * {@link Float}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link Float}.
  *
  * @author higa
  */
 public abstract class FloatConversionUtil {
 
     /**
-     * {@link Float}に変換します。
+     * Converts to {@link Float}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link Float}
+     *            The object to convert
+     * @return The converted {@link Float}
      */
     public static Float toFloat(final Object o) {
         return toFloat(o, null);
     }
 
     /**
-     * {@link Float}に変換します。
+     * Converts to {@link Float}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Float}
+     *            The pattern string
+     * @return The converted {@link Float}
      */
     public static Float toFloat(final Object o, final String pattern) {
         if (o == null) {
@@ -74,24 +74,24 @@ public abstract class FloatConversionUtil {
     }
 
     /**
-     * {@literal float}に変換します。
+     * Converts to {@literal float}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@literal float}
+     *            The object to convert
+     * @return The converted {@literal float}
      */
     public static float toPrimitiveFloat(final Object o) {
         return toPrimitiveFloat(o, null);
     }
 
     /**
-     * {@literal float}に変換します。
+     * Converts to {@literal float}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal float}
+     *            The pattern string
+     * @return The converted {@literal float}
      */
     public static float toPrimitiveFloat(final Object o, final String pattern) {
         if (o == null) {

--- a/src/main/java/org/codelibs/core/convert/IntegerConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/IntegerConversionUtil.java
@@ -21,31 +21,31 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.text.DecimalFormatUtil;
 
 /**
- * {@link Integer}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link Integer}.
  *
  * @author higa
  */
 public abstract class IntegerConversionUtil {
 
     /**
-     * {@link Integer}に変換します。
+     * Converts to {@link Integer}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link Integer}
+     *            The object to convert
+     * @return The converted {@link Integer}
      */
     public static Integer toInteger(final Object o) {
         return toInteger(o, null);
     }
 
     /**
-     * {@link Integer}に変換します。
+     * Converts to {@link Integer}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Integer}
+     *            The pattern string
+     * @return The converted {@link Integer}
      */
     public static Integer toInteger(final Object o, final String pattern) {
         if (o == null) {
@@ -76,24 +76,24 @@ public abstract class IntegerConversionUtil {
     }
 
     /**
-     * {@literal int}に変換します。
+     * Converts to {@literal int}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@literal int}
+     *            The object to convert
+     * @return The converted {@literal int}
      */
     public static int toPrimitiveInt(final Object o) {
         return toPrimitiveInt(o, null);
     }
 
     /**
-     * {@literal int}に変換します。
+     * Converts to {@literal int}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal int}
+     *            The pattern string
+     * @return The converted {@literal int}
      */
     public static int toPrimitiveInt(final Object o, final String pattern) {
         if (o == null) {

--- a/src/main/java/org/codelibs/core/convert/LongConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/LongConversionUtil.java
@@ -21,31 +21,31 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.text.DecimalFormatUtil;
 
 /**
- * {@link Long}用の変換ユーティリティです。
+ * Utility class for conversions to {@link Long}.
  *
  * @author higa
  */
 public abstract class LongConversionUtil {
 
     /**
-     * {@link Long}に変換します。
+     * Converts the given object to a {@link Long}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link Long}
+     *            the object to convert
+     * @return the converted {@link Long}
      */
     public static Long toLong(final Object o) {
         return toLong(o, null);
     }
 
     /**
-     * {@link Long}に変換します。
+     * Converts the given object to a {@link Long}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            the object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Long}
+     *            the pattern string
+     * @return the converted {@link Long}
      */
     public static Long toLong(final Object o, final String pattern) {
         if (o == null) {
@@ -76,24 +76,24 @@ public abstract class LongConversionUtil {
     }
 
     /**
-     * 変換された{@literal long}に変換します。
+     * Converts the given object to a {@literal long}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@literal long}
+     *            the object to convert
+     * @return the converted {@literal long}
      */
     public static long toPrimitiveLong(final Object o) {
         return toPrimitiveLong(o, null);
     }
 
     /**
-     * {@literal long}に変換します。
+     * Converts the given object to a {@literal long}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            the object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal long}
+     *            the pattern string
+     * @return the converted {@literal long}
      */
     public static long toPrimitiveLong(final Object o, final String pattern) {
         if (o == null) {

--- a/src/main/java/org/codelibs/core/convert/NumberConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/NumberConversionUtil.java
@@ -24,20 +24,20 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.text.DecimalFormatSymbolsUtil;
 
 /**
- * {@link Number}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link Number}.
  *
  * @author higa
  */
 public abstract class NumberConversionUtil {
 
     /**
-     * 適切な {@link Number}に変換します。
+     * Converts to the appropriate {@link Number}.
      *
      * @param type
-     *            変換先の型
+     *            Target type
      * @param o
-     *            変換元のオブジェクト
-     * @return {@literal type}に変換された{@link Number}
+     *            Source object
+     * @return {@link Number} converted to {@literal type}
      */
     public static Object convertNumber(final Class<?> type, final Object o) {
         if (type == Integer.class) {
@@ -61,13 +61,13 @@ public abstract class NumberConversionUtil {
     }
 
     /**
-     * 指定されたプリミティブ型に対応するラッパー型に変換して返します。
+     * Converts to the wrapper type corresponding to the specified primitive type.
      *
      * @param type
-     *            プリミティブ型
+     *            Primitive type
      * @param o
-     *            変換元のオブジェクト
-     * @return 指定されたプリミティブ型に対応するラッパー型に変換されたオブジェクト
+     *            Source object
+     * @return Object converted to the wrapper type corresponding to the specified primitive type
      */
     public static Object convertPrimitiveWrapper(final Class<?> type, final Object o) {
         if (type == int.class) {
@@ -117,13 +117,13 @@ public abstract class NumberConversionUtil {
     }
 
     /**
-     * デリミタを削除します。
+     * Removes delimiters.
      *
      * @param value
-     *            文字列の値
+     *            String value
      * @param locale
-     *            ロケール
-     * @return デリミタを削除した結果の文字列
+     *            Locale
+     * @return String result with delimiters removed
      */
     public static String removeDelimeter(String value, final Locale locale) {
         final String groupingSeparator = findGroupingSeparator(locale);
@@ -134,11 +134,11 @@ public abstract class NumberConversionUtil {
     }
 
     /**
-     * グルーピング用のセパレータを探します。
+     * Finds the separator for grouping.
      *
      * @param locale
-     *            ロケール
-     * @return グルーピング用のセパレータ
+     *            Locale
+     * @return Separator for grouping
      */
     public static String findGroupingSeparator(final Locale locale) {
         final DecimalFormatSymbols symbol = getDecimalFormatSymbols(locale);
@@ -146,11 +146,11 @@ public abstract class NumberConversionUtil {
     }
 
     /**
-     * 数値のセパレータを返します。
+     * Returns the separator for decimal numbers.
      *
      * @param locale
-     *            ロケール
-     * @return 数値のセパレータ
+     *            Locale
+     * @return Separator for decimal numbers
      */
     public static String findDecimalSeparator(final Locale locale) {
         final DecimalFormatSymbols symbol = getDecimalFormatSymbols(locale);

--- a/src/main/java/org/codelibs/core/convert/ShortConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/ShortConversionUtil.java
@@ -21,31 +21,31 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.text.DecimalFormatUtil;
 
 /**
- * {@link Short}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link Short}.
  *
  * @author higa
  */
 public abstract class ShortConversionUtil {
 
     /**
-     * {@link Short}に変換します。
+     * Converts to {@link Short}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@link Short}
+     *            The object to convert
+     * @return The converted {@link Short}
      */
     public static Short toShort(final Object o) {
         return toShort(o, null);
     }
 
     /**
-     * {@link Short}に変換します。
+     * Converts to {@link Short}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Short}
+     *            The pattern string
+     * @return The converted {@link Short}
      */
     public static Short toShort(final Object o, final String pattern) {
         if (o == null) {
@@ -76,24 +76,24 @@ public abstract class ShortConversionUtil {
     }
 
     /**
-     * {@literal short}に変換します。
+     * Converts to {@literal short}.
      *
      * @param o
-     *            変換元のオブジェクト
-     * @return 変換された{@literal short}
+     *            The object to convert
+     * @return The converted {@literal short}
      */
     public static short toPrimitiveShort(final Object o) {
         return toPrimitiveShort(o, null);
     }
 
     /**
-     * {@literal short}に変換します。
+     * Converts to {@literal short}.
      *
      * @param o
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal short}
+     *            The pattern string
+     * @return The converted {@literal short}
      */
     public static short toPrimitiveShort(final Object o, final String pattern) {
         if (o == null) {

--- a/src/main/java/org/codelibs/core/convert/StringConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/StringConversionUtil.java
@@ -23,7 +23,7 @@ import java.text.SimpleDateFormat;
 import org.codelibs.core.misc.Base64Util;
 
 /**
- * {@link String}用の変換ユーティリティです。
+ * Utility class for conversions related to {@link String}.
  *
  * @author higa
  */
@@ -66,24 +66,24 @@ public abstract class StringConversionUtil {
     public static final char FULLWIDTH_NOT_SIGN = '\uFFE2';
 
     /**
-     * 文字列に変換します。
+     * Converts the given object to a string.
      *
      * @param value
-     *            変換元のオブジェクト
-     * @return 変換された{@literal String}
+     *            The object to convert
+     * @return The converted {@literal String}
      */
     public static String toString(final Object value) {
         return toString(value, null);
     }
 
     /**
-     * 文字列に変換します。
+     * Converts the given object to a string.
      *
      * @param value
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal String}
+     *            The pattern string
+     * @return The converted {@literal String}
      */
     public static String toString(final Object value, final String pattern) {
         if (value == null) {
@@ -102,13 +102,13 @@ public abstract class StringConversionUtil {
     }
 
     /**
-     * 文字列に変換します。
+     * Converts the given object to a string.
      *
      * @param value
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal String}
+     *            The pattern string
+     * @return The converted {@literal String}
      */
     public static String toString(final Number value, final String pattern) {
         if (value != null) {
@@ -121,13 +121,13 @@ public abstract class StringConversionUtil {
     }
 
     /**
-     * 文字列に変換します。
+     * Converts the given object to a string.
      *
      * @param value
-     *            変換元のオブジェクト
+     *            The object to convert
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@literal String}
+     *            The pattern string
+     * @return The converted {@literal String}
      */
     public static String toString(final java.util.Date value, final String pattern) {
         if (value != null) {
@@ -140,11 +140,11 @@ public abstract class StringConversionUtil {
     }
 
     /**
-     * Windows固有のマッピングルールで作成された文字列を修正します。
+     * Fixes a string created with Windows-specific mapping rules.
      *
      * @param source
-     *            Windows固有のマッピングルールで作成された文字列
-     * @return 修正された文字列
+     *            String created with Windows-specific mapping rules
+     * @return The fixed string
      */
     public static String fromWindowsMapping(final String source) {
         if (isEmpty(source)) {
@@ -179,11 +179,11 @@ public abstract class StringConversionUtil {
     }
 
     /**
-     * 文字列をWindows固有のマッピングルールに合わせて修正します。
+     * Fixes a string to match Windows-specific mapping rules.
      *
      * @param source
-     *            文字列
-     * @return Windows固有のマッピングルールに修正された文字列
+     *            The string
+     * @return The string fixed to match Windows-specific mapping rules
      */
     public static String toWindowsMapping(final String source) {
         if (isEmpty(source)) {

--- a/src/main/java/org/codelibs/core/convert/TimeConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/TimeConversionUtil.java
@@ -40,63 +40,63 @@ import org.codelibs.core.exception.ParseRuntimeException;
 import org.codelibs.core.misc.LocaleUtil;
 
 /**
- * 時刻を表現するオブジェクトから{@link Date}、{@link Calendar}、{@link Time} への変換ユーティリティです。
+ * Utility for converting time-representing objects to {@link Date}, {@link Calendar}, or {@link Time}.
  * <p>
- * 日付だけを表現するオブジェクトを変換する場合は {@link DateConversionUtil}を、 日付と時刻を表現するオブジェクトを変換する場合は
- * {@link TimestampConversionUtil}を 参照してください。
+ * For objects representing only dates, see {@link DateConversionUtil}. For objects representing both date and time,
+ * refer to {@link TimestampConversionUtil}.
  * </p>
  * <p>
- * 変換元のオブジェクトが{@link Date}、{@link Calendar}、{@link Time}の場合は、
- * それらの持つミリ秒単位の値を使って変換後のオブジェクトを作成します。
- * その他の型の場合は変換元オブジェクトの文字列表現から変換後のオブジェクトを作成します。
+ * If the source object is an instance of {@link Date}, {@link Calendar}, or {@link Time},
+ * the conversion uses their millisecond value to create the target object.
+ * For other types, the conversion uses the string representation of the source object.
  * </p>
  * <p>
- * パターンを指定されなかった場合、変換に使用するパターンはロケールに依存して次のようになります。
+ * If no pattern is specified, the pattern used for conversion depends on the locale as follows:
  * </p>
  * <table border="1">
  * <caption>Conversion Patterns</caption>
  * <tr>
- * <th>カテゴリ</th>
- * <th>パターン</th>
- * <th>{@link Locale#JAPANESE}の例</th>
+ * <th>Category</th>
+ * <th>Pattern</th>
+ * <th>Example for {@link Locale#JAPANESE}</th>
  * </tr>
  * <tr>
- * <td rowspan="4">{@link DateFormat}の標準形式</td>
- * <td>{@link DateFormat#SHORT}の形式</td>
+ * <td rowspan="4">Standard {@link DateFormat} formats</td>
+ * <td>{@link DateFormat#SHORT} format</td>
  * <td>{@literal H:mm}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#MEDIUM}の形式</td>
+ * <td>{@link DateFormat#MEDIUM} format</td>
  * <td>{@literal H:mm:ss}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#LONG}の形式</td>
+ * <td>{@link DateFormat#LONG} format</td>
  * <td>{@literal H:mm:ss z}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#FULL}の形式</td>
+ * <td>{@link DateFormat#FULL} format</td>
  * <td>{@literal H'時'mm'分'ss'秒' z}</td>
  * </tr>
  * <tr>
- * <td rowspan="4">プレーン形式</td>
- * <td>{@link DateFormat#SHORT}の区切り文字を除去した形式</td>
+ * <td rowspan="4">Plain formats</td>
+ * <td>{@link DateFormat#SHORT} format without delimiters</td>
  * <td>{@literal HHmm}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#MEDIUM}の区切り文字を除去した形式</td>
+ * <td>{@link DateFormat#MEDIUM} format without delimiters</td>
  * <td>{@literal HHmmss}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#LONG}の区切り文字を除去した形式</td>
+ * <td>{@link DateFormat#LONG} format without delimiters</td>
  * <td>{@literal HHmmss z}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#FULL}の区切り文字を除去した形式</td>
+ * <td>{@link DateFormat#FULL} format without delimiters</td>
  * <td>{@literal HHmmss z}</td>
  * </tr>
  * <tr>
- * <td>その他</td>
- * <td>{@link Time#valueOf(String) Jdbcエスケープ構文}形式</td>
+ * <td>Other</td>
+ * <td>{@link Time#valueOf(String) JDBC escape syntax} format</td>
  * <td>{@literal HH:mm:ss}</td>
  * </tr>
  * </table>
@@ -107,24 +107,24 @@ import org.codelibs.core.misc.LocaleUtil;
  */
 public abstract class TimeConversionUtil {
 
-    /** {@link DateFormat}が持つスタイルの配列 */
+    /** Array of styles held by {@link DateFormat} */
     protected static final int[] STYLES = new int[] { SHORT, MEDIUM, LONG, FULL };
 
     /**
-     * デフォルロケールで{@link DateFormat#SHORT}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#SHORT} style in the default locale.
      *
-     * @return {@link DateFormat#SHORT}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#SHORT} style
      */
     public static String getShortPattern() {
         return getShortPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#SHORT}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#SHORT} style in the specified locale.
      *
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#SHORT}スタイルのパターン文字列
+     *            Locale. Must not be {@literal null}.
+     * @return the pattern string for {@link DateFormat#SHORT} style
      */
     public static String getShortPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -132,20 +132,20 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#MEDIUM}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#MEDIUM} style in the default locale.
      *
-     * @return {@link DateFormat#MEDIUM}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#MEDIUM} style
      */
     public static String getMediumPattern() {
         return getMediumPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#MEDIUM}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#MEDIUM} style in the specified locale.
      *
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#MEDIUM}スタイルのパターン文字列
+     *            Locale. Must not be {@literal null}.
+     * @return the pattern string for {@link DateFormat#MEDIUM} style
      */
     public static String getMediumPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -153,20 +153,20 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#LONG}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#LONG} style in the default locale.
      *
-     * @return {@link DateFormat#LONG}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#LONG} style
      */
     public static String getLongPattern() {
         return getLongPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#LONG}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#LONG} style in the specified locale.
      *
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#LONG}スタイルのパターン文字列
+     *            Locale. Must not be {@literal null}.
+     * @return the pattern string for {@link DateFormat#LONG} style
      */
     public static String getLongPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -174,20 +174,20 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#FULL}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#FULL} style in the default locale.
      *
-     * @return {@link DateFormat#FULL}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#FULL} style
      */
     public static String getFullPattern() {
         return getFullPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#FULL}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#FULL} style in the specified locale.
      *
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#FULL}スタイルのパターン文字列
+     *            Locale. Must not be {@literal null}.
+     * @return the pattern string for {@link DateFormat#FULL} style
      */
     public static String getFullPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -195,37 +195,37 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts the given object to a {@link Date}.
      *
      * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link Date}
+     *            The source object to convert.
+     * @return The converted {@link Date}.
      */
     public static Date toDate(final Object src) {
         return toDate(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts the given object to a {@link Date}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Date}
+     *            The pattern string.
+     * @return The converted {@link Date}.
      */
     public static Date toDate(final Object src, final String pattern) {
         return toDate(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts the given object to a {@link Date}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link Date}
+     *            Locale. Must not be {@literal null}.
+     * @return The converted {@link Date}.
      */
     public static Date toDate(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -233,15 +233,15 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts the given object to a {@link Date}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
+     *            The pattern string.
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     *            Locale.
+     * @return The converted {@link Date}.
      */
     protected static Date toDate(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -279,37 +279,37 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts the given object to a {@link Calendar}.
      *
      * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link Date}
+     *            The source object to convert.
+     * @return The converted {@link Calendar}.
      */
     public static Calendar toCalendar(final Object src) {
         return toCalendar(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts the given object to a {@link Calendar}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Date}
+     *            The pattern string.
+     * @return The converted {@link Calendar}.
      */
     public static Calendar toCalendar(final Object src, final String pattern) {
         return toCalendar(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts the given object to a {@link Calendar}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link Date}
+     *            Locale. Must not be {@literal null}.
+     * @return The converted {@link Calendar}.
      */
     public static Calendar toCalendar(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -317,15 +317,15 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts the given object to a {@link Calendar}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
+     *            The pattern string.
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     *            Locale.
+     * @return The converted {@link Calendar}.
      */
     protected static Calendar toCalendar(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -360,37 +360,37 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Time}に変換します。
+     * Converts the given object to a {@link Time}.
      *
      * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link Time}
+     *            The source object to convert.
+     * @return The converted {@link Time}.
      */
     public static Time toSqlTime(final Object src) {
         return toSqlTime(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Time}に変換します。
+     * Converts the given object to a {@link Time}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Time}
+     *            The pattern string.
+     * @return The converted {@link Time}.
      */
     public static Time toSqlTime(final Object src, final String pattern) {
         return toSqlTime(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Time}に変換します。
+     * Converts the given object to a {@link Time}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link Time}
+     *            Locale. Must not be {@literal null}.
+     * @return The converted {@link Time}.
      */
     public static Time toSqlTime(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -398,15 +398,15 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Time}に変換します。
+     * Converts the given object to a {@link Time}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
+     *            The pattern string.
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Time}
+     *            Locale.
+     * @return The converted {@link Time}.
      */
     protected static Time toSqlTime(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -444,13 +444,13 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * 文字列を{@link Date}に変換します。
+     * Converts a string to a {@link Date}.
      *
      * @param str
-     *            文字列
+     *            The string to convert.
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     *            The locale.
+     * @return The converted {@link Date}.
      */
     @SuppressWarnings("unchecked")
     protected static Date toDate(final String str, final Locale locale) {
@@ -467,13 +467,13 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * 文字列を{@link Date}に変換します。
+     * Converts a string to a {@link Date}.
      *
      * @param str
-     *            文字列
+     *            The string to convert.
      * @param format
      *            {@link DateFormat}
-     * @return 変換された{@link Date}
+     * @return The converted {@link Date}
      */
     protected static Date toDate(final String str, final DateFormat format) {
         final ParsePosition pos = new ParsePosition(0);
@@ -492,13 +492,13 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * {@link Date}を{@link Calendar}に変換します。
+     * Converts a {@link Date} to a {@link Calendar}.
      *
      * @param date
      *            {@link Date}
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Calendar}
+     *            Locale
+     * @return The converted {@link Calendar}
      */
     protected static Calendar toCalendar(final Date date, final Locale locale) {
         final Calendar calendar;
@@ -512,11 +512,11 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * 文字列を{@link Time}に変換します。
+     * Converts a string to a {@link Time}.
      *
      * @param str
-     *            文字列
-     * @return 変換された{@link Time}
+     *            The string to convert.
+     * @return The converted {@link Time}.
      */
     protected static Time toSqlTimeJdbcEscape(final String str) {
         try {
@@ -527,11 +527,11 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * パターン文字列を区切り文字を含まないプレーンなパターン文字列に変換して返します。
+     * Converts a pattern string to a plain pattern string without delimiters.
      *
      * @param pattern
-     *            パターン文字列
-     * @return 区切り文字を含まないプレーンなパターン文字列
+     *            The pattern string.
+     * @return The plain pattern string without delimiters.
      */
     protected static String toPlainPattern(final String pattern) {
         final StringBuilder buf = new StringBuilder(pattern.length());
@@ -563,23 +563,23 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * ロケールが持つスタイルに対応する{@link DateFormat}を反復する{@link Iterator}です。
+     * An {@link Iterator} that iterates over {@link DateFormat} instances corresponding to the styles supported by the locale.
      *
      * @author koichik
      */
     protected static class DateFormatIterator implements Iterator<DateFormat> {
 
-        /** ロケール */
+        /** Locale */
         protected final Locale locale;
 
-        /** 現在のスタイルを示すインデックス */
+        /** Index indicating the current style */
         protected int index;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param locale
-         *            ロケール
+         *            Locale
          */
         public DateFormatIterator(final Locale locale) {
             this.locale = locale;
@@ -607,28 +607,28 @@ public abstract class TimeConversionUtil {
     }
 
     /**
-     * ロケールが持つスタイルに対応する{@link DateFormat}を反復する{@link Iterator}です。
+     * An {@link Iterator} that iterates over {@link DateFormat} instances corresponding to the styles supported by the locale.
      *
      * @author koichik
      */
     protected static class PlainDateFormatIterator implements Iterator<DateFormat> {
 
-        /** 変換元の文字列 */
+        /** Source string to convert */
         protected final String src;
 
-        /** ロケール */
+        /** Locale */
         protected final Locale locale;
 
-        /** 現在のスタイルを示すインデックス */
+        /** Index indicating the current style */
         protected int index;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param src
-         *            変換後の文字列
+         *            The string to convert.
          * @param locale
-         *            ロケール
+         *            Locale.
          */
         public PlainDateFormatIterator(final String src, final Locale locale) {
             this.src = src;

--- a/src/main/java/org/codelibs/core/convert/TimestampConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/TimestampConversionUtil.java
@@ -40,92 +40,67 @@ import org.codelibs.core.exception.ParseRuntimeException;
 import org.codelibs.core.misc.LocaleUtil;
 
 /**
- * 日付と時刻を表現するオブジェクトから{@link Date}、{@link Calendar}、{@link Timestamp}
- * への変換ユーティリティです。
+ * Utility for converting objects representing date and time to {@link Date}, {@link Calendar}, and {@link Timestamp}.
  * <p>
- * 日付だけを表現するオブジェクトを変換する場合は{@link DateConversionUtil}を、 時刻だけを表現するオブジェクトを変換する場合は
- * {@link TimeConversionUtil}を参照してください。
+ * For objects representing only dates, use {@link DateConversionUtil}. For objects representing only time, see {@link TimeConversionUtil}.
  * </p>
  * <p>
- * 変換元のオブジェクトが{@link Date}、{@link Calendar}、{@link Timestamp}の場合は、
- * それらの持つミリ秒単位の値を使って変換後のオブジェクトを作成します。
- * その他の型の場合は変換元オブジェクトの文字列表現から変換後のオブジェクトを作成します。
+ * If the source object is a {@link Date}, {@link Calendar}, or {@link Timestamp}, the converted object is created using their millisecond value.
+ * For other types, the converted object is created from the string representation of the source object.
  * </p>
  * <p>
- * パターンを指定されなかった場合、変換に使用するパターンはロケールに依存して次のようになります。
+ * If no pattern is specified, the pattern used for conversion depends on the locale as follows:
  * </p>
  * <table border="1">
  * <caption>Conversion Patterns</caption>
  * <tr>
- * <th>カテゴリ</th>
- * <th>パターン</th>
- * <th>{@link Locale#JAPANESE}の例</th>
+ * <th>Category</th>
+ * <th>Pattern</th>
+ * <th>Example for {@link Locale#JAPANESE}</th>
  * </tr>
  * <tr>
- * <td rowspan="4">{@link DateFormat}の標準形式</td>
- * <td>{@link DateFormat#SHORT}の形式</td>
+ * <td rowspan="4">Standard formats of {@link DateFormat}</td>
+ * <td>{@link DateFormat#SHORT} format</td>
  * <td>{@literal yy/MM/dd H:mm}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#MEDIUM}の形式</td>
+ * <td>{@link DateFormat#MEDIUM} format</td>
  * <td>{@literal yyyy/MM/dd H:mm:ss}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#LONG}の形式</td>
+ * <td>{@link DateFormat#LONG} format</td>
  * <td>{@literal yyyy/MM/dd H:mm:ss z}</td>
  * </tr>
  * <tr>
- * <td>{@link DateFormat#FULL}の形式</td>
+ * <td>{@link DateFormat#FULL} format</td>
  * <td>{@literal yyyy'年'M'月'd'日' H'時'mm'分'ss'秒' z}</td>
- * </tr>
- * <tr>
- * <td rowspan="4">プレーン形式</td>
- * <td>{@link DateFormat#SHORT}の区切り文字を除去した形式</td>
- * <td>{@literal yyMMdd HHmm}</td>
- * </tr>
- * <tr>
- * <td>{@link DateFormat#MEDIUM}の区切り文字を除去した形式</td>
- * <td>{@literal yyyyMMdd HHmmss}</td>
- * </tr>
- * <tr>
- * <td>{@link DateFormat#LONG}の区切り文字を除去した形式</td>
- * <td>{@literal yyyyMMdd HHmmss z}</td>
- * </tr>
- * <tr>
- * <td>{@link DateFormat#FULL}の区切り文字を除去した形式</td>
- * <td>{@literal yyyyMMdd HHmmss z}</td>
- * </tr>
- * <tr>
- * <td>その他</td>
- * <td>{@link Timestamp#valueOf(String) Jdbcエスケープ構文}形式</td>
- * <td>{@literal yyyy-MM-dd HH:mm:ss[.SSS...]}</td>
  * </tr>
  * </table>
  *
- * @author higa
+ * @author shinsuke
  * @see DateConversionUtil
  * @see TimeConversionUtil
  */
 public abstract class TimestampConversionUtil {
 
-    /** {@link DateFormat}が持つスタイルの配列 */
+    /** Array of styles held by {@link DateFormat} */
     protected static final int[] STYLES = new int[] { SHORT, MEDIUM, LONG, FULL };
 
     /**
-     * デフォルロケールで{@link DateFormat#SHORT}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#SHORT} style using the default locale.
      *
-     * @return {@link DateFormat#SHORT}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#SHORT} style
      */
     public static String getShortPattern() {
         return getShortPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#SHORT}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#SHORT} style using the specified locale.
      *
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#SHORT}スタイルのパターン文字列
+     *            Locale. Must not be {@literal null}.
+     * @return the pattern string for {@link DateFormat#SHORT} style
      */
     public static String getShortPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -133,20 +108,20 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#MEDIUM}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#MEDIUM} style using the default locale.
      *
-     * @return {@link DateFormat#MEDIUM}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#MEDIUM} style
      */
     public static String getMediumPattern() {
         return getMediumPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#MEDIUM}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#MEDIUM} style using the specified locale.
      *
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#MEDIUM}スタイルのパターン文字列
+     *            Locale. Must not be {@literal null}.
+     * @return the pattern string for {@link DateFormat#MEDIUM} style
      */
     public static String getMediumPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -154,40 +129,40 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#LONG}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#LONG} style using the default locale.
      *
-     * @return {@link DateFormat#LONG}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#LONG} style
      */
     public static String getLongPattern() {
         return getLongPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#LONG}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#LONG} style using the specified locale.
      *
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#LONG}スタイルのパターン文字列
+     *            Locale. Must not be {@literal null}.
+     * @return the pattern string for {@link DateFormat#LONG} style
      */
     public static String getLongPattern(final Locale locale) {
         return ((SimpleDateFormat) getDateTimeInstance(LONG, LONG, locale)).toPattern();
     }
 
     /**
-     * デフォルロケールで{@link DateFormat#FULL}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#FULL} style using the default locale.
      *
-     * @return {@link DateFormat#FULL}スタイルのパターン文字列
+     * @return the pattern string for {@link DateFormat#FULL} style
      */
     public static String getFullPattern() {
         return getFullPattern(LocaleUtil.getDefault());
     }
 
     /**
-     * 指定されたロケールで{@link DateFormat#FULL}スタイルのパターン文字列を返します。
+     * Returns the pattern string for {@link DateFormat#FULL} style using the specified locale.
      *
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return {@link DateFormat#FULL}スタイルのパターン文字列
+     *            Locale. Must not be {@literal null}.
+     * @return the pattern string for {@link DateFormat#FULL} style
      */
     public static String getFullPattern(final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -195,37 +170,37 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts the given object to a {@link Date}.
      *
      * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link Date}
+     *            The source object to convert.
+     * @return The converted {@link Date}.
      */
     public static Date toDate(final Object src) {
         return toDate(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts the given object to a {@link Date}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Date}
+     *            The pattern string.
+     * @return The converted {@link Date}.
      */
     public static Date toDate(final Object src, final String pattern) {
         return toDate(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts the given object to a {@link Date}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link Date}
+     *            Locale. Must not be {@literal null}.
+     * @return The converted {@link Date}.
      */
     public static Date toDate(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -233,15 +208,15 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Date}に変換します。
+     * Converts the given object to a {@link Date}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
+     *            The pattern string.
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     *            The locale.
+     * @return The converted {@link Date}.
      */
     protected static Date toDate(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -279,37 +254,37 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts the given object to a {@link Calendar}.
      *
      * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link Date}
+     *            The source object to convert.
+     * @return The converted {@link Calendar}.
      */
     public static Calendar toCalendar(final Object src) {
         return toCalendar(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts the given object to a {@link Calendar}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Date}
+     *            The pattern string.
+     * @return The converted {@link Date}.
      */
     public static Calendar toCalendar(final Object src, final String pattern) {
         return toCalendar(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts the given object to a {@link Calendar}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link Date}
+     *            Locale. Must not be {@literal null}.
+     * @return The converted {@link Calendar}.
      */
     public static Calendar toCalendar(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -317,15 +292,15 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Calendar}に変換します。
+     * Converts the given object to a {@link Calendar}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
+     *            The pattern string.
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     *            The locale.
+     * @return The converted {@link Calendar}.
      */
     protected static Calendar toCalendar(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -360,37 +335,37 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Timestamp}に変換します。
+     * Converts the given object to a {@link Timestamp}.
      *
      * @param src
-     *            変換元のオブジェクト
-     * @return 変換された{@link Timestamp}
+     *            The source object to convert.
+     * @return The converted {@link Timestamp}.
      */
     public static Timestamp toSqlTimestamp(final Object src) {
         return toSqlTimestamp(src, null, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Timestamp}に変換します。
+     * Converts the given object to a {@link Timestamp}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
-     * @return 変換された{@link Timestamp}
+     *            The pattern string.
+     * @return The converted {@link Timestamp}.
      */
     public static Timestamp toSqlTimestamp(final Object src, final String pattern) {
         return toSqlTimestamp(src, pattern, LocaleUtil.getDefault());
     }
 
     /**
-     * オブジェクトを{@link Timestamp}に変換します。
+     * Converts the given object to a {@link Timestamp}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param locale
-     *            ロケール。{@literal null}であってはいけません
-     * @return 変換された{@link Timestamp}
+     *            Locale. Must not be {@literal null}.
+     * @return The converted {@link Timestamp}.
      */
     public static Timestamp toSqlTimestamp(final Object src, final Locale locale) {
         assertArgumentNotNull("locale", locale);
@@ -398,15 +373,15 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * オブジェクトを{@link Timestamp}に変換します。
+     * Converts the given object to a {@link Timestamp}.
      *
      * @param src
-     *            変換元のオブジェクト
+     *            The source object to convert.
      * @param pattern
-     *            パターン文字列
+     *            The pattern string.
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Timestamp}
+     *            The locale.
+     * @return The converted {@link Timestamp}.
      */
     protected static Timestamp toSqlTimestamp(final Object src, final String pattern, final Locale locale) {
         if (src == null) {
@@ -444,13 +419,13 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * 文字列を{@link Date}に変換します。
+     * Converts the string to a {@link Date}.
      *
      * @param str
-     *            文字列
+     *            The string to convert.
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Date}
+     *            The locale.
+     * @return The converted {@link Date}.
      */
     @SuppressWarnings("unchecked")
     protected static Date toDate(final String str, final Locale locale) {
@@ -467,13 +442,13 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * 文字列を{@link Date}に変換します。
+     * Converts a string to a {@link Date}.
      *
      * @param str
-     *            文字列
+     *            The string to convert.
      * @param format
      *            {@link DateFormat}
-     * @return 変換された{@link Date}
+     * @return The converted {@link Date}
      */
     protected static Date toDate(final String str, final DateFormat format) {
         final ParsePosition pos = new ParsePosition(0);
@@ -492,13 +467,13 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * {@link Date}を{@link Calendar}に変換します。
+     * Converts a {@link Date} to a {@link Calendar}.
      *
      * @param date
      *            {@link Date}
      * @param locale
-     *            ロケール
-     * @return 変換された{@link Calendar}
+     *            Locale
+     * @return The converted {@link Calendar}
      */
     protected static Calendar toCalendar(final Date date, final Locale locale) {
         final Calendar calendar;
@@ -512,11 +487,11 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * 文字列を{@link Timestamp}に変換します。
+     * Converts a string to a {@link Timestamp}.
      *
      * @param str
-     *            文字列
-     * @return 変換された{@link Timestamp}
+     *            The string to convert.
+     * @return The converted {@link Timestamp}.
      */
     protected static Timestamp toSqlTimestampJdbcEscape(final String str) {
         try {
@@ -527,11 +502,11 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * パターン文字列を区切り文字を含まないプレーンなパターン文字列に変換して返します。
+     * Converts the pattern string to a plain pattern string without delimiters.
      *
      * @param pattern
-     *            パターン文字列
-     * @return 区切り文字を含まないプレーンなパターン文字列
+     *            The pattern string.
+     * @return The plain pattern string without delimiters.
      */
     protected static String toPlainPattern(final String pattern) {
         final StringBuilder buf = new StringBuilder(pattern.length());
@@ -581,23 +556,23 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * ロケールが持つスタイルに対応する{@link DateFormat}を反復する{@link Iterator}です。
+     * An {@link Iterator} that iterates over {@link DateFormat} instances corresponding to the styles supported by the locale.
      *
      * @author koichik
      */
     protected static class DateFormatIterator implements Iterator<DateFormat> {
 
-        /** ロケール */
+        /** Locale */
         protected final Locale locale;
 
-        /** 現在のスタイルを示すインデックス */
+        /** Index indicating the current style */
         protected int index;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param locale
-         *            ロケール
+         *            Locale
          */
         public DateFormatIterator(final Locale locale) {
             this.locale = locale;
@@ -625,28 +600,28 @@ public abstract class TimestampConversionUtil {
     }
 
     /**
-     * ロケールが持つスタイルに対応する{@link DateFormat}を反復する{@link Iterator}です。
+     * An {@link Iterator} that iterates over {@link DateFormat} instances corresponding to the styles supported by the locale.
      *
      * @author koichik
      */
     protected static class PlainDateFormatIterator implements Iterator<DateFormat> {
 
-        /** 変換元の文字列 */
+        /** Source string to be converted */
         protected final String src;
 
-        /** ロケール */
+        /** Locale */
         protected final Locale locale;
 
-        /** 現在のスタイルを示すインデックス */
+        /** Index indicating the current style */
         protected int index;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param src
-         *            変換後の文字列
+         *            The string to be converted.
          * @param locale
-         *            ロケール
+         *            The locale.
          */
         public PlainDateFormatIterator(final String src, final Locale locale) {
             this.src = src;

--- a/src/main/java/org/codelibs/core/exception/ClIllegalArgumentException.java
+++ b/src/main/java/org/codelibs/core/exception/ClIllegalArgumentException.java
@@ -18,7 +18,7 @@ package org.codelibs.core.exception;
 import org.codelibs.core.message.MessageFormatter;
 
 /**
- * {@link IllegalArgumentException}をラップする例外です。
+ * Exception that wraps {@link IllegalArgumentException}.
  *
  * @author koichik
  */
@@ -26,40 +26,40 @@ public class ClIllegalArgumentException extends IllegalArgumentException {
 
     private static final long serialVersionUID = -3701473506893554853L;
 
-    /** {@code null} である引数の名前 */
+    /** Name of the argument that is {@code null} */
     protected final String argName;
 
-    /** メッセージコード */
+    /** Message code */
     protected final String messageCode;
 
-    /** メッセージの引数 */
+    /** Arguments for the message */
     protected final Object[] args;
 
     /**
-     * {@link ClIllegalArgumentException}を作成します。
+     * Creates a {@link ClIllegalArgumentException}.
      *
      * @param argName
-     *            引数の名前
+     *            Name of the argument
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の配列
+     *            Array of arguments
      */
     public ClIllegalArgumentException(final String argName, final String messageCode, final Object[] args) {
         this(argName, messageCode, args, null);
     }
 
     /**
-     * {@link ClIllegalArgumentException}を作成します。
+     * Creates a {@link ClIllegalArgumentException}.
      *
      * @param argName
-     *            引数の名前
+     *            Name of the argument
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の配列
+     *            Array of arguments
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public ClIllegalArgumentException(final String argName, final String messageCode, final Object[] args, final Throwable cause) {
         super(MessageFormatter.getMessage(messageCode, args), cause);
@@ -69,27 +69,27 @@ public class ClIllegalArgumentException extends IllegalArgumentException {
     }
 
     /**
-     * 引数の名前を返します。
+     * Returns the name of the argument.
      *
-     * @return 引数の名前
+     * @return Name of the argument
      */
     public String getArgName() {
         return argName;
     }
 
     /**
-     * メッセージコードを返します。
+     * Returns the message code.
      *
-     * @return メッセージコード
+     * @return Message code
      */
     public String getMessageCode() {
         return messageCode;
     }
 
     /**
-     * 引数の配列を返します。
+     * Returns the array of arguments.
      *
-     * @return 引数の配列
+     * @return Array of arguments
      */
     public Object[] getArgs() {
         return args;

--- a/src/main/java/org/codelibs/core/exception/ClIllegalStateException.java
+++ b/src/main/java/org/codelibs/core/exception/ClIllegalStateException.java
@@ -16,7 +16,7 @@
 package org.codelibs.core.exception;
 
 /**
- * {@link IllegalStateException}をラップする例外です。
+ * Exception that wraps {@link IllegalStateException}.
  *
  * @author wyukawa
  */
@@ -25,39 +25,39 @@ public class ClIllegalStateException extends IllegalStateException {
     private static final long serialVersionUID = -2154525994315946504L;
 
     /**
-     * {@link ClIllegalStateException}を作成します。
+     * Creates a {@link ClIllegalStateException}.
      */
     public ClIllegalStateException() {
         super();
     }
 
     /**
-     * {@link ClIllegalStateException}を作成します。
+     * Creates a {@link ClIllegalStateException}.
      *
      * @param message
-     *            メッセージ
+     *            Message
      */
     public ClIllegalStateException(final String message) {
         super(message);
     }
 
     /**
-     * {@link ClIllegalStateException}を作成します。
+     * Creates a {@link ClIllegalStateException}.
      *
      * @param message
-     *            メッセージ
+     *            Message
      * @param cause
-     *            元の例外
+     *            The original exception
      */
     public ClIllegalStateException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * {@link ClIllegalStateException}を作成します。
+     * Creates a {@link ClIllegalStateException}.
      *
      * @param cause
-     *            元の例外
+     *            The original exception
      */
     public ClIllegalStateException(final Throwable cause) {
         super(cause);

--- a/src/main/java/org/codelibs/core/exception/ClIndexOutOfBoundsException.java
+++ b/src/main/java/org/codelibs/core/exception/ClIndexOutOfBoundsException.java
@@ -16,7 +16,7 @@
 package org.codelibs.core.exception;
 
 /**
- * {@link IndexOutOfBoundsException}をラップする例外です。
+ * Exception that wraps {@link IndexOutOfBoundsException}.
  *
  * @author wyukawa
  */
@@ -25,17 +25,17 @@ public class ClIndexOutOfBoundsException extends IndexOutOfBoundsException {
     private static final long serialVersionUID = -824874776607593608L;
 
     /**
-     * {@link ClIndexOutOfBoundsException}を作成します。
+     * Creates a {@link ClIndexOutOfBoundsException}.
      */
     public ClIndexOutOfBoundsException() {
         super();
     }
 
     /**
-     * {@link ClIndexOutOfBoundsException}を作成します。
+     * Creates a {@link ClIndexOutOfBoundsException}.
      *
      * @param message
-     *            メッセージ
+     *            Message
      */
     public ClIndexOutOfBoundsException(final String message) {
         super(message);

--- a/src/main/java/org/codelibs/core/exception/ClSQLException.java
+++ b/src/main/java/org/codelibs/core/exception/ClSQLException.java
@@ -20,7 +20,7 @@ import java.sql.SQLException;
 import org.codelibs.core.message.MessageFormatter;
 
 /**
- * S2Util用の{@link SQLException}です。
+ * {@link SQLException} for S2Util.
  *
  * @author higa
  */
@@ -35,90 +35,90 @@ public class ClSQLException extends SQLException {
     private final String sql;
 
     /**
-     * {@link ClSQLException}を作成します。
+     * Creates a {@link ClSQLException}.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の並び
+     *            Array of arguments
      */
     public ClSQLException(final String messageCode, final Object[] args) {
         this(messageCode, args, null, 0, null, null);
     }
 
     /**
-     * {@link ClSQLException}を作成します。
+     * Creates a {@link ClSQLException}.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の並び
+     *            Array of arguments
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public ClSQLException(final String messageCode, final Object[] args, final Throwable cause) {
         this(messageCode, args, null, 0, cause, null);
     }
 
     /**
-     * {@link ClSQLException}を作成します。
+     * Creates a {@link ClSQLException}.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の並び
+     *            Array of arguments
      * @param sqlState
-     *            SQLステート
+     *            SQL state
      */
     public ClSQLException(final String messageCode, final Object[] args, final String sqlState) {
         this(messageCode, args, sqlState, 0, null, null);
     }
 
     /**
-     * {@link ClSQLException}を作成します。
+     * Creates a {@link ClSQLException}.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の並び
+     *            Array of arguments
      * @param sqlState
-     *            SQLステート
+     *            SQL state
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public ClSQLException(final String messageCode, final Object[] args, final String sqlState, final Throwable cause) {
         this(messageCode, args, sqlState, 0, cause, null);
     }
 
     /**
-     * {@link ClSQLException}を作成します。
+     * Creates a {@link ClSQLException}.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の並び
+     *            Array of arguments
      * @param sqlState
-     *            SQLステート
+     *            SQL state
      * @param vendorCode
-     *            ベンダーコード
+     *            Vendor code
      */
     public ClSQLException(final String messageCode, final Object[] args, final String sqlState, final int vendorCode) {
         this(messageCode, args, sqlState, vendorCode, null, null);
     }
 
     /**
-     * {@link ClSQLException}を作成します。
+     * Creates a {@link ClSQLException}.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の並び
+     *            Array of arguments
      * @param sqlState
-     *            SQLステート
+     *            SQL state
      * @param vendorCode
-     *            ベンダーコード
+     *            Vendor code
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public ClSQLException(final String messageCode, final Object[] args, final String sqlState, final int vendorCode,
             final Throwable cause) {
@@ -126,38 +126,38 @@ public class ClSQLException extends SQLException {
     }
 
     /**
-     * {@link ClSQLException}を作成します。
+     * Creates a {@link ClSQLException}.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の並び
+     *            Array of arguments
      * @param sqlState
-     *            SQLステート
+     *            SQL state
      * @param vendorCode
-     *            ベンダーコード
+     *            Vendor code
      * @param sql
-     *            SQL文字列
+     *            SQL string
      */
     public ClSQLException(final String messageCode, final Object[] args, final String sqlState, final int vendorCode, final String sql) {
         this(messageCode, args, sqlState, vendorCode, null, sql);
     }
 
     /**
-     * {@link ClSQLException}を作成します。
+     * Creates a {@link ClSQLException}.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の並び
+     *            Array of arguments
      * @param sqlState
-     *            SQLステート
+     *            SQL state
      * @param vendorCode
-     *            ベンダーコード
+     *            Vendor code
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      * @param sql
-     *            SQL文字列
+     *            SQL string
      */
     public ClSQLException(final String messageCode, final Object[] args, final String sqlState, final int vendorCode, final Throwable cause,
             final String sql) {
@@ -168,25 +168,25 @@ public class ClSQLException extends SQLException {
     }
 
     /**
-     * メッセージコードを返します。
+     * Returns the message code.
      *
-     * @return メッセージコード
+     * @return Message code
      */
     public String getMessageCode() {
         return messageCode;
     }
 
     /**
-     * 引数の配列を返します。
+     * Returns the array of arguments.
      *
-     * @return 引数の配列
+     * @return Array of arguments
      */
     public Object[] getArgs() {
         return args;
     }
 
     /**
-     * SQLを返します。
+     * Returns the SQL.
      *
      * @return SQL
      */

--- a/src/main/java/org/codelibs/core/exception/ClUnsupportedOperationException.java
+++ b/src/main/java/org/codelibs/core/exception/ClUnsupportedOperationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
 package org.codelibs.core.exception;
 
 /**
- * {@link UnsupportedOperationException}をラップする例外です。
+ * Exception that wraps {@link UnsupportedOperationException}.
  *
  * @author wyukawa
  */
@@ -25,38 +25,34 @@ public class ClUnsupportedOperationException extends UnsupportedOperationExcepti
     private static final long serialVersionUID = -6732367317955522602L;
 
     /**
-     * {@link ClUnsupportedOperationException}を作成します。
+     * Creates a {@link ClUnsupportedOperationException}.
      */
     public ClUnsupportedOperationException() {
     }
 
     /**
-     * {@link ClUnsupportedOperationException}を作成します。
+     * Creates a {@link ClUnsupportedOperationException}.
      *
-     * @param message
-     *            メッセージ
+     * @param message the message
      */
     public ClUnsupportedOperationException(final String message) {
         super(message);
     }
 
     /**
-     * {@link ClUnsupportedOperationException}を作成します。
+     * Creates a {@link ClUnsupportedOperationException}.
      *
-     * @param message
-     *            メッセージ
-     * @param cause
-     *            元の例外
+     * @param message the message
+     * @param cause the underlying exception
      */
     public ClUnsupportedOperationException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * {@link ClUnsupportedOperationException}を作成します。
+     * Creates a {@link ClUnsupportedOperationException}.
      *
-     * @param cause
-     *            元の例外
+     * @param cause the underlying exception
      */
     public ClUnsupportedOperationException(final Throwable cause) {
         super(cause);

--- a/src/main/java/org/codelibs/core/exception/ClassNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ClassNotFoundRuntimeException.java
@@ -18,7 +18,7 @@ package org.codelibs.core.exception;
 import static org.codelibs.core.collection.ArrayUtil.asArray;
 
 /**
- * クラスが見つからないときにスローされる例外です。
+ * Exception thrown when a class cannot be found.
  *
  * @author higa
  */
@@ -29,22 +29,19 @@ public class ClassNotFoundRuntimeException extends ClRuntimeException {
     private final String className;
 
     /**
-     * {@link ClassNotFoundRuntimeException}を作成します。
+     * Creates a {@link ClassNotFoundRuntimeException}.
      *
-     * @param cause
-     *            原因となった例外
+     * @param cause the underlying exception
      */
     public ClassNotFoundRuntimeException(final ClassNotFoundException cause) {
         this(null, cause);
     }
 
     /**
-     * {@link ClassNotFoundRuntimeException}を作成します。
+     * Creates a {@link ClassNotFoundRuntimeException}.
      *
-     * @param className
-     *            クラス名
-     * @param cause
-     *            原因となった例外
+     * @param className the class name
+     * @param cause the underlying exception
      */
     public ClassNotFoundRuntimeException(final String className, final ClassNotFoundException cause) {
         super("ECL0044", asArray(cause), cause);
@@ -52,9 +49,9 @@ public class ClassNotFoundRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * クラス名を返します。
+     * Returns the class name.
      *
-     * @return クラス名
+     * @return the class name
      */
     public String getClassName() {
         return className;

--- a/src/main/java/org/codelibs/core/exception/ConstructorNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ConstructorNotFoundRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.lang.reflect.Constructor;
 
 /**
- * {@link Constructor}が見つからなかったときにスローされる例外Vです。
+ * Exception thrown when a {@link Constructor} cannot be found.
  *
  * @author higa
  */
@@ -35,12 +35,12 @@ public class ConstructorNotFoundRuntimeException extends ClRuntimeException {
     private final Class<?>[] paramTypes;
 
     /**
-     * {@link ConstructorNotFoundRuntimeException}を作成します。
+     * Creates a {@link ConstructorNotFoundRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param methodArgs
-     *            引数の並び
+     *            Array of arguments
      */
     public ConstructorNotFoundRuntimeException(final Class<?> targetClass, final Object[] methodArgs) {
         super("ECL0048", asArray(targetClass.getName(), getSignature(methodArgs)));
@@ -50,12 +50,12 @@ public class ConstructorNotFoundRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * {@link ConstructorNotFoundRuntimeException}を作成します。
+     * Creates a {@link ConstructorNotFoundRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param paramTypes
-     *            引数型の並び
+     *            Array of parameter types
      */
     public ConstructorNotFoundRuntimeException(final Class<?> targetClass, final Class<?>[] paramTypes) {
         super("ECL0048", asArray(targetClass.getName(), getSignature(paramTypes)));
@@ -65,27 +65,27 @@ public class ConstructorNotFoundRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * 引数の並びを返します。
+     * Returns the array of arguments.
      *
-     * @return 引数の並び
+     * @return Array of arguments
      */
     public Object[] getMethodArgs() {
         return methodArgs;
     }
 
     /**
-     * 引数型の並びを返します。
+     * Returns the array of parameter types.
      *
-     * @return 引数型の並び
+     * @return Array of parameter types
      */
     public Class<?>[] getParamTypes() {
         return paramTypes;

--- a/src/main/java/org/codelibs/core/exception/ConverterRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ConverterRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import org.codelibs.core.beans.Converter;
 
 /**
- * {@link Converter}でエラーが起きた場合にスローされる例外です。
+ * Exception thrown when an error occurs in a {@link Converter}.
  *
  * @author higa
  */
@@ -33,14 +33,14 @@ public class ConverterRuntimeException extends ClRuntimeException {
     private final Object value;
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
      * @param propertyName
-     *            プロパティ名
+     *            Property name
      * @param value
-     *            値
+     *            Value
      * @param cause
-     *            原因
+     *            Cause
      */
     public ConverterRuntimeException(final String propertyName, final Object value, final Throwable cause) {
         super("ECL0097", asArray(propertyName, value, cause), cause);
@@ -49,18 +49,18 @@ public class ConverterRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * プロパティ名を返します。
+     * Returns the property name.
      *
-     * @return プロパティ名
+     * @return Property name
      */
     public String getPropertyName() {
         return propertyName;
     }
 
     /**
-     * 値を返します。
+     * Returns the value.
      *
-     * @return 値
+     * @return Value
      */
     public Object getValue() {
         return value;

--- a/src/main/java/org/codelibs/core/exception/EmptyArgumentException.java
+++ b/src/main/java/org/codelibs/core/exception/EmptyArgumentException.java
@@ -16,7 +16,7 @@
 package org.codelibs.core.exception;
 
 /**
- * 空の場合にスローされる例外です。
+ * Exception thrown when an argument is empty.
  *
  * @author higa
  */
@@ -25,30 +25,30 @@ public class EmptyArgumentException extends ClIllegalArgumentException {
     private static final long serialVersionUID = 4625805280526951642L;
 
     /**
-     * {@link EmptyArgumentException}を作成します。
+     * Creates an {@link EmptyArgumentException}.
      *
      * @param argName
-     *            引数の名前
+     *            Name of the argument
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の配列
+     *            Array of arguments
      */
     public EmptyArgumentException(final String argName, final String messageCode, final Object[] args) {
         this(argName, messageCode, args, null);
     }
 
     /**
-     * {@link EmptyArgumentException}を作成します。
+     * Creates an {@link EmptyArgumentException}.
      *
      * @param argName
-     *            引数の名前
+     *            Name of the argument
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数の配列
+     *            Array of arguments
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public EmptyArgumentException(final String argName, final String messageCode, final Object[] args, final Throwable cause) {
         super(argName, messageCode, args, cause);

--- a/src/main/java/org/codelibs/core/exception/FieldNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/FieldNotFoundRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.lang.reflect.Field;
 
 /**
- * {@link Field}が見つからない場合にスローされる例外です。
+ * Exception thrown when a {@link Field} cannot be found.
  *
  * @author higa
  *
@@ -34,12 +34,12 @@ public class FieldNotFoundRuntimeException extends ClRuntimeException {
     private final String fieldName;
 
     /**
-     * {@link FieldNotFoundRuntimeException}を作成します。
+     * Creates a {@link FieldNotFoundRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param fieldName
-     *            フィールド名
+     *            Field name
      */
     public FieldNotFoundRuntimeException(final Class<?> targetClass, final String fieldName) {
         super("ECL0070", asArray(targetClass.getName(), fieldName));
@@ -48,18 +48,18 @@ public class FieldNotFoundRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * フィールド名を返します。
+     * Returns the field name.
      *
-     * @return フィールド名
+     * @return Field name
      */
     public String getFieldName() {
         return fieldName;

--- a/src/main/java/org/codelibs/core/exception/FieldNotStaticRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/FieldNotStaticRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.lang.reflect.Field;
 
 /**
- * オブジェクトを指定せずに非{@literal static}な{@link Field}にアクセスした場合にスローされる例外です。
+ * Exception thrown when accessing a non-{@literal static} {@link Field} without specifying an object.
  *
  * @author koichik
  */
@@ -33,12 +33,12 @@ public class FieldNotStaticRuntimeException extends ClRuntimeException {
     private final String fieldName;
 
     /**
-     * {@link FieldNotStaticRuntimeException}を作成します。
+     * Creates a {@link FieldNotStaticRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param fieldName
-     *            フィールド名
+     *            Field name
      */
     public FieldNotStaticRuntimeException(final Class<?> targetClass, final String fieldName) {
         super("ECL0099", asArray(targetClass.getName(), fieldName));
@@ -47,18 +47,18 @@ public class FieldNotStaticRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * フィールド名を返します。
+     * Returns the field name.
      *
-     * @return フィールド名
+     * @return Field name
      */
     public String getFieldName() {
         return fieldName;

--- a/src/main/java/org/codelibs/core/exception/IORuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/IORuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.io.IOException;
 
 /**
- * {@link IOException}をラップする例外です。
+ * Exception that wraps {@link IOException}.
  *
  * @author higa
  */
@@ -29,10 +29,10 @@ public class IORuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = 1533554330702215389L;
 
     /**
-     * {@link IORuntimeException}を作成します。
+     * Creates a {@link IORuntimeException}.
      *
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public IORuntimeException(final IOException cause) {
         super("ECL0040", asArray(cause), cause);

--- a/src/main/java/org/codelibs/core/exception/IllegalAccessRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/IllegalAccessRuntimeException.java
@@ -18,7 +18,7 @@ package org.codelibs.core.exception;
 import static org.codelibs.core.collection.ArrayUtil.asArray;
 
 /**
- * {@link IllegalAccessException}をラップする例外です。
+ * Exception that wraps {@link IllegalAccessException}.
  *
  * @author higa
  */
@@ -29,12 +29,12 @@ public class IllegalAccessRuntimeException extends ClRuntimeException {
     private final Class<?> targetClass;
 
     /**
-     * {@link IllegalAccessRuntimeException}を作成します。
+     * Creates a {@link IllegalAccessRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public IllegalAccessRuntimeException(final Class<?> targetClass, final IllegalAccessException cause) {
         super("ECL0042", asArray(targetClass.getName(), cause), cause);
@@ -42,9 +42,9 @@ public class IllegalAccessRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;

--- a/src/main/java/org/codelibs/core/exception/IllegalKeyOfBeanMapException.java
+++ b/src/main/java/org/codelibs/core/exception/IllegalKeyOfBeanMapException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.util.Map;
 
 /**
- * {@literal BeanMap}に含まれていないキーを使用した場合にスローされる例外です。
+ * Exception thrown when using a key not contained in a {@literal BeanMap}.
  *
  * @author koichik
  */
@@ -29,12 +29,12 @@ public class IllegalKeyOfBeanMapException extends ClIllegalArgumentException {
     private static final long serialVersionUID = 3456740832476626338L;
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
      * @param key
-     *            マップのキー
+     *            Key of the map
      * @param map
-     *            マップ
+     *            Map
      */
     public IllegalKeyOfBeanMapException(final Object key, final Map<?, ?> map) {
         super("key", "ECL0016", asArray(key, map));

--- a/src/main/java/org/codelibs/core/exception/IllegalPropertyRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/IllegalPropertyRuntimeException.java
@@ -18,7 +18,7 @@ package org.codelibs.core.exception;
 import static org.codelibs.core.collection.ArrayUtil.asArray;
 
 /**
- * プロパティの値の設定に失敗したときにスローされる例外です。
+ * Exception thrown when setting a property value fails.
  *
  * @author higa
  *
@@ -32,14 +32,14 @@ public class IllegalPropertyRuntimeException extends ClRuntimeException {
     private final String propertyName;
 
     /**
-     * {@link IllegalPropertyRuntimeException}を作成します。
+     * Creates a {@link IllegalPropertyRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param propertyName
-     *            プロパティ名
+     *            Property name
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public IllegalPropertyRuntimeException(final Class<?> targetClass, final String propertyName, final Throwable cause) {
         super("ECL0059", asArray(targetClass.getName(), propertyName, cause), cause);
@@ -48,18 +48,18 @@ public class IllegalPropertyRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * プロパティ名を返します。
+     * Returns the property name.
      *
-     * @return プロパティ名
+     * @return Property name
      */
     public String getPropertyName() {
         return propertyName;

--- a/src/main/java/org/codelibs/core/exception/InstantiationRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/InstantiationRuntimeException.java
@@ -18,7 +18,7 @@ package org.codelibs.core.exception;
 import static org.codelibs.core.collection.ArrayUtil.asArray;
 
 /**
- * {@link InstantiationException}をラップする例外です。
+ * Exception that wraps {@link InstantiationException}.
  *
  * @author higa
  */
@@ -29,12 +29,12 @@ public class InstantiationRuntimeException extends ClRuntimeException {
     private final Class<?> targetClass;
 
     /**
-     * {@link InstantiationRuntimeException}を作成します。
+     * Creates a {@link InstantiationRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public InstantiationRuntimeException(final Class<?> targetClass, final InstantiationException cause) {
         super("ECL0041", asArray(targetClass.getName(), cause), cause);
@@ -47,9 +47,9 @@ public class InstantiationRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;

--- a/src/main/java/org/codelibs/core/exception/InvalidKeyRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/InvalidKeyRuntimeException.java
@@ -21,7 +21,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * {@link NoSuchAlgorithmException}をラップする例外です。
+ * Exception that wraps {@link NoSuchAlgorithmException}.
  *
  * @author shinsuke
  */
@@ -30,10 +30,10 @@ public class InvalidKeyRuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = -3176447530746274091L;
 
     /**
-     * {@link InvalidKeyRuntimeException}を作成します。
+     * Creates a {@link InvalidKeyRuntimeException}.
      *
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public InvalidKeyRuntimeException(final InvalidKeyException cause) {
         super("ECL0068", asArray(cause), cause);

--- a/src/main/java/org/codelibs/core/exception/InvocationTargetRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/InvocationTargetRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.lang.reflect.InvocationTargetException;
 
 /**
- * {@link InvocationTargetException}をラップする例外です。
+ * Exception that wraps {@link InvocationTargetException}.
  *
  * @author higa
  */
@@ -31,12 +31,12 @@ public class InvocationTargetRuntimeException extends ClRuntimeException {
     private final Class<?> targetClass;
 
     /**
-     * {@link InvocationTargetRuntimeException}を作成します。
+     * Creates a {@link InvocationTargetRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public InvocationTargetRuntimeException(final Class<?> targetClass, final InvocationTargetException cause) {
         super("ECL0043", asArray(targetClass.getName(), cause.getTargetException()), cause.getTargetException());
@@ -44,9 +44,9 @@ public class InvocationTargetRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;

--- a/src/main/java/org/codelibs/core/exception/MethodNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/MethodNotFoundRuntimeException.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Method;
 import org.codelibs.core.lang.MethodUtil;
 
 /**
- * {@link Method}が見つからなかったときにスローされる例外です。
+ * Exception thrown when a {@link Method} cannot be found.
  *
  * @author higa
  *
@@ -38,28 +38,28 @@ public class MethodNotFoundRuntimeException extends ClRuntimeException {
     private final Class<?>[] methodArgClasses;
 
     /**
-     * {@link MethodNotFoundRuntimeException}を作成します。
+     * Creates a {@link MethodNotFoundRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param methodName
-     *            メソッド名
+     *            Method name
      * @param methodArgs
-     *            引数の並び
+     *            Array of arguments
      */
     public MethodNotFoundRuntimeException(final Class<?> targetClass, final String methodName, final Object[] methodArgs) {
         this(targetClass, methodName, toClassArray(methodArgs));
     }
 
     /**
-     * {@link MethodNotFoundRuntimeException}を作成します。
+     * Creates a {@link MethodNotFoundRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param methodName
-     *            メソッド名
+     *            Method name
      * @param methodArgClasses
-     *            引数型の並び
+     *            Array of parameter types
      */
     public MethodNotFoundRuntimeException(final Class<?> targetClass, final String methodName, final Class<?>[] methodArgClasses) {
         super("ECL0049", asArray(targetClass.getName(), MethodUtil.getSignature(methodName, methodArgClasses)));
@@ -69,27 +69,27 @@ public class MethodNotFoundRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットの{@link Class}を返します。
+     * Returns the {@link Class} of the target.
      *
-     * @return ターゲットの{@link Class}
+     * @return {@link Class} of the target
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * メソッド名を返します。
+     * Returns the method name.
      *
-     * @return メソッド名
+     * @return Method name
      */
     public String getMethodName() {
         return methodName;
     }
 
     /**
-     * メソッドの引数の{@link Class}の配列を返します。
+     * Returns the array of {@link Class} for the method arguments.
      *
-     * @return メソッドの引数の{@link Class}の配列
+     * @return Array of {@link Class} for the method arguments
      */
     public Class<?>[] getMethodArgClasses() {
         return methodArgClasses;

--- a/src/main/java/org/codelibs/core/exception/MethodNotStaticRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/MethodNotStaticRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.lang.reflect.Method;
 
 /**
- * オブジェクトを指定せずに非{@literal static}な{@link Method}にアクセスした場合にスローされる例外です。
+ * Exception thrown when accessing a non-{@literal static} {@link Method} without specifying an object.
  *
  * @author koichik
  */
@@ -33,12 +33,12 @@ public class MethodNotStaticRuntimeException extends ClRuntimeException {
     private final String methodName;
 
     /**
-     * {@link MethodNotStaticRuntimeException}を作成します。
+     * Creates a {@link MethodNotStaticRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param methodName
-     *            メソッド名
+     *            Method name
      */
     public MethodNotStaticRuntimeException(final Class<?> targetClass, final String methodName) {
         super("ECL0100", asArray(targetClass.getName(), methodName));
@@ -47,18 +47,18 @@ public class MethodNotStaticRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * メソッド名を返します。
+     * Returns the method name.
      *
-     * @return メソッド名
+     * @return Method name
      */
     public String getMethodName() {
         return methodName;

--- a/src/main/java/org/codelibs/core/exception/NamingRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NamingRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import javax.naming.NamingException;
 
 /**
- * {@link NamingException}をラップする例外です。
+ * Exception that wraps {@link NamingException}.
  *
  * @author higa
  */
@@ -29,10 +29,10 @@ public class NamingRuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = -3176447530746274091L;
 
     /**
-     * {@link NamingRuntimeException}を作成します。
+     * Creates a {@link NamingRuntimeException}.
      *
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public NamingRuntimeException(final NamingException cause) {
         super("ECL0066", asArray(cause), cause);

--- a/src/main/java/org/codelibs/core/exception/NoSuchAlgorithmRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NoSuchAlgorithmRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * {@link NoSuchAlgorithmException}をラップする例外です。
+ * Exception that wraps {@link NoSuchAlgorithmException}.
  *
  * @author higa
  */
@@ -29,10 +29,10 @@ public class NoSuchAlgorithmRuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = -3176447530746274091L;
 
     /**
-     * {@link NoSuchAlgorithmRuntimeException}を作成します。
+     * Creates a {@link NoSuchAlgorithmRuntimeException}.
      *
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public NoSuchAlgorithmRuntimeException(final NoSuchAlgorithmException cause) {
         super("ECL0067", asArray(cause), cause);

--- a/src/main/java/org/codelibs/core/exception/NoSuchConstructorRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NoSuchConstructorRuntimeException.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Constructor;
 import org.codelibs.core.lang.MethodUtil;
 
 /**
- * {@link Constructor}が見つからない場合にスローされる{@link NoSuchMethodException}をラップする例外です。
+ * Exception that wraps a {@link NoSuchMethodException} thrown when a {@link Constructor} cannot be found.
  *
  * @author higa
  */
@@ -35,14 +35,14 @@ public class NoSuchConstructorRuntimeException extends ClRuntimeException {
     private final Class<?>[] argTypes;
 
     /**
-     * {@link NoSuchConstructorRuntimeException}を作成します。
+     * Creates a {@link NoSuchConstructorRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param argTypes
-     *            引数型の並び
+     *            Array of parameter types
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public NoSuchConstructorRuntimeException(final Class<?> targetClass, final Class<?>[] argTypes, final Throwable cause) {
         super("ECL0064", asArray(targetClass.getName(), MethodUtil.getSignature(targetClass.getSimpleName(), argTypes)), cause);
@@ -51,18 +51,18 @@ public class NoSuchConstructorRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * 引数型の並びを返します。
+     * Returns the array of parameter types.
      *
-     * @return 引数型の並び
+     * @return Array of parameter types
      */
     public Class<?>[] getArgTypes() {
         return argTypes;

--- a/src/main/java/org/codelibs/core/exception/NoSuchFieldRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NoSuchFieldRuntimeException.java
@@ -18,7 +18,7 @@ package org.codelibs.core.exception;
 import static org.codelibs.core.collection.ArrayUtil.asArray;
 
 /**
- * {@link NoSuchFieldException}をラップする例外です。
+ * Exception that wraps {@link NoSuchFieldException}.
  *
  * @author higa
  */
@@ -31,14 +31,14 @@ public class NoSuchFieldRuntimeException extends ClRuntimeException {
     private final String fieldName;
 
     /**
-     * {@link NoSuchFieldRuntimeException}を作成します。
+     * Creates a {@link NoSuchFieldRuntimeException}.
      *
      * @param targetClass
-     *            ターゲットクラス
+     *            Target class
      * @param fieldName
-     *            フィールド名
+     *            Field name
      * @param cause
-     *            原因となった例外
+     *            The cause of the exception
      */
     public NoSuchFieldRuntimeException(final Class<?> targetClass, final String fieldName, final Throwable cause) {
         super("ECL0070", asArray(targetClass.getName(), fieldName), cause);
@@ -47,18 +47,18 @@ public class NoSuchFieldRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return Target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * フィールド名を返します。
+     * Returns the field name.
      *
-     * @return フィールド名
+     * @return Field name
      */
     public String getFieldName() {
         return fieldName;

--- a/src/main/java/org/codelibs/core/exception/NoSuchMethodRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NoSuchMethodRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import org.codelibs.core.lang.MethodUtil;
 
 /**
- * {@link NoSuchMethodException}をラップする例外です。
+ * Exception that wraps {@link NoSuchMethodException}.
  *
  * @author higa
  */
@@ -35,16 +35,12 @@ public class NoSuchMethodRuntimeException extends ClRuntimeException {
     private final Class<?>[] argTypes;
 
     /**
-     * {@link NoSuchMethodRuntimeException}を作成します。
+     * Creates a {@link NoSuchMethodRuntimeException}.
      *
-     * @param targetClass
-     *            ターゲットクラス
-     * @param methodName
-     *            メソッド名
-     * @param argTypes
-     *            引数型の並び
-     * @param cause
-     *            原因となった例外
+     * @param targetClass the target class
+     * @param methodName the method name
+     * @param argTypes the argument types
+     * @param cause the underlying exception
      */
     public NoSuchMethodRuntimeException(final Class<?> targetClass, final String methodName, final Class<?>[] argTypes,
             final Throwable cause) {
@@ -55,27 +51,27 @@ public class NoSuchMethodRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return the target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * メソッド名を返します。
+     * Returns the method name.
      *
-     * @return メソッド名
+     * @return the method name
      */
     public String getMethodName() {
         return methodName;
     }
 
     /**
-     * 引数型の並びを返します。
+     * Returns the argument types.
      *
-     * @return 引数型の並び
+     * @return the argument types
      */
     public Class<?>[] getArgTypes() {
         return argTypes;

--- a/src/main/java/org/codelibs/core/exception/NoSuchPaddingRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NoSuchPaddingRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import javax.crypto.NoSuchPaddingException;
 
 /**
- * {@link NoSuchPaddingException}をラップする例外です。
+ * Exception that wraps {@link NoSuchPaddingException}.
  *
  * @author shinsuke
  */
@@ -29,10 +29,9 @@ public class NoSuchPaddingRuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = -3176447530746274091L;
 
     /**
-     * {@link NoSuchPaddingException}を作成します。
+     * Creates a {@link NoSuchPaddingRuntimeException}.
      *
-     * @param cause
-     *            原因となった例外
+     * @param cause the underlying exception
      */
     public NoSuchPaddingRuntimeException(final NoSuchPaddingException cause) {
         super("ECL0069", asArray(cause), cause);

--- a/src/main/java/org/codelibs/core/exception/NullArgumentException.java
+++ b/src/main/java/org/codelibs/core/exception/NullArgumentException.java
@@ -18,9 +18,9 @@ package org.codelibs.core.exception;
 import static org.codelibs.core.collection.ArrayUtil.asArray;
 
 /**
- * 引数がnullだった場合にthrowする例外です。
+ * Exception thrown when an argument is null.
  *
- * {@link NullPointerException}をthrowする代わりに使うことを想定しています。
+ * Intended to be used instead of throwing {@link NullPointerException}.
  *
  * @author wyukawa
  */
@@ -32,10 +32,10 @@ public class NullArgumentException extends ClIllegalArgumentException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * {@link NullArgumentException}を作成します。
+     * Creates a {@link NullArgumentException}.
      *
      * @param argName
-     *            {@code null} である引数の名前
+     *            Name of the argument that is {@code null}
      */
     public NullArgumentException(final String argName) {
         super(argName, "ECL0008", asArray(argName));

--- a/src/main/java/org/codelibs/core/exception/ParseRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ParseRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import java.text.ParseException;
 
 /**
- * 解析できなかった場合にスローされる例外です。
+ * Exception thrown when parsing fails.
  *
  * @author higa
  */
@@ -29,20 +29,18 @@ public class ParseRuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = -5237329676597387063L;
 
     /**
-     * {@link ParseRuntimeException}を作成します。
+     * Creates a {@link ParseRuntimeException}.
      *
-     * @param cause
-     *            原因となった例外
+     * @param cause the underlying exception
      */
     public ParseRuntimeException(final ParseException cause) {
         super("ECL0050", asArray(cause), cause);
     }
 
     /**
-     * {@link ParseRuntimeException}を作成します。
+     * Creates a {@link ParseRuntimeException}.
      *
-     * @param s
-     *            解析できなかった文字列
+     * @param s the string that could not be parsed
      */
     public ParseRuntimeException(final String s) {
         super("ECL0051", asArray(s));

--- a/src/main/java/org/codelibs/core/exception/ParserConfigurationRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ParserConfigurationRuntimeException.java
@@ -20,7 +20,7 @@ import static org.codelibs.core.collection.ArrayUtil.asArray;
 import javax.xml.parsers.ParserConfigurationException;
 
 /**
- * {@link ParserConfigurationException}をラップする例外です。
+ * Exception that wraps {@link ParserConfigurationException}.
  *
  * @author higa
  */
@@ -29,10 +29,9 @@ public class ParserConfigurationRuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = -4610465906028959083L;
 
     /**
-     * {@link ParserConfigurationRuntimeException}を作成します。
+     * Creates a {@link ParserConfigurationRuntimeException}.
      *
-     * @param cause
-     *            原因となった例外
+     * @param cause the underlying exception
      */
     public ParserConfigurationRuntimeException(final ParserConfigurationException cause) {
         super("ECL0053", asArray(cause), cause);

--- a/src/main/java/org/codelibs/core/exception/PropertyNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/PropertyNotFoundRuntimeException.java
@@ -18,7 +18,7 @@ package org.codelibs.core.exception;
 import static org.codelibs.core.collection.ArrayUtil.asArray;
 
 /**
- * プロパティが見つからなかった場合にスローされる例外です。
+ * Exception thrown when a property cannot be found.
  *
  * @author higa
  *
@@ -32,12 +32,10 @@ public class PropertyNotFoundRuntimeException extends ClRuntimeException {
     private final String propertyName;
 
     /**
-     * {@link PropertyNotFoundRuntimeException}を返します。
+     * Returns a {@link PropertyNotFoundRuntimeException}.
      *
-     * @param targetClass
-     *            ターゲットクラス
-     * @param propertyName
-     *            プロパティ名
+     * @param targetClass the target class
+     * @param propertyName the property name
      */
     public PropertyNotFoundRuntimeException(final Class<?> targetClass, final String propertyName) {
         super("ECL0065", asArray(targetClass.getName(), propertyName));
@@ -46,18 +44,18 @@ public class PropertyNotFoundRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * ターゲットクラスを返します。
+     * Returns the target class.
      *
-     * @return ターゲットクラス
+     * @return the target class
      */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
     /**
-     * プロパティ名を返します。
+     * Returns the property name.
      *
-     * @return プロパティ名
+     * @return the property name
      */
     public String getPropertyName() {
         return propertyName;

--- a/src/main/java/org/codelibs/core/exception/ResourceNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ResourceNotFoundRuntimeException.java
@@ -18,7 +18,7 @@ package org.codelibs.core.exception;
 import static org.codelibs.core.collection.ArrayUtil.asArray;
 
 /**
- * リソースが見つからなかったときにスローされる例外です。
+ * Exception thrown when a resource cannot be found.
  *
  * @author higa
  */
@@ -29,10 +29,9 @@ public class ResourceNotFoundRuntimeException extends ClRuntimeException {
     private final String path;
 
     /**
-     * {@link ResourceNotFoundRuntimeException}を作成します。
+     * Creates a {@link ResourceNotFoundRuntimeException}.
      *
-     * @param path
-     *            リソースのパス
+     * @param path the resource path
      */
     public ResourceNotFoundRuntimeException(final String path) {
         super("ECL0055", asArray(path));
@@ -40,9 +39,9 @@ public class ResourceNotFoundRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * パスを返します。
+     * Returns the path.
      *
-     * @return パス
+     * @return the path
      */
     public String getPath() {
         return path;

--- a/src/main/java/org/codelibs/core/exception/SAXRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/SAXRuntimeException.java
@@ -21,7 +21,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 /**
- * {@link SAXException}をラップする例外です。
+ * Exception that wraps {@link SAXException}.
  *
  * @author higa
  */
@@ -30,21 +30,19 @@ public class SAXRuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = -4933312103385038765L;
 
     /**
-     * {@link SAXRuntimeException}を作成します。
+     * Creates a {@link SAXRuntimeException}.
      *
-     * @param cause
-     *            原因となった例外
+     * @param cause the underlying exception
      */
     public SAXRuntimeException(final SAXException cause) {
         super("ECL0054", asArray(createMessage(cause)), cause);
     }
 
     /**
-     * メッセージを作成します。
+     * Creates a message.
      *
-     * @param cause
-     *            原因
-     * @return メッセージ
+     * @param cause the underlying exception
+     * @return the message
      */
     protected static String createMessage(final SAXException cause) {
         final StringBuilder buf = new StringBuilder(100);

--- a/src/main/java/org/codelibs/core/exception/SQLRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/SQLRuntimeException.java
@@ -22,7 +22,7 @@ import java.sql.SQLException;
 import org.codelibs.core.message.MessageFormatter;
 
 /**
- * {@link SQLException}をラップする例外です。
+ * Exception that wraps {@link SQLException}.
  *
  * @author higa
  * @author manhole
@@ -32,21 +32,19 @@ public class SQLRuntimeException extends ClRuntimeException {
     private static final long serialVersionUID = 2533513110369526191L;
 
     /**
-     * {@link SQLRuntimeException}を作成します。
+     * Creates a {@link SQLRuntimeException}.
      *
-     * @param cause
-     *            原因となった例外
+     * @param cause the underlying exception
      */
     public SQLRuntimeException(final SQLException cause) {
         super("ECL0072", asArray(getSql(cause), getRealMessage(cause), Integer.toString(cause.getErrorCode()), cause.getSQLState()), cause);
     }
 
     /**
-     * <code>SQL</code>を返します。
+     * Returns the <code>SQL</code>.
      *
-     * @param cause
-     *            原因となった例外
-     * @return <code>SQL</code>
+     * @param cause the underlying exception
+     * @return the <code>SQL</code>
      */
     protected static String getSql(final SQLException cause) {
         if (cause instanceof ClSQLException) {
@@ -56,11 +54,10 @@ public class SQLRuntimeException extends ClRuntimeException {
     }
 
     /**
-     * 本当のメッセージを返します。
+     * Returns the real message.
      *
-     * @param cause
-     *            原因となった例外
-     * @return 本当のメッセージ
+     * @param cause the underlying exception
+     * @return the real message
      */
     protected static String getRealMessage(final SQLException cause) {
         final StringBuilder buf = new StringBuilder(256);

--- a/src/main/java/org/codelibs/core/io/ClassHandler.java
+++ b/src/main/java/org/codelibs/core/io/ClassHandler.java
@@ -16,19 +16,17 @@
 package org.codelibs.core.io;
 
 /**
- * クラスを処理するハンドラのインターフェースです。
+ * Interface for handlers that process classes.
  *
  * @author koichik
  */
 public interface ClassHandler {
 
     /**
-     * クラスを処理します。
+     * Processes a class.
      *
-     * @param packageName
-     *            パッケージ名
-     * @param shortClassName
-     *            クラスの単純名
+     * @param packageName the package name
+     * @param shortClassName the simple class name
      */
     void processClass(String packageName, String shortClassName);
 

--- a/src/main/java/org/codelibs/core/io/ClassTraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/ClassTraversalUtil.java
@@ -28,7 +28,7 @@ import org.codelibs.core.lang.ClassUtil;
 import org.codelibs.core.zip.ZipInputStreamUtil;
 
 /**
- * クラスを横断して処理するためのハンドラです。
+ * Handler for traversing and processing classes.
  *
  * @author koichik
  * @see ClassHandler
@@ -36,22 +36,20 @@ import org.codelibs.core.zip.ZipInputStreamUtil;
  */
 public abstract class ClassTraversalUtil {
 
-    /** クラスファイルの拡張子 */
+    /** The file extension for class files. */
     protected static final String CLASS_SUFFIX = ".class";
 
-    /** WARファイルの拡張子 */
+    /** The file extension for WAR files. */
     protected static final String WAR_FILE_EXTENSION = ".war";
 
-    /** WARファイル内のクラスファイルのエントリプレフィックス */
+    /** The entry prefix for class files inside a WAR file. */
     protected static final String WEB_INF_CLASSES_PATH = "WEB-INF/classes/";
 
     /**
-     * ルートディレクトリ配下を処理します。
+     * Processes the directory under the root directory.
      *
-     * @param rootDir
-     *            ルートディレクトリ。{@literal null}であってはいけません
-     * @param handler
-     *            クラスを処理するハンドラ。{@literal null}であってはいけません
+     * @param rootDir the root directory (must not be {@literal null})
+     * @param handler the handler to process classes (must not be {@literal null})
      */
     public static void forEach(final File rootDir, final ClassHandler handler) {
         assertArgumentNotNull("rootDir", rootDir);
@@ -61,14 +59,11 @@ public abstract class ClassTraversalUtil {
     }
 
     /**
-     * ファイルシステムに含まれるクラスをトラバースします。
+     * Traverses classes contained in the file system.
      *
-     * @param rootDir
-     *            ルートディレクトリ。{@literal null}であってはいけません
-     * @param rootPackage
-     *            ルートパッケージ
-     * @param handler
-     *            クラスを処理するハンドラ。{@literal null}であってはいけません
+     * @param rootDir the root directory (must not be {@literal null})
+     * @param rootPackage the root package
+     * @param handler the handler to process classes (must not be {@literal null})
      */
     public static void forEach(final File rootDir, final String rootPackage, final ClassHandler handler) {
         assertArgumentNotNull("rootDir", rootDir);
@@ -81,19 +76,15 @@ public abstract class ClassTraversalUtil {
     }
 
     /**
-     * Jarファイルに含まれるクラスをトラバースします。
+     * Traverses classes contained in a Jar file.
      * <p>
-     * 指定されたJarファイルが拡張子<code>.war</code>を持つ場合は、 Jarファイル内のエントリのうち、 接頭辞
-     * <code>WEB-INF/classes</code>で始まるパスを持つエントリがトラバースの対象となります。
-     * クラスを処理するハンドラには、接頭辞を除くエントリ名が渡されます。 例えばJarファイル内に
-     * <code>/WEB-INF/classes/ccc/ddd/Eee.class</code>というクラスファイルが存在すると、 ハンドラには
-     * パッケージ名<code>ccc.ddd</code>およびクラス名<code>Eee</code>が渡されます。
+     * If the specified Jar file has the extension <code>.war</code>, only entries whose path starts with the prefix <code>WEB-INF/classes</code> are traversed.
+     * The handler receives the entry name excluding the prefix. For example, if the Jar file contains <code>/WEB-INF/classes/ccc/ddd/Eee.class</code>,
+     * the handler receives the package name <code>ccc.ddd</code> and the class name <code>Eee</code>.
      * </p>
      *
-     * @param jarFile
-     *            Jarファイル。{@literal null}であってはいけません
-     * @param handler
-     *            クラスを処理するハンドラ。{@literal null}であってはいけません
+     * @param jarFile the Jar file (must not be {@literal null})
+     * @param handler the handler to process classes (must not be {@literal null})
      */
     public static void forEach(final JarFile jarFile, final ClassHandler handler) {
         assertArgumentNotNull("jarFile", jarFile);
@@ -107,21 +98,17 @@ public abstract class ClassTraversalUtil {
     }
 
     /**
-     * Jarファイルに含まれるクラスをトラバースします。
+     * Traverses classes contained in a Jar file.
      * <p>
-     * Jarファイル内のエントリのうち、接頭辞で始まるパスを持つエントリがトラバースの対象となります。
-     * クラスを処理するハンドラには、接頭辞を除くエントリ名が渡されます。 例えば接頭辞が <code>/aaa/bbb/</code>
-     * で、Jarファイル内に <code>/aaa/bbb/ccc/ddd/Eee.class</code>というクラスファイルが存在すると、
-     * ハンドラには パッケージ名<code>ccc.ddd</code>およびクラス名<code>Eee</code>が渡されます。
+     * Only entries whose path starts with the specified prefix are traversed. The handler receives the entry name excluding the prefix.
+     * For example, if the prefix is <code>/aaa/bbb/</code> and the Jar file contains <code>/aaa/bbb/ccc/ddd/Eee.class</code>,
+     * the handler receives the package name <code>ccc.ddd</code> and the class name <code>Eee</code>.
      * </p>
      *
-     * @param jarFile
-     *            Jarファイル。{@literal null}であってはいけません
-     * @param prefix
-     *            トラバースするリソースの名前が含む接頭辞。{@literal null}であってはいけません。
-     *            空文字列でない場合はスラッシュ('/')で終了していなければなりません
-     * @param handler
-     *            クラスを処理するハンドラ。{@literal null}であってはいけません
+     * @param jarFile the Jar file (must not be {@literal null})
+     * @param prefix the prefix that the resource name to traverse must contain (must not be {@literal null}).
+     *               If not empty, must end with a slash ('/')
+     * @param handler the handler to process classes (must not be {@literal null})
      */
     public static void forEach(final JarFile jarFile, final String prefix, final ClassHandler handler) {
         assertArgumentNotNull("jarFile", jarFile);
@@ -142,12 +129,10 @@ public abstract class ClassTraversalUtil {
     }
 
     /**
-     * ZIPファイル形式の入力ストリームに含まれるクラスをトラバースします。
+     * Traverses classes contained in a ZIP file input stream.
      *
-     * @param zipInputStream
-     *            ZIPファイル形式の入力ストリーム。{@literal null}であってはいけません
-     * @param handler
-     *            クラスを処理するハンドラ。{@literal null}であってはいけません
+     * @param zipInputStream the ZIP file input stream (must not be {@literal null})
+     * @param handler the handler to process classes (must not be {@literal null})
      */
     public static void forEach(final ZipInputStream zipInputStream, final ClassHandler handler) {
         assertArgumentNotNull("zipInputStream", zipInputStream);
@@ -157,22 +142,17 @@ public abstract class ClassTraversalUtil {
     }
 
     /**
-     * ZIPファイル形式の入力ストリームに含まれるクラスをトラバースします。
+     * Traverses classes contained in a ZIP file input stream.
      * <p>
-     * 入力ストリーム内のエントリのうち、接頭辞で始まるパスを持つエントリがトラバースの対象となります。
-     * クラスを処理するハンドラには、接頭辞を除くエントリ名が渡されます。 例えば接頭辞が <code>/aaa/bbb/</code>
-     * で、入力ストリーム内に <code>/aaa/bbb/ccc/ddd/Eee.class</code>というクラスファイルが存在すると、
-     * ハンドラには パッケージ名<code>ccc.ddd</code>およびクラス名<code>Eee</code>が渡されます。
+     * Only entries whose path starts with the specified prefix are traversed. The handler receives the entry name excluding the prefix.
+     * For example, if the prefix is <code>/aaa/bbb/</code> and the input stream contains <code>/aaa/bbb/ccc/ddd/Eee.class</code>,
+     * the handler receives the package name <code>ccc.ddd</code> and the class name <code>Eee</code>.
      * </p>
      *
-     * @param zipInputStream
-     *            ZIPファイル形式の入力ストリーム。{@literal null}であってはいけません
-     * @param prefix
-     *            トラバースするリソースの名前が含む接頭辞。{@literal null}であってはいけません。
-     *            空文字列でない場合はスラッシュ('/')で終了していなければなりません
-     *
-     * @param handler
-     *            クラスを処理するハンドラ。{@literal null}であってはいけません
+     * @param zipInputStream the ZIP file input stream (must not be {@literal null})
+     * @param prefix the prefix that the resource name to traverse must contain (must not be {@literal null}).
+     *               If not empty, must end with a slash ('/')
+     * @param handler the handler to process classes (must not be {@literal null})
      */
     public static void forEach(final ZipInputStream zipInputStream, final String prefix, final ClassHandler handler) {
         assertArgumentNotNull("zipInputStream", zipInputStream);
@@ -198,14 +178,11 @@ public abstract class ClassTraversalUtil {
     }
 
     /**
-     * ファイルシステムに含まれるクラスをトラバースします。
+     * Traverses classes contained in the file system.
      *
-     * @param dir
-     *            基点となるディレクトリ
-     * @param packageName
-     *            トラバースするパッケージ名
-     * @param handler
-     *            クラスを処理するハンドラ
+     * @param dir the base directory
+     * @param packageName the package name to traverse
+     * @param handler the handler to process classes
      */
     protected static void traverseFileSystem(final File dir, final String packageName, final ClassHandler handler) {
         for (final File file : dir.listFiles()) {
@@ -220,13 +197,11 @@ public abstract class ClassTraversalUtil {
     }
 
     /**
-     * ルートパッケージに対応するディレクトリを表す{@link File}を返します。
+     * Returns a {@link File} representing the directory corresponding to the root package.
      *
-     * @param rootDir
-     *            ルートディレクトリ
-     * @param rootPackage
-     *            ルートパッケージ
-     * @return パッケージに対応するディレクトリを表す{@link File}
+     * @param rootDir the root directory
+     * @param rootPackage the root package
+     * @return a {@link File} representing the directory corresponding to the package
      */
     protected static File getPackageDir(final File rootDir, final String rootPackage) {
         File packageDir = rootDir;

--- a/src/main/java/org/codelibs/core/io/CloseableUtil.java
+++ b/src/main/java/org/codelibs/core/io/CloseableUtil.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import org.codelibs.core.log.Logger;
 
 /**
- * {@link Closeable}用のユーティリティクラスです。
+ * Utility class for {@link Closeable} operations.
  *
  * @author koichik
  */
@@ -32,28 +32,23 @@ public abstract class CloseableUtil {
     private static final Logger logger = Logger.getLogger(CloseableUtil.class);
 
     /**
-     * {@link Closeable}をクローズします。
+     * Closes a {@link Closeable}.
      * <p>
-     * {@link Closeable#close()}が例外をスローした場合はログにエラーメッセージを出力します。
-     * 例外は再スローされません。これは、次のような状況で元の例外が失われるのを防ぐためです。
+     * If an exception is thrown by {@link Closeable#close()}, an error message is logged. The exception is not rethrown. This prevents the original exception from being lost in situations like the following:
      * </p>
-     *
      * <pre>
      * InputStream is = ...;
      * try {
      *   is.read(...);
-     * } finaly {
+     * } finally {
      *   close(is);
      * }
      * </pre>
      * <p>
-     * {@literal try}ブロックで例外が発生した場合、{@literal finally}ブロックの
-     * {@link #close(Closeable)}でも 例外が発生する可能性があります。その場合に{@literal finally}
-     * ブロックから例外をスローすると、 {@literal try}ブロックで発生した元の例外が失われてしまいます。
+     * If an exception occurs in the try block, there is a possibility that an exception will also occur in the finally block's {@link #close(Closeable)}. If the exception is thrown from the finally block, the original exception from the try block will be lost.
      * </p>
      *
-     * @param closeable
-     *            クローズ可能なオブジェクト
+     * @param closeable the closeable object
      * @see Closeable#close()
      */
     public static void close(final Closeable closeable) {

--- a/src/main/java/org/codelibs/core/io/CopyUtil.java
+++ b/src/main/java/org/codelibs/core/io/CopyUtil.java
@@ -46,15 +46,15 @@ import org.codelibs.core.net.URLUtil;
 import org.codelibs.core.nio.ChannelUtil;
 
 /**
- * コピーのためのユーティリティです。
+ * Utility for copying.
  * <p>
- * コピー可能な入力と出力の組み合わせと、コピーされる要素の単位は以下のとおりです。
+ * The combinations of input and output types and the unit of elements copied are as follows:
  * </p>
  * <table border="1">
- * <caption>Elements for coping instances</caption>
+ * <caption>Elements for copying instances</caption>
  * <tr>
- * <th rowspan="2">入力の型</th>
- * <th colspan="4">出力の型</th>
+ * <th rowspan="2">Input type</th>
+ * <th colspan="4">Output type</th>
  * </tr>
  * <tr>
  * <th>{@link OutputStream}</th>
@@ -64,76 +64,73 @@ import org.codelibs.core.nio.ChannelUtil;
  * </tr>
  * <tr>
  * <th>{@link InputStream}</th>
- * <td>バイト</td>
- * <td>文字</td>
- * <td>バイト、文字</td>
- * <td>文字</td>
+ * <td>bytes</td>
+ * <td>characters</td>
+ * <td>bytes, characters</td>
+ * <td>characters</td>
  * </tr>
  * <tr>
  * <th>{@link Reader}</th>
- * <td>文字</td>
- * <td>文字</td>
- * <td>文字</td>
- * <td>文字</td>
+ * <td>characters</td>
+ * <td>characters</td>
+ * <td>characters</td>
+ * <td>characters</td>
  * </tr>
  * <tr>
  * <th>{@link File}</th>
- * <td>バイト</td>
- * <td>文字</td>
- * <td>バイト、文字</td>
- * <td>文字</td>
+ * <td>bytes</td>
+ * <td>characters</td>
+ * <td>bytes, characters</td>
+ * <td>characters</td>
  * </tr>
  * <tr>
  * <th>{@link URL}</th>
- * <td>バイト</td>
- * <td>文字</td>
- * <td>バイト、文字</td>
- * <td>文字</td>
+ * <td>bytes</td>
+ * <td>characters</td>
+ * <td>bytes, characters</td>
+ * <td>characters</td>
  * </tr>
  * <tr>
  * <th>{@literal byte[]}</th>
- * <td>バイト</td>
- * <td>文字</td>
- * <td>バイト、文字</td>
- * <td>文字</td>
+ * <td>bytes</td>
+ * <td>characters</td>
+ * <td>bytes, characters</td>
+ * <td>characters</td>
  * </tr>
  * <tr>
  * <th>{@link String}</th>
- * <td>文字</td>
- * <td>文字</td>
- * <td>文字</td>
- * <td>×</td>
+ * <td>characters</td>
+ * <td>characters</td>
+ * <td>characters</td>
+ * <td>&times;</td>
  * </tr>
  * </table>
  * <p>
- * 引数に{@link InputStream}/{@link OutputStream}/{@link Reader}/{@link Writer}
- * を受け取るメソッドは、 どれも引数に対して{@link Closeable#close()}を呼び出しません。 クローズする責務は呼び出し側にあります。
+ * Methods that take {@link InputStream}/{@link OutputStream}/{@link Reader}/{@link Writer} as arguments do not call {@link Closeable#close()} on the arguments. The caller is responsible for closing them.
  * </p>
  * <p>
- * どのメソッドも発生した{@link IOException}は{@link IORuntimeException}にラップしてスローされます。
+ * Any {@link IOException} thrown by these methods is wrapped and thrown as an {@link IORuntimeException}.
  * </p>
  *
  * @author koichik
  */
 public abstract class CopyUtil {
 
-    /** コピーで使用するバッファサイズ */
+    /** Buffer size used for copying. */
     protected static final int DEFAULT_BUF_SIZE = 4096;
 
     // ////////////////////////////////////////////////////////////////
     // from InputStream to OutputStream
     //
     /**
-     * 入力ストリームから出力ストリームへコピーします。
+     * Copies from an input stream to an output stream.
      * <p>
-     * 入力ストリーム、出力ストリームともクローズされません。
+     * Neither the input stream nor the output stream is closed.
      * </p>
      *
-     * @param in
-     *            入力ストリーム。{@literal null}であってはいけません
-     * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
-     * @return コピーしたバイト数
+     * @param in the input stream (must not be {@literal null})
+     * @param out the output stream (must not be {@literal null})
+     * @return the number of bytes copied
      */
     public static int copy(final InputStream in, final OutputStream out) {
         assertArgumentNotNull("in", in);
@@ -155,16 +152,14 @@ public abstract class CopyUtil {
     // from InputStream to Writer
     //
     /**
-     * プラットフォームのデフォルトエンコーディングで入力ストリームからライターへコピーします。
+     * Copies from an input stream to a writer using the platform default encoding.
      * <p>
-     * 入力ストリーム、ライターともクローズされません。
+     * Neither the input stream nor the writer is closed.
      * </p>
      *
-     * @param in
-     *            入力ストリーム。{@literal null}であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the input stream (must not be {@literal null})
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final InputStream in, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -175,18 +170,15 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定のエンコーディングで入力ストリームからライターへコピーします。
+     * Copies from an input stream to a writer using the specified encoding.
      * <p>
-     * 入力ストリーム、ライターともクローズされません。
+     * Neither the input stream nor the writer is closed.
      * </p>
      *
-     * @param in
-     *            入力ストリーム。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            ライター
-     * @return コピーした文字数。{@literal null}であってはいけません
+     * @param in the input stream (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final InputStream in, final String encoding, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -201,16 +193,14 @@ public abstract class CopyUtil {
     // from InputStream to File
     //
     /**
-     * 入力ストリームからファイルへコピーします。
+     * Copies from an input stream to a file.
      * <p>
-     * 入力ストリームはクローズされません。
+     * The input stream is not closed.
      * </p>
      *
-     * @param in
-     *            入力ストリーム。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @return コピーしたバイト数
+     * @param in the input stream (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @return the number of bytes copied
      */
     public static int copy(final InputStream in, final File out) {
         assertArgumentNotNull("in", in);
@@ -231,16 +221,14 @@ public abstract class CopyUtil {
     // from InputStream to StringBuilder
     //
     /**
-     * プラットフォームのデフォルトエンコーディングで入力ストリームから{@link StringBuilder}へコピーします。
+     * Copies from an input stream to a {@link StringBuilder} using the platform default encoding.
      * <p>
-     * 入力ストリームはクローズされません。
+     * The input stream is not closed.
      * </p>
      *
-     * @param in
-     *            入力ストリーム。{@literal null}であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the input stream (must not be {@literal null})
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final InputStream in, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -251,18 +239,15 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定のエンコーディングで入力ストリームから{@link StringBuilder}へコピーします。
+     * Copies from an input stream to a {@link StringBuilder} using the specified encoding.
      * <p>
-     * 入力ストリームはクローズされません。
+     * The input stream is not closed.
      * </p>
      *
-     * @param in
-     *            入力ストリーム。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the input stream (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final InputStream in, final String encoding, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -277,16 +262,14 @@ public abstract class CopyUtil {
     // from Reader to OutputStream
     //
     /**
-     * プラットフォームのデフォルトエンコーディングでリーダーから出力ストリームへコピーします。
+     * Copies from a reader to an output stream using the platform default encoding.
      * <p>
-     * リーダー、出力ストリームともクローズされません。
+     * Neither the reader nor the output stream is closed.
      * </p>
      *
-     * @param in
-     *            リーダー。{@literal null}であってはいけません
-     * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the reader (must not be {@literal null})
+     * @param out the output stream (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final Reader in, final OutputStream out) {
         assertArgumentNotNull("in", in);
@@ -297,18 +280,15 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定のエンコーディングでリーダーから出力ストリームへコピーします。
+     * Copies from a reader to an output stream using the specified encoding.
      * <p>
-     * リーダー、出力ストリームともクローズされません。
+     * Neither the reader nor the output stream is closed.
      * </p>
      *
-     * @param in
-     *            リーダー。{@literal null}であってはいけません
-     * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the reader (must not be {@literal null})
+     * @param out the output stream (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final Reader in, final OutputStream out, final String encoding) {
         assertArgumentNotNull("in", in);
@@ -323,16 +303,14 @@ public abstract class CopyUtil {
     // from Reader to Writer
     //
     /**
-     * リーダーからライターへコピーします。
+     * Copies from a reader to a writer.
      * <p>
-     * リーダー、ライターともクローズされません。
+     * Neither the reader nor the writer is closed.
      * </p>
      *
-     * @param in
-     *            リーダー。{@literal null}であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the reader (must not be {@literal null})
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final Reader in, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -345,16 +323,14 @@ public abstract class CopyUtil {
     // from Reader to File
     //
     /**
-     * プラットフォームのデフォルトエンコーディングでリーダーからファイルへコピーします。
+     * Copies from a reader to a file using the platform default encoding.
      * <p>
-     * リーダーはクローズされません。
+     * The reader is not closed.
      * </p>
      *
-     * @param in
-     *            リーダー。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the reader (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final Reader in, final File out) {
         assertArgumentNotNull("in", in);
@@ -369,15 +345,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定のエンコーディングでリーダーからファイルへコピーします。
+     * Copies from a reader to a file using the specified encoding.
      *
-     * @param in
-     *            リーダー。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the reader (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final Reader in, final File out, final String encoding) {
         assertArgumentNotNull("in", in);
@@ -396,16 +369,14 @@ public abstract class CopyUtil {
     // from Reader to StringBuilder
     //
     /**
-     * リーダーから{@link StringBuilder}へコピーします。
+     * Copies from a reader to a {@link StringBuilder}.
      * <p>
-     * リーダーはクローズされません。
+     * The reader is not closed.
      * </p>
      *
-     * @param in
-     *            リーダー。{@literal null}であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the reader (must not be {@literal null})
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final Reader in, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -418,16 +389,14 @@ public abstract class CopyUtil {
     // from File to OutputStream
     //
     /**
-     * ファイルから出力ストリームへコピーします。
+     * Copies from a file to an output stream.
      * <p>
-     * 出力ストリームはクローズされません。
+     * The output stream is not closed.
      * </p>
      *
-     * @param in
-     *            ファイル。{@literal null}であってはいけません
-     * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
-     * @return コピーしたバイト数
+     * @param in the file (must not be {@literal null})
+     * @param out the output stream (must not be {@literal null})
+     * @return the number of bytes copied
      */
     public static int copy(final File in, final OutputStream out) {
         assertArgumentNotNull("in", in);
@@ -448,16 +417,14 @@ public abstract class CopyUtil {
     // from File to Writer
     //
     /**
-     * プラットフォームのデフォルトエンコーディングでファイルからライターへコピーします。
+     * Copies from a file to a writer using the platform default encoding.
      * <p>
-     * ライターはクローズされません。
+     * The writer is not closed.
      * </p>
      *
-     * @param in
-     *            ファイル。{@literal null}であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the file (must not be {@literal null})
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final File in, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -472,18 +439,15 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定のエンコーディングでファイルからライターへコピーします。
+     * Copies from a file to a writer using the specified encoding.
      * <p>
-     * ライターはクローズされません。
+     * The writer is not closed.
      * </p>
      *
-     * @param in
-     *            ファイル。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the file (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final File in, final String encoding, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -502,13 +466,11 @@ public abstract class CopyUtil {
     // from File to File
     //
     /**
-     * ファイルからファイルへコピーします。
+     * Copies from a file to a file.
      *
-     * @param in
-     *            入力ファイル。{@literal null}であってはいけません
-     * @param out
-     *            出力ファイル。{@literal null}であってはいけません
-     * @return コピーしたバイト数
+     * @param in the input file (must not be {@literal null})
+     * @param out the output file (must not be {@literal null})
+     * @return the number of bytes copied
      */
     public static int copy(final File in, final File out) {
         assertArgumentNotNull("in", in);
@@ -528,15 +490,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングのファイルからプラットフォームデフォルトエンコーディングのファイルへコピーします。
+     * Copies from a file with the specified encoding to a file with the platform default encoding.
      *
-     * @param in
-     *            入力ファイル。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            出力ファイル。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the input file (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the output file (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final File in, final String encoding, final File out) {
         assertArgumentNotNull("in", in);
@@ -557,15 +516,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * プラットフォームデフォルトエンコーディングのファイルから指定されたエンコーディングのファイルへコピーします。
+     * Copies from a file with the platform default encoding to a file with the specified encoding.
      *
-     * @param in
-     *            入力ファイル。{@literal null}であってはいけません
-     * @param out
-     *            出力ファイル。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the input file (must not be {@literal null})
+     * @param out the output file (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final File in, final File out, final String encoding) {
         assertArgumentNotNull("in", in);
@@ -586,17 +542,13 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングのファイルから指定されたエンコーディングのファイルへコピーします。
+     * Copies from a file with the specified encoding to a file with the specified encoding.
      *
-     * @param in
-     *            入力ファイル。{@literal null}であってはいけません
-     * @param inputEncoding
-     *            入力ファイルのエンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            出力ファイル。{@literal null}であってはいけません
-     * @param outputEncoding
-     *            出力ファイルのエンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the input file (must not be {@literal null})
+     * @param inputEncoding the input file encoding (must not be {@literal null} or empty)
+     * @param out the output file (must not be {@literal null})
+     * @param outputEncoding the output file encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final File in, final String inputEncoding, final File out, final String outputEncoding) {
         assertArgumentNotNull("in", in);
@@ -621,13 +573,11 @@ public abstract class CopyUtil {
     // from File to StringBuilder
     //
     /**
-     * プラットフォームのデフォルトエンコーディングでファイルから{@link StringBuilder}へコピーします。
+     * Copies from a file to a {@link StringBuilder} using the platform default encoding.
      *
-     * @param in
-     *            ファイル。{@literal null}であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the file (must not be {@literal null})
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final File in, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -642,15 +592,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングでファイルから{@link StringBuilder}へコピーします。
+     * Copies from a file to a {@link StringBuilder} using the specified encoding.
      *
-     * @param in
-     *            ファイル。{@literal null}であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the file (must not be {@literal null})
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final File in, final String encoding, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -669,16 +616,14 @@ public abstract class CopyUtil {
     // from URL to OutputStream
     //
     /**
-     * URLから出力ストリームへコピーします。
+     * Copies from a URL to an output stream.
      * <p>
-     * 出力ストリームはクローズされません。
+     * The output stream is not closed.
      * </p>
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
-     * @return コピーしたバイト数
+     * @param in the URL (must not be {@literal null})
+     * @param out the output stream (must not be {@literal null})
+     * @return the number of bytes copied
      */
     public static int copy(final URL in, final OutputStream out) {
         assertArgumentNotNull("in", in);
@@ -699,16 +644,14 @@ public abstract class CopyUtil {
     // from URL to Writer
     //
     /**
-     * プラットフォームのデフォルトエンコーディングでURLからライターへコピーします。
+     * Copies from a URL to a writer using the platform default encoding.
      * <p>
-     * ライターはクローズされません。
+     * The writer is not closed.
      * </p>
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the URL (must not be {@literal null})
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final URL in, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -723,18 +666,15 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定のエンコーディングでURLからライターへコピーします。
+     * Copies from a URL to a writer using the specified encoding.
      * <p>
-     * ライターはクローズされません。
+     * The writer is not closed.
      * </p>
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the URL (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final URL in, final String encoding, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -753,13 +693,11 @@ public abstract class CopyUtil {
     // from URL to File
     //
     /**
-     * URLからファイルへコピーします。
+     * Copies from a URL to a file.
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @return コピーしたバイト数
+     * @param in the URL (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @return the number of bytes copied
      */
     public static int copy(final URL in, final File out) {
         assertArgumentNotNull("in", in);
@@ -779,15 +717,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングのURLからプラットフォームデフォルトエンコーディングのファイルへコピーします。
+     * Copies from a URL with the specified encoding to a file with the platform default encoding.
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            出力ファイル。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the URL (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the output file (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final URL in, final String encoding, final File out) {
         assertArgumentNotNull("in", in);
@@ -808,15 +743,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * プラットフォームデフォルトエンコーディングのURLから指定されたエンコーディングのファイルへコピーします。
+     * Copies from a URL with the platform default encoding to a file with the specified encoding.
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the URL (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final URL in, final File out, final String encoding) {
         assertArgumentNotNull("in", in);
@@ -837,17 +769,13 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングのURLから指定されたエンコーディングのファイルへコピーします。
+     * Copies from a URL with the specified encoding to a file with the specified encoding.
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param inputEncoding
-     *            URLのエンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @param outputEncoding
-     *            ファイルのエンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the URL (must not be {@literal null})
+     * @param inputEncoding the URL encoding (must not be {@literal null} or empty)
+     * @param out the file (must not be {@literal null})
+     * @param outputEncoding the file encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final URL in, final String inputEncoding, final File out, final String outputEncoding) {
         assertArgumentNotNull("in", in);
@@ -872,13 +800,11 @@ public abstract class CopyUtil {
     // from URL to StringBuilder
     //
     /**
-     * プラットフォームのデフォルトエンコーディングでURLから{@link StringBuilder}へコピーします。
+     * Copies from a URL to a {@link StringBuilder} using the platform default encoding.
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the URL (must not be {@literal null})
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final URL in, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -893,15 +819,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングでURLから{@link StringBuilder}へコピーします。
+     * Copies from a URL to a {@link StringBuilder} using the specified encoding.
      *
-     * @param in
-     *            URL。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the URL (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final URL in, final String encoding, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -920,16 +843,14 @@ public abstract class CopyUtil {
     // from bytes to OutputStream
     //
     /**
-     * バイト配列から出力ストリームへコピーします。
+     * Copies from a byte array to an output stream.
      * <p>
-     * 出力ストリームはクローズされません。
+     * The output stream is not closed.
      * </p>
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
-     * @return コピーしたバイト数
+     * @param in the byte array (must not be {@literal null})
+     * @param out the output stream (must not be {@literal null})
+     * @return the number of bytes copied
      */
     public static int copy(final byte[] in, final OutputStream out) {
         assertArgumentNotNull("in", in);
@@ -946,16 +867,14 @@ public abstract class CopyUtil {
     // from bytes to Writer
     //
     /**
-     * プラットフォームのデフォルトエンコーディングでバイト配列からライターへコピーします。
+     * Copies from a byte array to a writer using the platform default encoding.
      * <p>
-     * ライターはクローズされません。
+     * The writer is not closed.
      * </p>
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the byte array (must not be {@literal null})
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final byte[] in, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -966,18 +885,15 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングでバイト配列からライターへコピーします。
+     * Copies from a byte array to a writer using the specified encoding.
      * <p>
-     * ライターはクローズされません。
+     * The writer is not closed.
      * </p>
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the byte array (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final byte[] in, final String encoding, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -992,13 +908,11 @@ public abstract class CopyUtil {
     // from bytes to File
     //
     /**
-     * バイト配列からファイルへコピーします。
+     * Copies from a byte array to a file.
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @return コピーしたバイト数
+     * @param in the byte array (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @return the number of bytes copied
      */
     public static int copy(final byte[] in, final File out) {
         assertArgumentNotNull("in", in);
@@ -1015,15 +929,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングのバイト配列からプラットフォームデフォルトエンコーディングのファイルへコピーします。
+     * Copies from a byte array with the specified encoding to a file with the platform default encoding.
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the byte array (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @param out the file (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final byte[] in, final String encoding, final File out) {
         assertArgumentNotNull("in", in);
@@ -1040,15 +951,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * プラットフォームデフォルトエンコーディングのバイト配列から指定されたエンコーディングのファイルへコピーします。
+     * Copies from a byte array with the platform default encoding to a file with the specified encoding.
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング
-     * @return コピーした文字数
+     * @param in the byte array (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final byte[] in, final File out, final String encoding) {
         assertArgumentNotNull("in", in);
@@ -1065,17 +973,13 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングのバイト配列から指定されたエンコーディングのファイルへコピーします。
+     * Copies from a byte array with the specified encoding to a file with the specified encoding.
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param inputEncoding
-     *            入力のエンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @param outputEncoding
-     *            出力のエンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the byte array (must not be {@literal null})
+     * @param inputEncoding the input encoding (must not be {@literal null} or empty)
+     * @param out the file (must not be {@literal null})
+     * @param outputEncoding the output encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final byte[] in, final String inputEncoding, final File out, final String outputEncoding) {
         assertArgumentNotNull("in", in);
@@ -1096,13 +1000,11 @@ public abstract class CopyUtil {
     // from bytes to StringBuilder
     //
     /**
-     * プラットフォームのデフォルトエンコーディングでバイト配列から{@link StringBuilder}へコピーします。
+     * Copies from a byte array to a {@link StringBuilder} using the platform default encoding.
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the byte array (must not be {@literal null})
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final byte[] in, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -1113,15 +1015,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングのバイト配列からプラットフォームデフォルトエンコーディングの{@link StringBuilder}へコピーします。
+     * Copies from a byte array with the specified encoding to a {@link StringBuilder} using the platform default encoding.
      *
-     * @param in
-     *            バイト配列。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @param out
-     *            {@link StringBuilder}。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the byte array (must not be {@literal null})
+     * @param out the {@link StringBuilder} (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final byte[] in, final String encoding, final StringBuilder out) {
         assertArgumentNotNull("in", in);
@@ -1136,16 +1035,14 @@ public abstract class CopyUtil {
     // from String to OutputStream
     //
     /**
-     * プラットフォームのデフォルトエンコーディングで文字列を出力ストリームへコピーします。
+     * Copies a string to an output stream using the platform default encoding.
      * <p>
-     * 出力ストリームはクローズされません。
+     * The output stream is not closed.
      * </p>
      *
-     * @param in
-     *            文字列。{@literal null}であってはいけません
-     * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the string (must not be {@literal null})
+     * @param out the output stream (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final String in, final OutputStream out) {
         assertArgumentNotNull("in", in);
@@ -1156,18 +1053,15 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングで文字列を出力ストリームへコピーします。
+     * Copies a string to an output stream using the specified encoding.
      * <p>
-     * 出力ストリームはクローズされません。
+     * The output stream is not closed.
      * </p>
      *
-     * @param in
-     *            文字列。{@literal null}であってはいけません
-     * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the string (must not be {@literal null})
+     * @param out the output stream (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final String in, final OutputStream out, final String encoding) {
         assertArgumentNotNull("in", in);
@@ -1182,16 +1076,14 @@ public abstract class CopyUtil {
     // from String to Writer
     //
     /**
-     * 文字列をライターへコピーします。
+     * Copies a string to a writer.
      * <p>
-     * ライターはクローズされません。
+     * The writer is not closed.
      * </p>
      *
-     * @param in
-     *            文字列。{@literal null}であってはいけません
-     * @param out
-     *            ライター。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the string (must not be {@literal null})
+     * @param out the writer (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final String in, final Writer out) {
         assertArgumentNotNull("in", in);
@@ -1204,13 +1096,11 @@ public abstract class CopyUtil {
     // from String to File
     //
     /**
-     * プラットフォームのデフォルトエンコーディングで文字列をファイルへコピーします。
+     * Copies a string to a file using the platform default encoding.
      *
-     * @param in
-     *            文字列。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @return コピーした文字数
+     * @param in the string (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @return the number of characters copied
      */
     public static int copy(final String in, final File out) {
         assertArgumentNotNull("in", in);
@@ -1225,15 +1115,12 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 指定されたエンコーディングで文字列をファイルへコピーします。
+     * Copies a string to a file using the specified encoding.
      *
-     * @param in
-     *            文字列。{@literal null}であってはいけません
-     * @param out
-     *            ファイル。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return コピーした文字数
+     * @param in the string (must not be {@literal null})
+     * @param out the file (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return the number of characters copied
      */
     public static int copy(final String in, final File out, final String encoding) {
         assertArgumentNotNull("in", in);
@@ -1252,16 +1139,14 @@ public abstract class CopyUtil {
     // internal methods
     //
     /**
-     * 入力ストリームの内容を出力ストリームにコピーします。
+     * Copies the contents of an input stream to an output stream.
      * <p>
-     * 入力ストリーム、出力ストリームともクローズされません。
+     * Neither the input stream nor the output stream is closed.
      * </p>
      *
-     * @param in
-     *            入力ストリーム
-     * @param out
-     *            出力ストリーム
-     * @return コピーしたバイト数
+     * @param in the input stream
+     * @param out the output stream
+     * @return the number of bytes copied
      */
     protected static int copyInternal(final InputStream in, final OutputStream out) {
         try {
@@ -1280,16 +1165,14 @@ public abstract class CopyUtil {
     }
 
     /**
-     * ファイル入力ストリームの内容を出力ストリームにコピーします。
+     * Copies the contents of a file input stream to an output stream.
      * <p>
-     * ファイル入力ストリーム、出力ストリームともクローズされません。
+     * Neither the file input stream nor the output stream is closed.
      * </p>
      *
-     * @param in
-     *            ファイル入力ストリーム
-     * @param out
-     *            出力ストリーム
-     * @return コピーしたバイト数
+     * @param in the file input stream
+     * @param out the output stream
+     * @return the number of bytes copied
      */
     protected static int copyInternal(final FileInputStream in, final OutputStream out) {
         try {
@@ -1311,16 +1194,14 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 入力ストリームの内容をファイル出力ストリームにコピーします。
+     * Copies the contents of an input stream to a file output stream.
      * <p>
-     * 入力ストリーム、ファイル出力ストリームともクローズされません。
+     * Neither the input stream nor the file output stream is closed.
      * </p>
      *
-     * @param in
-     *            入力ストリーム
-     * @param out
-     *            ファイル出力ストリーム
-     * @return コピーしたバイト数
+     * @param in the input stream
+     * @param out the file output stream
+     * @return the number of bytes copied
      */
     protected static int copyInternal(final InputStream in, final FileOutputStream out) {
         try {
@@ -1343,16 +1224,14 @@ public abstract class CopyUtil {
     }
 
     /**
-     * ファイル入力ストリームの内容をファイル出力ストリームにコピーします。
+     * Copies the contents of a file input stream to a file output stream.
      * <p>
-     * ファイル入力ストリーム、ファイル出力ストリームともクローズされません。
+     * Neither the file input stream nor the file output stream is closed.
      * </p>
      *
-     * @param in
-     *            ファイル入力ストリーム
-     * @param out
-     *            ファイル出力ストリーム
-     * @return コピーしたバイト数
+     * @param in the file input stream
+     * @param out the file output stream
+     * @return the number of bytes copied
      */
     protected static int copyInternal(final FileInputStream in, final FileOutputStream out) {
         final FileChannel ic = in.getChannel();
@@ -1361,16 +1240,14 @@ public abstract class CopyUtil {
     }
 
     /**
-     * リーダーの内容をライターにコピーします。
+     * Copies the contents of a reader to a writer.
      * <p>
-     * リーダー、ライターともクローズされません。
+     * Neither the reader nor the writer is closed.
      * </p>
      *
-     * @param in
-     *            リーダー
-     * @param out
-     *            ライター
-     * @return コピーした文字数
+     * @param in the reader
+     * @param out the writer
+     * @return the number of characters copied
      */
     protected static int copyInternal(final Reader in, final Writer out) {
         try {
@@ -1389,13 +1266,11 @@ public abstract class CopyUtil {
     }
 
     /**
-     * リーダーの内容を{@link StringBuilder}にコピーします。
+     * Copies the contents of a reader to a {@link StringBuilder}.
      *
-     * @param in
-     *            リーダー
-     * @param out
-     *            {@link StringBuilder}
-     * @return コピーした文字数
+     * @param in the reader
+     * @param out the {@link StringBuilder}
+     * @return the number of characters copied
      */
     protected static int copyInternal(final Reader in, final StringBuilder out) {
         try {
@@ -1413,11 +1288,10 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 必要があれば入力ストリームを{@link BufferedInputStream}でラップします。
+     * Wraps the input stream with a {@link BufferedInputStream} if necessary.
      *
-     * @param is
-     *            入力ストリーム
-     * @return ラップされた入力ストリーム
+     * @param is the input stream
+     * @return the wrapped input stream
      */
     protected static InputStream wrap(final InputStream is) {
         if (is instanceof BufferedInputStream) {
@@ -1430,11 +1304,10 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 必要があれば出力ストリームを{@link BufferedOutputStream}でラップします。
+     * Wraps the output stream with a {@link BufferedOutputStream} if necessary.
      *
-     * @param os
-     *            出力ストリーム
-     * @return ラップされた出力ストリーム
+     * @param os the output stream
+     * @return the wrapped output stream
      */
     protected static OutputStream wrap(final OutputStream os) {
         if (os instanceof BufferedOutputStream) {
@@ -1447,11 +1320,10 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 必要があればリーダーを{@link BufferedReader}でラップします。
+     * Wraps the reader with a {@link BufferedReader} if necessary.
      *
-     * @param reader
-     *            リーダー
-     * @return ラップされたリーダー
+     * @param reader the reader
+     * @return the wrapped reader
      */
     protected static Reader wrap(final Reader reader) {
         if (reader instanceof BufferedReader) {
@@ -1464,11 +1336,10 @@ public abstract class CopyUtil {
     }
 
     /**
-     * 必要があればライターを{@link BufferedWriter}でラップします。
+     * Wraps the writer with a {@link BufferedWriter} if necessary.
      *
-     * @param writer
-     *            ライター
-     * @return ラップされたライター
+     * @param writer the writer
+     * @return the wrapped writer
      */
     protected static Writer wrap(final Writer writer) {
         if (writer instanceof BufferedWriter) {

--- a/src/main/java/org/codelibs/core/io/FileUtil.java
+++ b/src/main/java/org/codelibs/core/io/FileUtil.java
@@ -37,13 +37,13 @@ import org.codelibs.core.nio.ChannelUtil;
 import org.codelibs.core.timer.TimeoutManager;
 
 /**
- * {@link File}を扱うユーティリティ・クラスです。
+ * Utility class for handling {@link File}.
  *
  * @author higa
  */
 public abstract class FileUtil {
 
-    /** UTF-8のエンコーディング名 */
+    /** The encoding name for UTF-8. */
     private static final String UTF8 = "UTF-8";
 
     /** Default Buffer Size */
@@ -53,11 +53,10 @@ public abstract class FileUtil {
     protected static final int MAX_BUF_SIZE = 10 * 1024 * 1024; // 10m
 
     /**
-     * この抽象パス名の正規の形式を返します。
+     * Returns the canonical path string for this abstract pathname.
      *
-     * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return この抽象パス名と同じファイルまたはディレクトリを示す正規パス名文字列
+     * @param file the file (must not be {@literal null})
+     * @return the canonical pathname string representing the same file or directory as this abstract pathname
      */
     public static String getCanonicalPath(final File file) {
         assertArgumentNotNull("file", file);
@@ -70,11 +69,10 @@ public abstract class FileUtil {
     }
 
     /**
-     * この抽象パス名を<code>file:</code> URLに変換します。
+     * Converts this abstract pathname to a <code>file:</code> URL.
      *
-     * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return ファイルURLを表すURLオブジェクト
+     * @param file the file (must not be {@literal null})
+     * @return a URL object representing the file URL
      */
     public static URL toURL(final File file) {
         assertArgumentNotNull("file", file);
@@ -87,11 +85,11 @@ public abstract class FileUtil {
     }
 
     /**
-     * ファイルの内容をバイト配列に読み込んで返します。
+     * Reads the contents of a file into a byte array and returns it.
      *
      * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return ファイルの内容を読み込んだバイト配列
+     *            The file. Must not be {@literal null}.
+     * @return A byte array containing the contents of the file.
      */
     public static byte[] readBytes(final File file) {
         assertArgumentNotNull("file", file);
@@ -108,11 +106,11 @@ public abstract class FileUtil {
     }
 
     /**
-     * デフォルトエンコーディングでファイルからテキストを読み込みます。
+     * Reads text from a file using the default encoding.
      *
      * @param path
-     *            ファイルのパス。{@literal null}や空文字列であってはいけません
-     * @return 読み込んだテキスト
+     *            The file path. Must not be {@literal null} or empty.
+     * @return The text read from the file.
      */
     public static String readText(final String path) {
         assertArgumentNotEmpty("path", path);
@@ -120,11 +118,11 @@ public abstract class FileUtil {
     }
 
     /**
-     * デフォルトエンコーディングでファイルからテキストを読み込みます。
+     * Reads text from a file using the default encoding.
      *
      * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return 読み込んだテキスト
+     *            The file. Must not be {@literal null}.
+     * @return The text read from the file.
      */
     public static String readText(final File file) {
         assertArgumentNotNull("file", file);
@@ -132,13 +130,13 @@ public abstract class FileUtil {
     }
 
     /**
-     * 指定のエンコーディングでファイルからテキストを読み込みます。
+     * Reads text from a file with the specified encoding.
      *
      * @param path
-     *            パス。{@literal null}や空文字列であってはいけません
+     *            The file path. Must not be {@literal null} or empty.
      * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return 読み込んだテキスト
+     *            The encoding. Must not be {@literal null} or empty.
+     * @return The text read from the file.
      */
     public static String readText(final String path, final String encoding) {
         assertArgumentNotEmpty("path", path);
@@ -158,13 +156,13 @@ public abstract class FileUtil {
     }
 
     /**
-     * 指定のエンコーディングでファイルからテキストを読み込みます。
+     * Reads text from a file with the specified encoding.
      *
      * @param file
-     *            ファイル。{@literal null}であってはいけません
+     *            The file. Must not be {@literal null}.
      * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return 読み込んだテキスト
+     *            The encoding. Must not be {@literal null} or empty.
+     * @return The text read from the file.
      */
     public static String readText(final File file, final String encoding) {
         assertArgumentNotNull("file", file);
@@ -180,11 +178,11 @@ public abstract class FileUtil {
     }
 
     /**
-     * UTF8でファイルからテキストを読み込みます。
+     * Reads text from a file in UTF-8 encoding.
      *
      * @param path
-     *            パス。{@literal null}や空文字列であってはいけません
-     * @return 読み込んだテキスト
+     *            The path. Must not be {@literal null} or empty.
+     * @return The text read from the file.
      */
     public static String readUTF8(final String path) {
         assertArgumentNotEmpty("path", path);
@@ -192,11 +190,11 @@ public abstract class FileUtil {
     }
 
     /**
-     * UTF8でファイルからテキストを読み込みます。
+     * Reads text from a file in UTF-8 encoding.
      *
      * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return 読み込んだテキスト
+     *            The file. Must not be {@literal null}.
+     * @return The text read from the file.
      */
     public static String readUTF8(final File file) {
         assertArgumentNotNull("file", file);
@@ -204,13 +202,13 @@ public abstract class FileUtil {
     }
 
     /**
-     * リーダーから読み込んだ内容を文字列で返します。
+     * Returns the contents read from the reader as a string.
      *
      * @param reader
-     *            リーダー
+     *            the reader
      * @param initialCapacity
-     *            バッファの初期容量
-     * @return リーダーから読み込んだ文字列
+     *            the initial buffer capacity
+     * @return the string read from the reader
      */
     protected static String read(final Reader reader, final int initialCapacity) {
         int bufferSize;

--- a/src/main/java/org/codelibs/core/io/InputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/io/InputStreamUtil.java
@@ -26,21 +26,20 @@ import java.io.InputStream;
 import org.codelibs.core.exception.IORuntimeException;
 
 /**
- * {@link InputStream}用のユーティリティクラスです。
+ * Utility class for {@link InputStream}.
  *
  * @author higa
  */
 public abstract class InputStreamUtil {
 
-    /** デフォルトのバッファサイズ */
+    /** Default buffer size. */
     private static final int BUF_SIZE = 4096;
 
     /**
-     * {@link FileInputStream}を作成します。
+     * Creates a {@link FileInputStream}.
      *
-     * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return ファイルから入力する{@link FileInputStream}
+     * @param file the file (must not be {@literal null})
+     * @return a {@link FileInputStream} to read from the file
      * @see FileInputStream#FileInputStream(File)
      */
     public static FileInputStream create(final File file) {
@@ -54,14 +53,13 @@ public abstract class InputStreamUtil {
     }
 
     /**
-     * {@link InputStream}からbyteの配列を取得します。
+     * Gets a byte array from an {@link InputStream}.
      * <p>
-     * 入力ストリームはクローズされません。
+     * The input stream is not closed.
      * </p>
      *
-     * @param is
-     *            入力ストリーム。{@literal null}であってはいけません
-     * @return byteの配列
+     * @param is the input stream (must not be {@literal null})
+     * @return the byte array
      */
     public static final byte[] getBytes(final InputStream is) {
         assertArgumentNotNull("is", is);
@@ -72,11 +70,10 @@ public abstract class InputStreamUtil {
     }
 
     /**
-     * {@link InputStream#available()}の例外処理をラップしたメソッドです。
+     * A method that wraps exception handling for {@link InputStream#available()}.
      *
-     * @param is
-     *            入力ストリーム。{@literal null}であってはいけません
-     * @return 可能なサイズ
+     * @param is the input stream (must not be {@literal null})
+     * @return the available size
      */
     public static int available(final InputStream is) {
         assertArgumentNotNull("is", is);
@@ -89,10 +86,9 @@ public abstract class InputStreamUtil {
     }
 
     /**
-     * {@link InputStream}をリセットします。
+     * Resets the {@link InputStream}.
      *
-     * @param is
-     *            入力ストリーム。{@literal null}であってはいけません
+     * @param is the input stream (must not be {@literal null})
      * @see InputStream#reset()
      */
     public static void reset(final InputStream is) {

--- a/src/main/java/org/codelibs/core/io/LineIterator.java
+++ b/src/main/java/org/codelibs/core/io/LineIterator.java
@@ -25,9 +25,9 @@ import java.util.NoSuchElementException;
 import org.codelibs.core.exception.ClUnsupportedOperationException;
 
 /**
- * {@link BufferedReader}から読み込んだ行単位の文字列を反復する{@link Iterator}です。
+ * An {@link Iterator} that iterates over lines read from a {@link BufferedReader}.
  * <p>
- * 次のように使います．
+ * Usage example:
  * </p>
  *
  * <pre>
@@ -43,21 +43,21 @@ import org.codelibs.core.exception.ClUnsupportedOperationException;
  */
 public class LineIterator implements Iterator<String> {
 
-    /** {@link #line}が空であることを示す{@literal String}オブジェクト */
+    /** String object indicating that {@link #line} is empty */
     protected static final String EMPTY = new String();
 
     /** {@link BufferedReader} */
     protected final BufferedReader reader;
 
-    /** 読み込み済みの文字列 */
+    /** The line that has been read */
     protected String line = EMPTY;
 
     /**
-     * for each構文で使用するために{@link LineIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps a {@link LineIterator} for use in enhanced for-loops.
      *
      * @param reader
-     *            文字列を読み込む{@link Reader}。{@literal null}であってはいけません
-     * @return {@link LineIterator}をラップした{@link Iterable}
+     *            The {@link Reader} to read strings from. Must not be {@literal null}.
+     * @return An {@link Iterable} that wraps a {@link LineIterator}.
      */
     public static Iterable<String> iterable(final Reader reader) {
         assertArgumentNotNull("reader", reader);
@@ -65,11 +65,11 @@ public class LineIterator implements Iterator<String> {
     }
 
     /**
-     * for each構文で使用するために{@link LineIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps a {@link LineIterator} for use in enhanced for-loops.
      *
      * @param reader
-     *            文字列を読み込む{@link BufferedReader}。{@literal null}であってはいけません
-     * @return {@link LineIterator}をラップした{@link Iterable}
+     *            The {@link BufferedReader} to read strings from. Must not be {@literal null}.
+     * @return An {@link Iterable} that wraps a {@link LineIterator}.
      */
     public static Iterable<String> iterable(final BufferedReader reader) {
         assertArgumentNotNull("reader", reader);
@@ -78,10 +78,10 @@ public class LineIterator implements Iterator<String> {
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
      * @param reader
-     *            文字列を読み込む{@link Reader}。{@literal null}であってはいけません
+     *            The {@link Reader} to read strings from. Must not be {@literal null}.
      */
     public LineIterator(final Reader reader) {
         assertArgumentNotNull("reader", reader);
@@ -89,10 +89,10 @@ public class LineIterator implements Iterator<String> {
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
      * @param reader
-     *            文字列を読み込む{@link BufferedReader}。{@literal null}であってはいけません
+     *            The {@link BufferedReader} to read strings from. Must not be {@literal null}.
      */
     public LineIterator(final BufferedReader reader) {
         assertArgumentNotNull("reader", reader);

--- a/src/main/java/org/codelibs/core/io/OutputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/io/OutputStreamUtil.java
@@ -25,18 +25,17 @@ import java.io.OutputStream;
 import org.codelibs.core.exception.IORuntimeException;
 
 /**
- * {@link OutputStream}用のユーティリティクラスです。
+ * Utility class for {@link OutputStream} operations.
  *
  * @author shot
  */
 public abstract class OutputStreamUtil {
 
     /**
-     * {@link FileOutputStream}を作成します。
+     * Creates a {@link FileOutputStream}.
      *
-     * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return ファイルへ出力する{@link FileOutputStream}
+     * @param file the file (must not be {@literal null})
+     * @return a {@link FileOutputStream} to output to the file
      * @see FileOutputStream#FileOutputStream(File)
      */
     public static FileOutputStream create(final File file) {
@@ -50,10 +49,9 @@ public abstract class OutputStreamUtil {
     }
 
     /**
-     * {@link OutputStream}をflushします。
+     * Flushes the {@link OutputStream}.
      *
-     * @param out
-     *            出力ストリーム
+     * @param out the output stream
      */
     public static void flush(final OutputStream out) {
         if (out == null) {

--- a/src/main/java/org/codelibs/core/io/PropertiesUtil.java
+++ b/src/main/java/org/codelibs/core/io/PropertiesUtil.java
@@ -32,22 +32,20 @@ import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.net.URLUtil;
 
 /**
- * {@link Properties}用のユーティリティクラスです。
+ * Utility class for {@link Properties} operations.
  *
  * @author higa
  */
 public abstract class PropertiesUtil {
 
     /**
-     * {@link Properties#load(InputStream)}の例外処理をラップします。
+     * Wraps exception handling for {@link Properties#load(InputStream)}.
      * <p>
-     * 入力ストリームはクローズされません。
+     * The input stream is not closed.
      * </p>
      *
-     * @param props
-     *            プロパティセット。{@literal null}であってはいけません
-     * @param in
-     *            入力ストリーム。{@literal null}であってはいけません
+     * @param props the property set (must not be {@literal null})
+     * @param in the input stream (must not be {@literal null})
      */
     public static void load(final Properties props, final InputStream in) {
         assertArgumentNotNull("props", props);
@@ -61,15 +59,13 @@ public abstract class PropertiesUtil {
     }
 
     /**
-     * {@link Properties#load(Reader)}の例外処理をラップします。
+     * Wraps exception handling for {@link Properties#load(Reader)}.
      * <p>
-     * 入力リーダはクローズされません。
+     * The input reader is not closed.
      * </p>
      *
-     * @param props
-     *            プロパティセット。{@literal null}であってはいけません
-     * @param reader
-     *            入力リーダ。{@literal null}であってはいけません
+     * @param props the property set (must not be {@literal null})
+     * @param reader the input reader (must not be {@literal null})
      */
     public static void load(final Properties props, final Reader reader) {
         assertArgumentNotNull("props", props);
@@ -83,14 +79,14 @@ public abstract class PropertiesUtil {
     }
 
     /**
-     * 指定のエンコーディングでファイルを読み込んで{@link Properties}にロードします（例外処理はラップします）。
+     * Loads the specified file into the {@link Properties} using the given encoding (wraps exception handling).
      *
      * @param props
-     *            プロパティセット。{@literal null}であってはいけません
+     *            Property set. Must not be {@literal null}.
      * @param file
-     *            ファイル。{@literal null}であってはいけません
+     *            File. Must not be {@literal null}.
      * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
+     *            Encoding. Must not be {@literal null} or empty.
      */
     public static void load(final Properties props, final File file, final String encoding) {
         assertArgumentNotNull("props", props);
@@ -109,24 +105,24 @@ public abstract class PropertiesUtil {
     }
 
     /**
-     * プラットフォームデフォルトエンコーディングでファイルを読み込んで{@link Properties}にロードします（例外処理はラップします）。
+     * Loads the specified file into the {@link Properties} using the platform default encoding (wraps exception handling).
      *
      * @param props
-     *            プロパティセット。{@literal null}であってはいけません
+     *            Property set. Must not be {@literal null}.
      * @param file
-     *            ファイル。{@literal null}であってはいけません
+     *            File. Must not be {@literal null}.
      */
     public static void load(final Properties props, final File file) {
         load(props, file, Charset.defaultCharset().name());
     }
 
     /**
-     * {@link URL}を読み込んで{@link Properties}にロードします（例外処理はラップします）。
+     * Loads the specified {@link URL} into the {@link Properties} (wraps exception handling).
      *
      * @param props
-     *            プロパティセット。{@literal null}であってはいけません
+     *            Property set. Must not be {@literal null}.
      * @param url
-     *            URL。{@literal null}であってはいけません
+     *            URL. Must not be {@literal null}.
      */
     public static void load(final Properties props, final URL url) {
         assertArgumentNotNull("props", props);
@@ -144,12 +140,12 @@ public abstract class PropertiesUtil {
     }
 
     /**
-     * コンテキストクラスローダからリソースを読み込んで{@link Properties}にロードします（例外処理はラップします）。
+     * Loads a resource from the context class loader into the {@link Properties} (wraps exception handling).
      *
      * @param props
-     *            プロパティセット。{@literal null}であってはいけません
+     *            Property set. Must not be {@literal null}.
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
+     *            Resource path. Must not be {@literal null} or empty.
      */
     public static void load(final Properties props, final String path) {
         assertArgumentNotNull("props", props);
@@ -159,18 +155,18 @@ public abstract class PropertiesUtil {
     }
 
     /**
-     * {@link Properties#store(OutputStream, String)}の例外処理をラップします。
+     * Wraps exception handling for {@link Properties#store(OutputStream, String)}.
      *
      * <p>
-     * 出力ストリームはクローズされません。
+     * The output stream is not closed.
      * </p>
      *
      * @param props
-     *            プロパティセット。{@literal null}であってはいけません
+     *            Property set. Must not be {@literal null}.
      * @param out
-     *            出力ストリーム。{@literal null}であってはいけません
+     *            Output stream. Must not be {@literal null}.
      * @param comments
-     *            コメント
+     *            Comments.
      */
     public static void store(final Properties props, final OutputStream out, final String comments) {
         assertArgumentNotNull("props", props);
@@ -184,18 +180,18 @@ public abstract class PropertiesUtil {
     }
 
     /**
-     * {@link Properties#store(Writer, String)}の例外処理をラップします。
+     * Wraps exception handling for {@link Properties#store(Writer, String)}.
      *
      * <p>
-     * 出力ライタはクローズされません。
+     * The output writer is not closed.
      * </p>
      *
      * @param props
-     *            プロパティセット。{@literal null}であってはいけません
+     *            Property set. Must not be {@literal null}.
      * @param writer
-     *            出力ライタ。{@literal null}であってはいけません
+     *            Output writer. Must not be {@literal null}.
      * @param comments
-     *            コメント
+     *            Comments.
      */
     public static void store(final Properties props, final Writer writer, final String comments) {
         assertArgumentNotNull("props", props);
@@ -209,16 +205,16 @@ public abstract class PropertiesUtil {
     }
 
     /**
-     * 指定のエンコーディングでファイルを書き出して{@link Properties}をストアします（例外処理はラップします）。
+     * Stores the {@link Properties} to a file with the specified encoding (wraps exception handling).
      *
      * @param props
-     *            プロパティセット。{@literal null}であってはいけません
+     *            Property set. Must not be {@literal null}.
      * @param file
-     *            ファイル。{@literal null}であってはいけません
+     *            File. Must not be {@literal null}.
      * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
+     *            Encoding. Must not be {@literal null} or empty.
      * @param comments
-     *            コメント
+     *            Comments.
      */
     public static void store(final Properties props, final File file, final String encoding, final String comments) {
         assertArgumentNotNull("props", props);
@@ -236,14 +232,14 @@ public abstract class PropertiesUtil {
     }
 
     /**
-     * プラットフォームデフォルトエンコーディングでファイルを書き出して{@link Properties}をストアします（例外処理はラップします）。
+     * Stores the {@link Properties} to a file using the platform default encoding (wraps exception handling).
      *
      * @param props
-     *            プロパティセット。{@literal null}であってはいけません
+     *            Property set. Must not be {@literal null}.
      * @param file
-     *            ファイル。{@literal null}であってはいけません
+     *            File. Must not be {@literal null}.
      * @param comments
-     *            コメント
+     *            Comments.
      */
     public static void store(final Properties props, final File file, final String comments) {
         store(props, file, Charset.defaultCharset().name(), comments);

--- a/src/main/java/org/codelibs/core/io/ReaderUtil.java
+++ b/src/main/java/org/codelibs/core/io/ReaderUtil.java
@@ -30,23 +30,23 @@ import java.io.Reader;
 import org.codelibs.core.exception.IORuntimeException;
 
 /**
- * {@link Reader}用のユーティリティクラスです。
+ * Utility class for {@link Reader} operations.
  *
  * @author higa
  */
 public abstract class ReaderUtil {
 
-    /** デフォルトのバッファサイズ */
+    /** Default buffer size */
     private static final int BUF_SIZE = 4096;
 
     /**
-     * 指定のエンコーディングでファイルから入力する{@link Reader}を作成します。
+     * Creates a {@link Reader} to read from a file with the specified encoding.
      *
      * @param is
-     *            入力ストリーム。{@literal null}であってはいけません
+     *            the input stream (must not be {@literal null})
      * @param encoding
-     *            入力ストリームのエンコーディング。{@literal null}や空文字列であってはいけません
-     * @return ファイルかへ出力する{@link Reader}
+     *            the encoding of the input stream (must not be {@literal null} or empty)
+     * @return a {@link Reader} to read from the file
      */
     public static InputStreamReader create(final InputStream is, final String encoding) {
         assertArgumentNotNull("is", is);
@@ -60,11 +60,11 @@ public abstract class ReaderUtil {
     }
 
     /**
-     * プラットフォームデフォルトエンコーディングでファイルから入力する{@link Reader}を作成します。
+     * Creates a {@link Reader} to read from a file with the default encoding.
      *
      * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return ファイルから入力する{@link Reader}
+     *            the file (must not be {@literal null})
+     * @return a {@link Reader} to read from the file
      */
     public static Reader create(final File file) {
         assertArgumentNotNull("file", file);
@@ -77,13 +77,13 @@ public abstract class ReaderUtil {
     }
 
     /**
-     * 指定のエンコーディングでファイルから入力する{@link Reader}を作成します。
+     * Creates a {@link Reader} to read from a file with the specified encoding.
      *
      * @param file
-     *            ファイル。{@literal null}であってはいけません
+     *            the file (must not be {@literal null})
      * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return ファイルから入力する{@link Reader}
+     *            the encoding (must not be {@literal null} or empty)
+     * @return a {@link Reader} to read from the file
      */
     public static Reader create(final File file, final String encoding) {
         assertArgumentNotNull("file", file);
@@ -97,11 +97,11 @@ public abstract class ReaderUtil {
     }
 
     /**
-     * {@link BufferedReader}から一行読み込んで返します。
+     * Reads a single line from the given {@link BufferedReader}.
      *
      * @param reader
-     *            {@link BufferedReader}。{@literal null}であってはいけません
-     * @return 一行の文字列。終端に達した場合は{@literal null}
+     *            the {@link BufferedReader} (must not be {@literal null})
+     * @return a line of text, or {@literal null} if the end of the stream has been reached
      * @see BufferedReader#readLine()
      */
     public static String readLine(final BufferedReader reader) {
@@ -115,14 +115,14 @@ public abstract class ReaderUtil {
     }
 
     /**
-     * {@link Reader}からテキストを読み込みます。
+     * Reads text from the given {@link Reader}.
      * <p>
-     * {@link Reader}はクローズされません。
+     * The {@link Reader} is not closed by this method.
      * </p>
      *
      * @param reader
-     *            読み込み文字ストリーム。{@literal null}であってはいけません
-     * @return テキスト
+     *            the character input stream to read from (must not be {@literal null})
+     * @return the text read from the reader
      */
     public static String readText(final Reader reader) {
         assertArgumentNotNull("reader", reader);

--- a/src/main/java/org/codelibs/core/io/ResourceBundleUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceBundleUtil.java
@@ -28,17 +28,16 @@ import java.util.ResourceBundle;
 import org.codelibs.core.misc.LocaleUtil;
 
 /**
- * {@link ResourceBundle}用のユーティリティクラスです。
+ * Utility class for {@link ResourceBundle} operations.
  *
  * @author higa
  */
 public abstract class ResourceBundleUtil {
 
     /**
-     * バンドルを返します。 見つからない場合は、<code>null</code>を返します。
+     * Returns the bundle. Returns <code>null</code> if not found.
      *
-     * @param name
-     *            リソースバンドの名前。{@literal null}や空文字列であってはいけません
+     * @param name the resource bundle name (must not be {@literal null} or empty)
      * @return {@link ResourceBundle}
      * @see ResourceBundle#getBundle(String)
      */
@@ -53,12 +52,10 @@ public abstract class ResourceBundleUtil {
     }
 
     /**
-     * バンドルを返します。 見つからない場合は、<code>null</code>を返します。
+     * Returns the bundle. Returns <code>null</code> if not found.
      *
-     * @param name
-     *            リソースバンドの名前。{@literal null}や空文字列であってはいけません
-     * @param locale
-     *            ロケール
+     * @param name the resource bundle name (must not be {@literal null} or empty)
+     * @param locale the locale
      * @return {@link ResourceBundle}
      * @see ResourceBundle#getBundle(String, Locale)
      */
@@ -73,14 +70,11 @@ public abstract class ResourceBundleUtil {
     }
 
     /**
-     * バンドルを返します。 見つからない場合は、<code>null</code>を返します。
+     * Returns the bundle. Returns <code>null</code> if not found.
      *
-     * @param name
-     *            リソースバンドルの名前。{@literal null}や空文字列であってはいけません
-     * @param locale
-     *            ロケール
-     * @param classLoader
-     *            クラスローダ。{@literal null}や空文字列であってはいけません
+     * @param name the resource bundle name (must not be {@literal null} or empty)
+     * @param locale the locale
+     * @param classLoader the class loader (must not be {@literal null} or empty)
      * @return {@link ResourceBundle}
      * @see ResourceBundle#getBundle(String, Locale, ClassLoader)
      */
@@ -96,13 +90,11 @@ public abstract class ResourceBundleUtil {
     }
 
     /**
-     * リソースバンドルから指定されたキーの文字列を返します。
+     * Returns the string for the specified key from the resource bundle.
      *
-     * @param bundle
-     *            リソースバンドル。{@literal null}や空文字列であってはいけません
-     * @param key
-     *            キー
-     * @return 指定されたキーの文字列。{@literal null}や空文字列であってはいけません
+     * @param bundle the resource bundle (must not be {@literal null} or empty)
+     * @param key the key
+     * @return the string for the specified key (must not be {@literal null} or empty)
      * @see ResourceBundle#getString(String)
      */
     public static String getString(final ResourceBundle bundle, final String key) {
@@ -117,10 +109,9 @@ public abstract class ResourceBundleUtil {
     }
 
     /**
-     * リソースバンドルを{@link Map}に変換します。
+     * Converts the resource bundle to a {@link Map}.
      *
-     * @param bundle
-     *            リソースバンドル。{@literal null}であってはいけません
+     * @param bundle the resource bundle (must not be {@literal null})
      * @return {@link Map}
      */
     public static final Map<String, String> convertMap(final ResourceBundle bundle) {
@@ -136,12 +127,10 @@ public abstract class ResourceBundleUtil {
     }
 
     /**
-     * リソースバンドルを{@link Map}に変換して返します。
+     * Converts the resource bundle to a {@link Map} and returns it.
      *
-     * @param name
-     *            リソースバンドルの名前。{@literal null}や空文字列であってはいけません
-     * @param locale
-     *            ロケール
+     * @param name the resource bundle name (must not be {@literal null} or empty)
+     * @param locale the locale
      * @return {@link Map}
      */
     public static final Map<String, String> convertMap(final String name, final Locale locale) {
@@ -152,13 +141,10 @@ public abstract class ResourceBundleUtil {
     }
 
     /**
-     * {@literal locale}が{@literal null}でなければ{@literal locale}を、{@literal null}
-     * ならデフォルトのロケールを返します。
+     * Returns the {@literal locale} if not {@literal null}, otherwise returns the default locale.
      *
-     * @param locale
-     *            ロケール
-     * @return {@literal locale}が{@literal null}でなければ{@literal locale}を、
-     *         {@literal null}ならデフォルトのロケールを返します。
+     * @param locale the locale
+     * @return the {@literal locale} if not {@literal null}, otherwise the default locale
      */
     protected static Locale getLocale(final Locale locale) {
         if (locale != null) {

--- a/src/main/java/org/codelibs/core/io/ResourceHandler.java
+++ b/src/main/java/org/codelibs/core/io/ResourceHandler.java
@@ -18,19 +18,17 @@ package org.codelibs.core.io;
 import java.io.InputStream;
 
 /**
- * リソースを処理するハンドラのインターフェースです。
+ * Interface for handlers that process resources.
  *
  * @author taedium
  */
 public interface ResourceHandler {
 
     /**
-     * リソースを処理します。
+     * Processes a resource.
      *
-     * @param path
-     *            パス
-     * @param is
-     *            リソースを読み込むための{@link InputStream}
+     * @param path the path
+     * @param is the {@link InputStream} to read the resource
      */
     void processResource(String path, InputStream is);
 

--- a/src/main/java/org/codelibs/core/io/ResourceTraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceTraversalUtil.java
@@ -31,7 +31,7 @@ import org.codelibs.core.jar.JarFileUtil;
 import org.codelibs.core.zip.ZipInputStreamUtil;
 
 /**
- * リソースをトラバースするためのクラスです。
+ * Class for traversing resources.
  *
  * @author taedium
  * @see ResourceHandler
@@ -40,12 +40,10 @@ import org.codelibs.core.zip.ZipInputStreamUtil;
 public abstract class ResourceTraversalUtil {
 
     /**
-     * ファイルシステムに含まれるリソースをトラバースします。
+     * Traverses resources contained in the file system.
      *
-     * @param rootDir
-     *            ルートディレクトリ。{@literal null}であってはいけません
-     * @param handler
-     *            リソースを処理するハンドラ。{@literal null}であってはいけません
+     * @param rootDir the root directory (must not be {@literal null})
+     * @param handler the handler to process resources (must not be {@literal null})
      */
     public static void forEach(final File rootDir, final ResourceHandler handler) {
         assertArgumentNotNull("rootDir", rootDir);
@@ -55,21 +53,14 @@ public abstract class ResourceTraversalUtil {
     }
 
     /**
-     * ファイルシステムに含まれるリソースをトラバースします。
+     * Traverses resources contained in the file system.
      * <p>
-     * ルートディレクトリ以下のリソースのうち、ベースディレクトリで始まるパスを持つリソースがトラバースの対象となります。
-     * リソースを処理するハンドラには、ルートディレクトリからの相対パスが渡されます。 例えばルートディレクトリが
-     * <code>/aaa/bbb</code>で、ベースディレクトリが<code>ccc/ddd</code>の場合、
-     * <code>/aaa/bbb/ccc/ddd/eee.txt</code>というリソースが存在すると、 ハンドラには
-     * <code>ccc/ddd/eee.txt</code>というパスが渡されます。
+     * Of the resources under the root directory, only those with paths starting with the base directory are traversed. The handler receives the relative path from the root directory. For example, if the root directory is <code>/aaa/bbb</code> and the base directory is <code>ccc/ddd</code>, and the resource <code>/aaa/bbb/ccc/ddd/eee.txt</code> exists, the handler receives the path <code>ccc/ddd/eee.txt</code>.
      * </p>
      *
-     * @param rootDir
-     *            ルートディレクトリ。{@literal null}であってはいけません
-     * @param baseDirectory
-     *            ベースディレクトリ
-     * @param handler
-     *            リソースを処理するハンドラ。{@literal null}であってはいけません
+     * @param rootDir the root directory (must not be {@literal null})
+     * @param baseDirectory the base directory
+     * @param handler the handler to process resources (must not be {@literal null})
      */
     public static void forEach(final File rootDir, final String baseDirectory, final ResourceHandler handler) {
         assertArgumentNotNull("rootDir", rootDir);
@@ -82,12 +73,12 @@ public abstract class ResourceTraversalUtil {
     }
 
     /**
-     * Jarファイル形式のファイルに含まれるリソースをトラバースします。
+     * Traverses resources contained in a Jar file.
      *
      * @param jarFile
-     *            jarファイル形式のファイル。{@literal null}であってはいけません
+     *            the Jar file (must not be {@literal null})
      * @param handler
-     *            リソースを処理するハンドラ。{@literal null}であってはいけません
+     *            the handler to process resources (must not be {@literal null})
      */
     public static void forEach(final JarFile jarFile, final ResourceHandler handler) {
         assertArgumentNotNull("jarFile", jarFile);
@@ -97,21 +88,21 @@ public abstract class ResourceTraversalUtil {
     }
 
     /**
-     * Jarファイル形式のファイルに含まれるリソースをトラバースします。
+     * Traverses resources contained in a Jar file.
      * <p>
-     * Jarファイル内のリソースのうち、接頭辞で始まるパスを持つリソースがトラバースの対象となります。
-     * リソースを処理するハンドラには、接頭辞を除くエントリ名が渡されます。 例えば接頭辞が <code>/aaa/bbb/</code>
-     * で、Jarファイル内に <code>/aaa/bbb/ccc/ddd/eee.txt</code>というリソースが存在すると、 ハンドラには
-     * <code>ccc/ddd/eee.txt</code>というパスが渡されます。
+     * Of the resources in the Jar file, only those with paths starting with the specified prefix are traversed.
+     * The handler receives the entry name with the prefix removed. For example, if the prefix is <code>/aaa/bbb/</code>
+     * and the Jar file contains a resource <code>/aaa/bbb/ccc/ddd/eee.txt</code>, the handler receives
+     * the path <code>ccc/ddd/eee.txt</code>.
      * </p>
      *
      * @param jarFile
-     *            jarファイル形式のファイル。{@literal null}であってはいけません
+     *            the Jar file (must not be {@literal null})
      * @param prefix
-     *            トラバースするリソースの名前が含む接頭辞。{@literal null}であってはいけません。
-     *            空文字列でない場合はスラッシュ('/')で終了していなければなりません
+     *            the prefix that resource names must start with (must not be {@literal null}).
+     *            If not empty, must end with a slash ('/').
      * @param handler
-     *            リソースを処理するハンドラ。{@literal null}であってはいけません
+     *            the handler to process resources (must not be {@literal null})
      */
     public static void forEach(final JarFile jarFile, final String prefix, final ResourceHandler handler) {
         assertArgumentNotNull("jarFile", jarFile);
@@ -136,12 +127,12 @@ public abstract class ResourceTraversalUtil {
     }
 
     /**
-     * ZIPファイル形式の入力ストリームに含まれるリソースをトラバースします。
+     * Traverses resources contained in a ZIP file input stream.
      *
      * @param zipInputStream
-     *            ZIPファイル形式の入力ストリーム。{@literal null}であってはいけません
+     *            the ZIP file input stream (must not be {@literal null})
      * @param handler
-     *            リソースを処理するハンドラ。{@literal null}であってはいけません
+     *            the handler to process resources (must not be {@literal null})
      */
     public static void forEach(final ZipInputStream zipInputStream, final ResourceHandler handler) {
         assertArgumentNotNull("zipInputStream", zipInputStream);
@@ -151,21 +142,21 @@ public abstract class ResourceTraversalUtil {
     }
 
     /**
-     * ZIPファイル形式の入力ストリームに含まれるリソースをトラバースします。
+     * Traverses resources contained in a ZIP file input stream.
      * <p>
-     * 入力ストリーム内のリソースのうち、接頭辞で始まるパスを持つリソースがトラバースの対象となります。
-     * リソースを処理するハンドラには、接頭辞を除くエントリ名が渡されます。 例えば接頭辞が <code>/aaa/bbb/</code>
-     * で、入力ストリーム内に <code>/aaa/bbb/ccc/ddd/eee.txt</code>というリソースが存在すると、 ハンドラには
-     * <code>ccc/ddd/eee.txt</code>というパスが渡されます。
+     * Of the resources in the input stream, only those with paths starting with the specified prefix are traversed.
+     * The handler receives the entry name with the prefix removed. For example, if the prefix is <code>/aaa/bbb/</code>
+     * and the input stream contains a resource <code>/aaa/bbb/ccc/ddd/eee.txt</code>, the handler receives
+     * the path <code>ccc/ddd/eee.txt</code>.
      * </p>
      *
      * @param zipInputStream
-     *            ZIPファイル形式の入力ストリーム。{@literal null}であってはいけません
+     *            the ZIP file input stream (must not be {@literal null})
      * @param prefix
-     *            トラバースするリソースの名前が含む接頭辞。{@literal null}であってはいけません。
-     *            空文字列でない場合はスラッシュ('/')で終了していなければなりません
+     *            the prefix that resource names must start with (must not be {@literal null}).
+     *            If not empty, must end with a slash ('/').
      * @param handler
-     *            リソースを処理するハンドラ。{@literal null}であってはいけません
+     *            the handler to process resources (must not be {@literal null})
      */
     public static void forEach(final ZipInputStream zipInputStream, final String prefix, final ResourceHandler handler) {
         assertArgumentNotNull("zipInputStream", zipInputStream);
@@ -191,14 +182,14 @@ public abstract class ResourceTraversalUtil {
     }
 
     /**
-     * ファイルシステムに含まれるリソースをトラバースします。
+     * Traverses resources contained in the file system.
      *
      * @param rootDir
-     *            ルートディレクトリ
+     *            the root directory
      * @param baseDir
-     *            ベースディレクトリ
+     *            the base directory
      * @param handler
-     *            リソースを処理するハンドラ
+     *            the handler to process resources
      */
     protected static void traverseFileSystem(final File rootDir, final File baseDir, final ResourceHandler handler) {
         for (final File file : baseDir.listFiles()) {
@@ -219,13 +210,13 @@ public abstract class ResourceTraversalUtil {
     }
 
     /**
-     * ベースディレクトリを表す{@link File}を返します。
+     * Returns a {@link File} representing the base directory.
      *
      * @param rootDir
-     *            ルートディレクトリ
+     *            the root directory
      * @param baseDirectory
-     *            ベースディレクトリ
-     * @return ベースディレクトリを表す{@link File}
+     *            the base directory
+     * @return a {@link File} representing the base directory
      */
     protected static File getBaseDir(final File rootDir, final String baseDirectory) {
         assertArgumentNotNull("rootDir", rootDir);

--- a/src/main/java/org/codelibs/core/io/ResourceUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceUtil.java
@@ -30,20 +30,20 @@ import org.codelibs.core.jar.JarFileUtil;
 import org.codelibs.core.net.URLUtil;
 
 /**
- * リソース用のユーティリティクラスです。
+ * Utility class for resource handling.
  *
  * @author higa
  */
 public abstract class ResourceUtil {
 
     /**
-     * リソースパスを返します。
+     * Returns the resource path.
      *
      * @param path
-     *            パス。{@literal null}であってはいけません
+     *            The path. Must not be {@literal null}.
      * @param extension
-     *            拡張子
-     * @return リソースパス
+     *            The extension.
+     * @return The resource path.
      */
     public static String getResourcePath(final String path, final String extension) {
         assertArgumentNotNull("path", path);
@@ -59,11 +59,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * リソースパスを返します。
+     * Returns the resource path.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return リソースパス
+     *            The class. Must not be {@literal null}.
+     * @return The resource path.
      */
     public static String getResourcePath(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -72,20 +72,20 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダを返します。
+     * Returns the context class loader.
      *
-     * @return コンテキストクラスローダ
+     * @return the context class loader
      */
     public static ClassLoader getClassLoader() {
         return Thread.currentThread().getContextClassLoader();
     }
 
     /**
-     * コンテキストクラスローダからリソースを返します。
+     * Returns the resource from the context class loader.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
-     * @return リソースの{@link URL}
+     *            The resource path. Must not be {@literal null} or empty string.
+     * @return The resource {@link URL}
      * @see #getResource(String, String)
      */
     public static URL getResource(final String path) {
@@ -95,13 +95,13 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダからリソースを返します。
+     * Returns the resource from the context class loader.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
+     *            The resource path. Must not be {@literal null} or empty string.
      * @param extension
-     *            リソースの拡張子
-     * @return リソースの{@link URL}
+     *            The resource extension.
+     * @return The resource {@link URL}
      */
     public static URL getResource(final String path, final String extension) {
         assertArgumentNotEmpty("path", path);
@@ -114,11 +114,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダからリソースを返します。見つからなかった場合は<code>null</code>を返します。
+     * Returns the resource from the context class loader. Returns <code>null</code> if not found.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
-     * @return リソースの{@link URL}
+     *            The resource path. Must not be {@literal null} or empty string.
+     * @return The resource {@link URL}
      * @see #getResourceNoException(String, String)
      */
     public static URL getResourceNoException(final String path) {
@@ -128,13 +128,13 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダからリソースを返します。見つからなかった場合は<code>null</code>を返します。
+     * Returns the resource from the context class loader. Returns <code>null</code> if not found.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
+     *            The resource path. Must not be {@literal null} or empty string.
      * @param extension
-     *            拡張子
-     * @return リソースの{@link URL}
+     *            The extension.
+     * @return The resource {@link URL}
      * @see #getResourceNoException(String, String, ClassLoader)
      */
     public static URL getResourceNoException(final String path, final String extension) {
@@ -144,15 +144,15 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * 指定のクラスローダからリソースを返します。見つからなかった場合は<code>null</code>を返します。
+     * Returns the resource from the specified class loader. Returns <code>null</code> if not found.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
+     *            The resource path. Must not be {@literal null} or empty string.
      * @param extension
-     *            リソースの拡張子
+     *            The resource extension.
      * @param loader
-     *            リソースを検索するクラスローダ。{@literal null}であってはいけません
-     * @return リソース
+     *            The class loader to search for the resource. Must not be {@literal null}.
+     * @return The resource {@link URL}
      * @see #getResourcePath(String, String)
      */
     public static URL getResourceNoException(final String path, final String extension, final ClassLoader loader) {
@@ -166,11 +166,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダからリソースを検索してストリームとして返します。
+     * Returns the resource as a stream from the context class loader.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
-     * @return ストリーム
+     *            The resource path. Must not be {@literal null} or empty string.
+     * @return The input stream
      * @see #getResourceAsStream(String, String)
      */
     public static InputStream getResourceAsStream(final String path) {
@@ -180,13 +180,13 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダからリソースを検索してストリームとして返します。
+     * Returns the resource as a stream from the context class loader.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
+     *            The resource path. Must not be {@literal null} or empty string.
      * @param extension
-     *            リソースの拡張子
-     * @return ストリーム
+     *            The resource extension.
+     * @return The input stream
      * @see #getResource(String, String)
      */
     public static InputStream getResourceAsStream(final String path, final String extension) {
@@ -197,12 +197,12 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダからリソースを検索してストリームとして返します。 リソースが見つからなかった場合は<code>null</code>
-     * を返します。
+     * Returns the resource as a stream from the context class loader.
+     * Returns <code>null</code> if the resource is not found.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
-     * @return ストリーム
+     *            The resource path. Must not be {@literal null} or empty string.
+     * @return The input stream, or <code>null</code> if not found.
      * @see #getResourceAsStreamNoException(String, String)
      */
     public static InputStream getResourceAsStreamNoException(final String path) {
@@ -212,14 +212,14 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダからリソースを検索してストリームとして返します。 リソースが見つからなかった場合は<code>null</code>
-     * を返します。
+     * Returns the resource as a stream from the context class loader.
+     * Returns <code>null</code> if the resource is not found.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
+     *            The resource path. Must not be {@literal null} or empty string.
      * @param extension
-     *            リソースの拡張子
-     * @return ストリーム
+     *            The resource extension.
+     * @return The input stream, or <code>null</code> if not found.
      * @see #getResourceNoException(String, String)
      */
     public static InputStream getResourceAsStreamNoException(final String path, final String extension) {
@@ -237,11 +237,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダにリソースが存在するかどうかを返します。
+     * Returns whether the resource exists in the context class loader.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
-     * @return リソースが存在すれば{@literal true}
+     *            The resource path. Must not be {@literal null} or empty string.
+     * @return {@literal true} if the resource exists
      * @see #getResourceNoException(String)
      */
     public static boolean isExist(final String path) {
@@ -251,11 +251,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * コンテキストクラスローダからプロパティファイルをロードして返します。
+     * Loads and returns a properties file from the context class loader.
      *
      * @param path
-     *            プロパティファイルのパス。{@literal null}や空文字列であってはいけません
-     * @return プロパティファイル
+     *            The path to the properties file. Must not be {@literal null} or empty string.
+     * @return The properties file.
      */
     public static Properties getProperties(final String path) {
         assertArgumentNotEmpty("path", path);
@@ -273,11 +273,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * パスの拡張子を返します。
+     * Returns the extension of the path.
      *
      * @param path
-     *            パス。{@literal null}であってはいけません
-     * @return 拡張子
+     *            The path. Must not be {@literal null}.
+     * @return The extension.
      */
     public static String getExtension(final String path) {
         assertArgumentNotNull("path", path);
@@ -290,11 +290,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * パスから拡張子を取り除きます。
+     * Removes the extension from the path.
      *
      * @param path
-     *            パス。{@literal null}であってはいけません
-     * @return 拡張子を取り除いたパス
+     *            The path. Must not be {@literal null}.
+     * @return The path without the extension.
      */
     public static String removeExtension(final String path) {
         assertArgumentNotNull("path", path);
@@ -307,11 +307,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * 指定されたクラスのクラスファイルが置かれているルートディレクトリを返します。
+     * Returns the root directory where the class file of the specified class is located.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return ルートディレクトリ
+     *            The class. Must not be {@literal null}.
+     * @return The root directory.
      * @see #getBuildDir(String)
      */
     public static File getBuildDir(final Class<?> clazz) {
@@ -321,11 +321,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * クラスファイルが置かれているルートディレクトリを返します。
+     * Returns the root directory where the class file is located.
      *
      * @param path
-     *            クラスファイルのパス。{@literal null}や空文字列であってはいけません
-     * @return ルートディレクトリ
+     *            The path to the class file. Must not be {@literal null} or empty string.
+     * @return The root directory.
      */
     public static File getBuildDir(final String path) {
         assertArgumentNotEmpty("path", path);
@@ -345,11 +345,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * リソースのURLを外部形式に変換します。
+     * Converts the resource URL to an external form.
      *
      * @param url
-     *            リソースのURL。{@literal null}であってはいけません
-     * @return 外部形式
+     *            The resource URL. Must not be {@literal null}.
+     * @return The external form.
      */
     public static String toExternalForm(final URL url) {
         assertArgumentNotNull("url", url);
@@ -359,11 +359,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * リソースのファイル名を返します。
+     * Returns the file name of the resource.
      *
      * @param url
-     *            リソースのURL。{@literal null}であってはいけません
-     * @return ファイル名
+     *            The resource URL. Must not be {@literal null}.
+     * @return The file name.
      */
     public static String getFileName(final URL url) {
         assertArgumentNotNull("url", url);
@@ -373,11 +373,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * リソースのファイルを返します。
+     * Returns the file of the resource.
      *
      * @param url
-     *            リソースのURL。{@literal null}であってはいけません
-     * @return ファイル
+     *            The resource URL. Must not be {@literal null}.
+     * @return The file.
      */
     public static File getFile(final URL url) {
         assertArgumentNotNull("url", url);
@@ -390,11 +390,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * リソースをファイルとして返します。
+     * Returns the resource as a file.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
-     * @return ファイル
+     *            The resource path. Must not be {@literal null} or empty string.
+     * @return The file.
      * @see #getResourceAsFile(String, String)
      */
     public static File getResourceAsFile(final String path) {
@@ -404,13 +404,13 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * リソースをファイルとして返します。
+     * Returns the resource as a file.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
+     *            The resource path. Must not be {@literal null} or empty string.
      * @param extension
-     *            リソースの拡張子
-     * @return ファイル
+     *            The resource extension.
+     * @return The file.
      * @see #getFile(URL)
      */
     public static File getResourceAsFile(final String path, final String extension) {
@@ -420,11 +420,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * クラスファイルを表すリソースをファイルとして返します。リソースが見つからない場合は<code>null</code>を返します。
+     * Returns the resource representing the class file as a file. Returns <code>null</code> if the resource is not found.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return ファイル
+     *            The class. Must not be {@literal null}.
+     * @return The file.
      * @see #getResourceAsFileNoException(String)
      */
     public static File getResourceAsFileNoException(final Class<?> clazz) {
@@ -434,11 +434,11 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * リソースをファイルとして返します。リソースが見つからない場合は<code>null</code>を返します。
+     * Returns the resource as a file. Returns <code>null</code> if the resource is not found.
      *
      * @param path
-     *            リソースのパス。{@literal null}や空文字列であってはいけません
-     * @return ファイル
+     *            The resource path. Must not be {@literal null} or empty string.
+     * @return The file.
      * @see #getResourceNoException(String)
      */
     public static File getResourceAsFileNoException(final String path) {
@@ -452,13 +452,13 @@ public abstract class ResourceUtil {
     }
 
     /**
-     * パスを変換します。
+     * Converts the path.
      *
      * @param path
-     *            リソースのパス
+     *            The resource path.
      * @param clazz
-     *            クラス
-     * @return 変換された結果
+     *            The class.
+     * @return The converted result.
      */
     public static String convertPath(final String path, final Class<?> clazz) {
         assertArgumentNotEmpty("path", path);

--- a/src/main/java/org/codelibs/core/io/SerializeUtil.java
+++ b/src/main/java/org/codelibs/core/io/SerializeUtil.java
@@ -28,7 +28,7 @@ import org.codelibs.core.exception.ClassNotFoundRuntimeException;
 import org.codelibs.core.exception.IORuntimeException;
 
 /**
- * オブジェクトをシリアライズするためのユーティリティです。
+ * Utility for serializing objects.
  *
  * @author higa
  */
@@ -37,11 +37,10 @@ public abstract class SerializeUtil {
     private static final int BYTE_ARRAY_SIZE = 8 * 1024;
 
     /**
-     * オブジェクトをシリアライズできるかテストします。
+     * Tests if the object can be serialized.
      *
-     * @param obj
-     *            シリアライズ対象のオブジェクト。{@literal null}であってはいけません
-     * @return シリアライズして復元したオブジェクト
+     * @param obj the object to be serialized (must not be {@literal null})
+     * @return the deserialized object
      */
     public static Object serialize(final Object obj) {
         assertArgumentNotNull("obj", obj);
@@ -51,11 +50,10 @@ public abstract class SerializeUtil {
     }
 
     /**
-     * オブジェクトをbyteの配列に変換します。
+     * Converts an object to a byte array.
      *
-     * @param obj
-     *            シリアライズするオブジェクト。{@literal null}であってはいけません
-     * @return オブジェクトのbyte配列
+     * @param obj the object to serialize (must not be {@literal null})
+     * @return the byte array of the object
      */
     public static byte[] fromObjectToBinary(final Object obj) {
         assertArgumentNotNull("obj", obj);
@@ -75,11 +73,10 @@ public abstract class SerializeUtil {
     }
 
     /**
-     * {@literal byte}の配列をオブジェクトに変換します。
+     * Converts a byte array to an object.
      *
-     * @param bytes
-     *            デシリアライズする配列。{@literal null}や空配列であってはいけません
-     * @return 復元したオブジェクト
+     * @param bytes the byte array (must not be {@literal null})
+     * @return the deserialized object
      */
     public static Object fromBinaryToObject(final byte[] bytes) {
         assertArgumentNotEmpty("bytes", bytes);

--- a/src/main/java/org/codelibs/core/io/TraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/TraversalUtil.java
@@ -42,22 +42,21 @@ import org.codelibs.core.zip.ZipFileUtil;
 import org.codelibs.core.zip.ZipInputStreamUtil;
 
 /**
- * ファイルシステム上やJarファイル中に展開されている、クラスやリソースの集まりを横断的に処理するためのユーティリティです。
+ * Utility for traversing collections of classes and resources on the file system or inside JAR files.
  * <p>
- * 対象となるファイルシステム上のディレクトリや、Jarファイルの一などは{@link URL}によって与えられます。 URLのプロトコルに応じて適切な
- * {@link Traverser}が返されるので、そのメソッドを呼び出すことでクラスやリソースをトラバースすることが出来ます。
+ * Target directories on the file system or JAR files are provided as {@link URL}. The appropriate {@link Traverser} is returned depending on the protocol of the URL, and you can traverse classes and resources by calling its methods.
  * </p>
  * <p>
- * 次のプロトコルをサポートしています。
+ * Supported protocols:
  * </p>
  * <ul>
  * <li>{@literal file}</li>
  * <li>{@literal jar}</li>
- * <li>{@literal wsjar} (WebShpere独自プロトコル、{@literal jar}の別名)</li>
- * <li>{@literal zip} (WebLogic独自プロトコル、通常のZipファイルは{@literal jar}プロトコルを使用してください)</li>
- * <li>{@literal code-source} (Oracle AS(OC4J)独自プロトコル)</li>
- * <li>{@literal vfsfile} (JBossAS5独自プロトコル、{@literal file}の別名)</li>
- * <li>{@literal vfszip} (JBossAS5独自プロトコル)</li>
+ * <li>{@literal wsjar} (WebSphere proprietary protocol, alias for {@literal jar})</li>
+ * <li>{@literal zip} (WebLogic proprietary protocol, use {@literal jar} protocol for normal zip files)</li>
+ * <li>{@literal code-source} (Oracle AS(OC4J) proprietary protocol)</li>
+ * <li>{@literal vfsfile} (JBossAS5 proprietary protocol, alias for {@literal file})</li>
+ * <li>{@literal vfszip} (JBossAS5 proprietary protocol)</li>
  * </ul>
  *
  * @author koichik
@@ -67,12 +66,12 @@ import org.codelibs.core.zip.ZipInputStreamUtil;
  */
 public abstract class TraversalUtil {
 
-    /** 空の{@link Traverser}の配列です。 */
+    /** An empty array of {@link Traverser}. */
     protected static final Traverser[] EMPTY_ARRAY = new Traverser[0];
 
     private static final Logger logger = Logger.getLogger(TraversalUtil.class);
 
-    /** URLのプロトコルをキー、{@link TraverserFactory}を値とするマッピングです。 */
+    /** Mapping from URL protocol (as key) to {@link TraverserFactory} (as value). */
     protected static final ConcurrentMap<String, TraverserFactory> traverserFactories = newConcurrentHashMap();
     static {
         addTraverserFactory("file", (url, rootPackage, rootDir) -> new FileSystemTraverser(getBaseDir(url, rootDir), rootPackage, rootDir));
@@ -85,12 +84,12 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * {@link TraverserFactory}を追加します。
+     * Adds a {@link TraverserFactory}.
      *
      * @param protocol
-     *            URLのプロトコル。{@literal null}や空文字列であってはいけません
+     *            The URL protocol. Must not be {@literal null} or empty.
      * @param factory
-     *            プロトコルに対応する{@link Traverser}のファクトリ。{@literal null}であってはいけません
+     *            The {@link Traverser} factory for the protocol. Must not be {@literal null}.
      */
     public static void addTraverserFactory(final String protocol, final TraverserFactory factory) {
         assertArgumentNotEmpty("protocol", protocol);
@@ -100,16 +99,16 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * 指定のクラスを基点とする、リソースやクラスの集まりを扱う{@link Traverser}を返します。
+     * Returns a {@link Traverser} that handles a collection of resources or classes based on the specified class.
      * <p>
-     * このメソッドが返す{@link Traverser}は、指定されたクラスをFQNで参照可能なパスをルートとします。 例えば指定されたクラスが
-     * <code>foo.Bar</code>で、そのクラスファイルが <code>classes/foo/Bar.class</code>の場合、
-     * このメソッドが返す {@link Traverser}は<code>classes</code>ディレクトリ以下のリソースの集合を扱います。
+     * The {@link Traverser} returned by this method uses the path where the specified class can be referenced by its FQN as the root.
+     * For example, if the specified class is <code>foo.Bar</code> and its class file is located at <code>classes/foo/Bar.class</code>,
+     * the {@link Traverser} returned by this method will handle the collection of resources under the <code>classes</code> directory.
      * </p>
      *
      * @param referenceClass
-     *            基点となるクラス。{@literal null}であってはいけません
-     * @return 指定のクラスを基点とする、クラスやリソースの集まりを扱う{@link Traverser}
+     *            The base class. Must not be {@literal null}.
+     * @return A {@link Traverser} that handles a collection of classes or resources based on the specified class.
      */
     public static Traverser getTraverser(final Class<?> referenceClass) {
         assertArgumentNotNull("referenceClass", referenceClass);
@@ -125,11 +124,11 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * 指定のディレクトリを基点とする、クラスやリソースの集まりを扱う{@link Traverser}を返します。
+     * Returns a {@link Traverser} that handles a collection of classes or resources based on the specified directory.
      *
      * @param rootDir
-     *            ルートディレクトリ。{@literal null}や空文字列であってはいけません
-     * @return 指定のディレクトリを基点とする、クラスやリソースの集まりを扱う{@link Traverser}
+     *            The root directory. Must not be {@literal null} or an empty string.
+     * @return A {@link Traverser} that handles a collection of classes or resources based on the specified directory.
      */
     public static Traverser getTraverser(final String rootDir) {
         assertArgumentNotEmpty("rootDir", rootDir);
@@ -139,11 +138,11 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * 指定のルートパッケージを基点とする、クラスやリソースの集まりを扱う{@link Traverser}の配列を返します。
+     * Returns an array of {@link Traverser} instances that handle collections of classes or resources based on the specified root package.
      *
      * @param rootPackage
-     *            ルートパッケージ
-     * @return 指定のルートパッケージを基点とするリソースの集まりを扱う{@link Traverser}の配列
+     *            The root package.
+     * @return An array of {@link Traverser} instances that handle collections of resources based on the specified root package.
      */
     public static Traverser[] getTraversers(final String rootPackage) {
         if (StringUtil.isEmpty(rootPackage)) {
@@ -167,18 +166,18 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * URLを扱う{@link Traverser}を作成して返します。
+     * Creates and returns a {@link Traverser} for handling the specified URL.
      * <p>
-     * URLのプロトコルが未知の場合は<code>null</code>を返します。
+     * Returns <code>null</code> if the protocol of the URL is unknown.
      * </p>
      *
      * @param url
-     *            リソースのURL
+     *            The URL of the resource.
      * @param rootPackage
-     *            ルートパッケージ
+     *            The root package.
      * @param rootDir
-     *            ルートディレクトリ
-     * @return URLを扱う{@link Traverser}
+     *            The root directory.
+     * @return A {@link Traverser} for handling the specified URL.
      */
     protected static Traverser getTraverser(final URL url, final String rootPackage, final String rootDir) {
         final TraverserFactory factory = traverserFactories.get(URLUtil.toCanonicalProtocol(url.getProtocol()));
@@ -190,11 +189,11 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * パッケージ名をディレクトリ名に変換して返します。
+     * Converts a package name to a directory name and returns it.
      *
      * @param packageName
-     *            パッケージ名
-     * @return ディレクトリ名
+     *            The package name.
+     * @return The directory name.
      */
     protected static String toDirectoryName(final String packageName) {
         if (StringUtil.isEmpty(packageName)) {
@@ -204,11 +203,11 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * クラス名をクラスファイルのパス名に変換して返します。
+     * Converts a class name to the corresponding class file path name and returns it.
      *
      * @param className
-     *            クラス名
-     * @return クラスファイルのパス名
+     *            The class name.
+     * @return The class file path name.
      */
     protected static String toClassFile(final String className) {
         assertArgumentNotNull("className", className);
@@ -217,13 +216,13 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * ファイルを表すURLからルートパッケージの上位となるベースディレクトリを求めて返します。
+     * Returns the base directory above the root package from a URL representing a file.
      *
      * @param url
-     *            ファイルを表すURL
+     *            The URL representing the file.
      * @param baseName
-     *            ベース名
-     * @return ルートパッケージの上位となるベースディレクトリ
+     *            The base name.
+     * @return The base directory above the root package.
      */
     protected static File getBaseDir(final URL url, final String baseName) {
         assertArgumentNotNull("url", url);
@@ -237,50 +236,50 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * {@link Traverser}のインスタンスを作成するファクトリです。
+     * Factory for creating instances of {@link Traverser}.
      *
      * @author koichik
      */
     public interface TraverserFactory {
         /**
-         * {@link Traverser}のインスタンスを作成して返します。
+         * Creates and returns an instance of {@link Traverser}.
          *
          * @param url
-         *            リソースを表すURL
+         *            The URL representing the resource.
          * @param rootPackage
-         *            ルートパッケージ
+         *            The root package.
          * @param rootDir
-         *            ルートディレクトリ
-         * @return URLで表されたリソースを扱う{@link Traverser}
+         *            The root directory.
+         * @return A {@link Traverser} that handles the resource represented by the URL.
          */
         Traverser create(URL url, String rootPackage, String rootDir);
     }
 
     /**
-     * ファイルシステム上のリソースの集まりを扱うオブジェクトです。
+     * Object that handles a collection of resources on the file system.
      *
      * @author koichik
      */
     public static class FileSystemTraverser implements Traverser {
 
-        /** ベースディレクトリです。 */
+        /** The base directory. */
         protected final File baseDir;
 
-        /** ルートパッケージです。 */
+        /** The root package. */
         protected final String rootPackage;
 
-        /** ルートディレクトリです。 */
+        /** The root directory. */
         protected final String rootDir;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param baseDir
-         *            ベースディレクトリ
+         *            The base directory.
          * @param rootPackage
-         *            ルートパッケージ
+         *            The root package.
          * @param rootDir
-         *            ルートディレクトリ
+         *            The root directory.
          */
         public FileSystemTraverser(final File baseDir, final String rootPackage, final String rootDir) {
             this.baseDir = baseDir;
@@ -289,14 +288,14 @@ public abstract class TraversalUtil {
         }
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param url
-         *            ディレクトリを表すURL
+         *            The URL representing the directory.
          * @param rootPackage
-         *            ルートパッケージ
+         *            The root package.
          * @param rootDir
-         *            ルートディレクトリ
+         *            The root directory.
          */
         public FileSystemTraverser(final URL url, final String rootPackage, final String rootDir) {
             this(URLUtil.toFile(url), rootPackage, rootDir);
@@ -325,30 +324,30 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * Jarファイル中のリソースの集まりを扱うオブジェクトです。
+     * Object that handles a collection of resources inside a Jar file.
      *
      * @author koichik
      */
     public static class JarFileTraverser implements Traverser {
 
-        /** Jarファイルです。 */
+        /** The Jar file. */
         protected final JarFile jarFile;
 
-        /** ルートパッケージです。 */
+        /** The root package. */
         protected final String rootPackage;
 
-        /** ルートディレクトリです。 */
+        /** The root directory. */
         protected final String rootDir;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param jarFile
-         *            Jarファイル
+         *            The Jar file.
          * @param rootPackage
-         *            ルートパッケージ
+         *            The root package.
          * @param rootDir
-         *            ルートディレクトリ
+         *            The root directory.
          */
         public JarFileTraverser(final JarFile jarFile, final String rootPackage, final String rootDir) {
             this.jarFile = jarFile;
@@ -357,14 +356,14 @@ public abstract class TraversalUtil {
         }
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param url
-         *            Jarファイルを表すURL
+         *            The URL representing the Jar file.
          * @param rootPackage
-         *            ルートパッケージ
+         *            The root package.
          * @param rootDir
-         *            ルートディレクトリ
+         *            The root directory.
          */
         public JarFileTraverser(final URL url, final String rootPackage, final String rootDir) {
             this(JarFileUtil.toJarFile(url), rootPackage, rootDir);
@@ -401,39 +400,39 @@ public abstract class TraversalUtil {
     }
 
     /**
-     * JBossAS5のvfszipプロトコルで表されるリソースの集まりを扱うオブジェクトです。
+     * Object that handles a collection of resources represented by the vfszip protocol of JBossAS5.
      *
      * @author koichik
      */
     public static class VfsZipTraverser implements Traverser {
 
-        /** WAR内の.classファイルの接頭辞です。 */
+        /** Prefix for .class files inside a WAR. */
         protected static final String WAR_CLASSES_PREFIX = "/WEB-INF/CLASSES/";
 
-        /** ルートパッケージです。 */
+        /** The root package. */
         protected final String rootPackage;
 
-        /** ルートディレクトリです。 */
+        /** The root directory. */
         protected final String rootDir;
 
-        /** ZipのURLです。 */
+        /** The URL of the zip file. */
         protected final URL zipUrl;
 
-        /** Zip内のエントリの接頭辞です。 */
+        /** Prefix of entries inside the zip. */
         protected final String prefix;
 
-        /** Zip内のエントリ名の{@link Set}です。 */
+        /** Set of entry names inside the zip. */
         protected final Set<String> entryNames = newHashSet();
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param url
-         *            ルートを表すURL
+         *            The URL representing the root.
          * @param rootPackage
-         *            ルートパッケージ
+         *            The root package.
          * @param rootDir
-         *            ルートディレクトリ
+         *            The root directory.
          */
         public VfsZipTraverser(final URL url, final String rootPackage, final String rootDir) {
             URL zipUrl = url;

--- a/src/main/java/org/codelibs/core/io/Traverser.java
+++ b/src/main/java/org/codelibs/core/io/Traverser.java
@@ -16,7 +16,7 @@
 package org.codelibs.core.io;
 
 /**
- * クラスやリソースの集まりを表すオブジェクトです。
+ * Object representing a collection of classes or resources.
  *
  * @author koichik
  * @see TraversalUtil
@@ -24,44 +24,38 @@ package org.codelibs.core.io;
 public interface Traverser {
 
     /**
-     * 指定されたクラス名に対応するクラスファイルがこのインスタンスが扱うリソースの中に存在すれば<code>true</code>を返します。
+     * Returns <code>true</code> if the class file corresponding to the specified class name exists in the resources handled by this instance.
      * <p>
-     * インスタンス構築時にルートパッケージが指定されている場合、 指定されたクラス名はルートパッケージからの相対名として解釈されます。
+     * If a root package is specified at instance construction, the specified class name is interpreted as a relative name from the root package.
      * </p>
      *
-     * @param className
-     *            クラス名
-     * @return 指定されたクラス名に対応するクラスファイルがこのインスタンスが扱うリソースの中に存在すれば <code>true</code>
+     * @param className the class name
+     * @return <code>true</code> if the class file exists in the resources handled by this instance
      */
     boolean isExistClass(final String className);
 
     /**
-     * このインスタンスが扱うクラスを探して {@link ClassHandler#processClass(String, String) ハンドラ}
-     * をコールバックします。
+     * Searches for classes handled by this instance and calls the handler for each class.
      * <p>
-     * インスタンス構築時にルートパッケージが指定されている場合は、 ルートパッケージ以下のクラスのみが対象となります。
+     * If a root package is specified at instance construction, only classes under the root package are targeted.
      * </p>
      *
-     * @param handler
-     *            クラスを処理するハンドラ
+     * @param handler the handler to process classes
      */
     void forEach(ClassHandler handler);
 
     /**
-     * このインスタンスが扱うリソースを探して
-     * {@link ResourceHandler#processResource(String, java.io.InputStream) ハンドラ}
-     * をコールバックします。
+     * Searches for resources handled by this instance and calls the handler for each resource.
      * <p>
-     * インスタンス構築時にルートディレクトリが指定されている場合は、 ルートディレクトリ以下のリソースのみが対象となります。
+     * If a root directory is specified at instance construction, only resources under the root directory are targeted.
      * </p>
      *
-     * @param handler
-     *            リソースを処理するハンドラ
+     * @param handler the handler to process resources
      */
     void forEach(ResourceHandler handler);
 
     /**
-     * リソースの後処理を行います。
+     * Performs post-processing of resources.
      */
     void close();
 

--- a/src/main/java/org/codelibs/core/io/WriterUtil.java
+++ b/src/main/java/org/codelibs/core/io/WriterUtil.java
@@ -29,20 +29,18 @@ import java.io.Writer;
 import org.codelibs.core.exception.IORuntimeException;
 
 /**
- * {@link Writer}用のユーティリティクラスです。
+ * Utility class for {@link Writer} operations.
  *
  * @author koichik
  */
 public abstract class WriterUtil {
 
     /**
-     * 指定のエンコーディングでストリームへ出力する{@link Writer}を作成します。
+     * Creates a {@link Writer} to output to a stream with the specified encoding.
      *
-     * @param os
-     *            ストリーム。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return ストリームへ出力する{@link Writer}
+     * @param os the stream (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return a {@link Writer} to output to the stream
      */
     public static Writer create(final OutputStream os, final String encoding) {
         assertArgumentNotNull("os", os);
@@ -56,11 +54,10 @@ public abstract class WriterUtil {
     }
 
     /**
-     * プラットフォームデフォルトエンコーディングでファイルへ出力する{@link Writer}を作成します。
+     * Creates a {@link Writer} to output to a file with the default encoding.
      *
-     * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return ファイルへ出力する{@link Writer}
+     * @param file the file (must not be {@literal null})
+     * @return a {@link Writer} to output to the file
      */
     public static Writer create(final File file) {
         assertArgumentNotNull("file", file);
@@ -73,13 +70,11 @@ public abstract class WriterUtil {
     }
 
     /**
-     * 指定のエンコーディングでファイルへ出力する{@link Writer}を作成します。
+     * Creates a {@link Writer} to output to a file with the specified encoding.
      *
-     * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @param encoding
-     *            エンコーディング。{@literal null}や空文字列であってはいけません
-     * @return ファイルへ出力する{@link Writer}
+     * @param file the file (must not be {@literal null})
+     * @param encoding the encoding (must not be {@literal null} or empty)
+     * @return a {@link Writer} to output to the file
      */
     public static Writer create(final File file, final String encoding) {
         assertArgumentNotNull("file", file);

--- a/src/main/java/org/codelibs/core/jar/JarFileUtil.java
+++ b/src/main/java/org/codelibs/core/jar/JarFileUtil.java
@@ -77,7 +77,7 @@ public abstract class JarFileUtil {
     /**
      * Returns an input stream to read the contents of the specified JAR file entry.
      *
-     * @param jarFile the JAR file (must not be {@literal null})
+     * @param file the JAR file (must not be {@literal null})
      * @param entry the JAR file entry (must not be {@literal null})
      * @return the input stream to read the entry
      */

--- a/src/main/java/org/codelibs/core/jar/JarFileUtil.java
+++ b/src/main/java/org/codelibs/core/jar/JarFileUtil.java
@@ -34,7 +34,7 @@ import org.codelibs.core.net.JarURLConnectionUtil;
 import org.codelibs.core.net.URLUtil;
 
 /**
- * {@link java.util.jar.JarFile}を扱うユーティリティクラスです。
+ * Utility class for handling {@link java.util.jar.JarFile}.
  *
  * @author higa
  */
@@ -43,11 +43,10 @@ public abstract class JarFileUtil {
     private static final Logger logger = Logger.getLogger(JarFileUtil.class);
 
     /**
-     * 指定されたJarファイルを読み取るための<code>JarFile</code>を作成して返します。
+     * Creates and returns a <code>JarFile</code> to read the specified JAR file.
      *
-     * @param file
-     *            ファイルパス。{@literal null}であってはいけません
-     * @return 指定されたJarファイルを読み取るための<code>JarFile</code>
+     * @param file the file path (must not be {@literal null})
+     * @return a <code>JarFile</code> to read the specified JAR file
      */
     public static JarFile create(final String file) {
         assertArgumentNotNull("file", file);
@@ -60,11 +59,10 @@ public abstract class JarFileUtil {
     }
 
     /**
-     * 指定されたJarファイルを読み取るための<code>JarFile</code>を作成して返します。
+     * Creates and returns a <code>JarFile</code> to read the specified JAR file.
      *
-     * @param file
-     *            ファイル。{@literal null}であってはいけません
-     * @return 指定されたJarファイルを読み取るための<code>JarFile</code>
+     * @param file the file (must not be {@literal null})
+     * @return a <code>JarFile</code> to read the specified JAR file
      */
     public static JarFile create(final File file) {
         assertArgumentNotNull("file", file);
@@ -77,13 +75,11 @@ public abstract class JarFileUtil {
     }
 
     /**
-     * 指定されたJarファイルエントリの内容を読み込むための入力ストリームを返します。
+     * Returns an input stream to read the contents of the specified JAR file entry.
      *
-     * @param file
-     *            Jarファイル。{@literal null}であってはいけません
-     * @param entry
-     *            Jarファイルエントリ。{@literal null}であってはいけません
-     * @return 指定されたJarファイルエントリの内容を読み込むための入力ストリーム
+     * @param jarFile the JAR file (must not be {@literal null})
+     * @param entry the JAR file entry (must not be {@literal null})
+     * @return the input stream to read the entry
      */
     public static InputStream getInputStream(final JarFile file, final ZipEntry entry) {
         assertArgumentNotNull("file", file);
@@ -97,11 +93,10 @@ public abstract class JarFileUtil {
     }
 
     /**
-     * URLで指定されたJarファイルを読み取るための<code>JarFile</code>を作成して返します。
+     * Creates and returns a <code>JarFile</code> to read the JAR file specified by the URL.
      *
-     * @param jarUrl
-     *            Jarファイルを示すURL。{@literal null}であってはいけません
-     * @return 指定されたJarファイルを読み取るための<code>JarFile</code>
+     * @param jarUrl the URL of the JAR file (must not be {@literal null})
+     * @return a <code>JarFile</code> to read the JAR file specified by the URL
      */
     public static JarFile toJarFile(final URL jarUrl) {
         assertArgumentNotNull("jarUrl", jarUrl);
@@ -114,11 +109,10 @@ public abstract class JarFileUtil {
     }
 
     /**
-     * URLで指定されたJarファイルのパスを返します。
+     * Returns the path of the JAR file specified by the URL.
      *
-     * @param jarUrl
-     *            Jarファイルを示すURL。{@literal null}であってはいけません
-     * @return URLで指定されたJarファイルのパス
+     * @param jarUrl the URL of the JAR file (must not be {@literal null})
+     * @return the path of the JAR file specified by the URL
      */
     public static String toJarFilePath(final URL jarUrl) {
         assertArgumentNotNull("jarUrl", jarUrl);
@@ -132,13 +126,12 @@ public abstract class JarFileUtil {
     }
 
     /**
-     * Jarファイルをクローズします。
+     * Closes the JAR file.
      * <p>
-     * {@link JarFile#close()}が例外をスローした場合はログにエラーメッセージを出力します。 例外は再スローされません。
+     * If {@link JarFile#close()} throws an exception, an error message is logged. The exception is not re-thrown.
      * </p>
      *
-     * @param jarFile
-     *            Jarファイル。{@literal null}であってはいけません
+     * @param jarFile the JAR file (must not be {@literal null})
      */
     public static void close(final JarFile jarFile) {
         assertArgumentNotNull("jarFile", jarFile);

--- a/src/main/java/org/codelibs/core/jar/JarInputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/jar/JarInputStreamUtil.java
@@ -25,20 +25,18 @@ import java.util.jar.JarInputStream;
 import org.codelibs.core.exception.IORuntimeException;
 
 /**
- * {@link JarInputStream}用のユーティリティクラスです。
+ * Utility class for {@link JarInputStream} operations.
  *
  * @author koichik
  */
 public abstract class JarInputStreamUtil {
 
     /**
-     * {@link JarInputStream}を作成します。
+     * Creates a {@link JarInputStream}.
      *
-     * @param is
-     *            入力ストリーム。{@literal null}であってはいけません
+     * @param is the input stream (must not be {@literal null})
      * @return {@link JarInputStream}
-     * @throws IORuntimeException
-     *             {@link IOException}が発生した場合
+     * @throws IORuntimeException if an {@link IOException} occurs
      * @see JarInputStream#JarInputStream(InputStream)
      */
     public static JarInputStream create(final InputStream is) throws IORuntimeException {
@@ -52,13 +50,11 @@ public abstract class JarInputStreamUtil {
     }
 
     /**
-     * {@link JarInputStream#getNextJarEntry()}の例外処理をラップするメソッドです。
+     * Method that wraps exception handling for {@link JarInputStream#getNextJarEntry()}.
      *
-     * @param is
-     *            入力ストリーム。{@literal null}であってはいけません
+     * @param is the input stream (must not be {@literal null})
      * @return {@link JarEntry}
-     * @throws IORuntimeException
-     *             {@link IOException}が発生した場合
+     * @throws IORuntimeException if an {@link IOException} occurs
      * @see JarInputStream#getNextJarEntry()
      */
     public static JarEntry getNextJarEntry(final JarInputStream is) throws IORuntimeException {

--- a/src/main/java/org/codelibs/core/lang/AnnotationUtil.java
+++ b/src/main/java/org/codelibs/core/lang/AnnotationUtil.java
@@ -26,18 +26,17 @@ import org.codelibs.core.beans.MethodDesc;
 import org.codelibs.core.beans.factory.BeanDescFactory;
 
 /**
- * アノテーションのためのユーティリティクラスです。
+ * Utility class for annotations.
  *
  * @author higa
  */
 public abstract class AnnotationUtil {
 
     /**
-     * アノテーションの要素を名前と値の{@link Map}として返します。
+     * Returns the elements of the annotation as a {@link Map} of names and values.
      *
-     * @param annotation
-     *            アノテーション。{@literal null}であってはいけません
-     * @return アノテーションの要素の名前と値からなる{@link Map}
+     * @param annotation the annotation (must not be {@literal null})
+     * @return a {@link Map} of annotation element names and values
      */
     public static Map<String, Object> getProperties(final Annotation annotation) {
         assertArgumentNotNull("annotation", annotation);
@@ -54,15 +53,12 @@ public abstract class AnnotationUtil {
     }
 
     /**
-     * アノテーションの要素の値を返します。
+     * Returns the value of an annotation element.
      *
-     * @param beanDesc
-     *            アノテーションを表す{@link BeanDesc}
-     * @param annotation
-     *            アノテーション
-     * @param name
-     *            要素の名前
-     * @return アノテーションの要素の値
+     * @param beanDesc the {@link BeanDesc} representing the annotation
+     * @param annotation the annotation
+     * @param name the name of the element
+     * @return the value of the annotation element
      */
     protected static Object getProperty(final BeanDesc beanDesc, final Annotation annotation, final String name) {
         final MethodDesc methodDesc = beanDesc.getMethodDescNoException(name);

--- a/src/main/java/org/codelibs/core/lang/ClassIterator.java
+++ b/src/main/java/org/codelibs/core/lang/ClassIterator.java
@@ -25,9 +25,9 @@ import org.codelibs.core.exception.ClUnsupportedOperationException;
 import org.codelibs.core.message.MessageFormatter;
 
 /**
- * クラスの継承階層を親クラスに向かって反復する{@link Iterator}です。
+ * An {@link Iterator} that iterates through the inheritance hierarchy of a class towards its superclasses.
  * <p>
- * 次のように使います．
+ * Usage example:
  * </p>
  *
  * <pre>
@@ -39,62 +39,56 @@ import org.codelibs.core.message.MessageFormatter;
  * }
  * </pre>
  * <p>
- * デフォルトでは{@link Object}クラスも反復の対象となります。 反復の対象に{@link Object}を含めたくない場合は、
- * {@link #iterable(Class, boolean)}または{@link #ClassIterator(Class, boolean)}
- * の第2引数に{@literal false}を指定します。
+ * By default, the {@link Object} class is also included in the iteration. If you do not want to include {@link Object},
+ * specify {@literal false} for the second argument of {@link #iterable(Class, boolean)} or {@link #ClassIterator(Class, boolean)}.
  * </p>
  *
  * @author koichik
  */
 public class ClassIterator implements Iterator<Class<?>> {
 
-    /** クラス */
+    /** The class */
     protected Class<?> clazz;
 
-    /** {@link Object}クラスも反復する場合は {@literal true} */
+    /** If {@link Object} class should also be iterated, set to {@literal true} */
     protected final boolean includeObject;
 
     /**
-     * for each構文で使用するために{@link ClassIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps a {@link ClassIterator} for use in a for-each statement.
      *
-     * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return {@link ClassIterator}をラップした{@link Iterable}
+     * @param clazz the class (must not be {@literal null})
+     * @return an {@link Iterable} wrapping a {@link ClassIterator}
      */
     public static Iterable<Class<?>> iterable(final Class<?> clazz) {
         return iterable(clazz, true);
     }
 
     /**
-     * for each構文で使用するために{@link ClassIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps a {@link ClassIterator} for use in a for-each statement.
      *
-     * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @param includeObject
-     *            {@link Object}クラスも反復する場合は {@literal true}
-     * @return {@link ClassIterator}をラップした{@link Iterable}
+     * @param clazz the class (must not be {@literal null})
+     * @param includeObject if {@literal true}, includes the {@link Object} class in the iteration
+     * @return an {@link Iterable} wrapping a {@link ClassIterator}
      */
     public static Iterable<Class<?>> iterable(final Class<?> clazz, final boolean includeObject) {
         return () -> new ClassIterator(clazz, includeObject);
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
+     *            the class (must not be {@literal null})
      */
     public ClassIterator(final Class<?> clazz) {
         this(clazz, true);
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
-     * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @param includeObject
-     *            {@link Object}クラスも反復する場合は {@literal true}
+     * @param clazz the class (must not be {@literal null})
+     * @param includeObject if {@literal true}, includes the {@link Object} class in the iteration
      */
     public ClassIterator(final Class<?> clazz, final boolean includeObject) {
         assertArgumentNotNull("clazz", clazz);

--- a/src/main/java/org/codelibs/core/lang/ClassLoaderIterator.java
+++ b/src/main/java/org/codelibs/core/lang/ClassLoaderIterator.java
@@ -23,9 +23,9 @@ import java.util.NoSuchElementException;
 import org.codelibs.core.exception.ClUnsupportedOperationException;
 
 /**
- * クラスローダの階層を親クラスローダに向かって反復する{@link Iterator}です。
+ * An {@link Iterator} that iterates through the hierarchy of class loaders towards their parent class loaders.
  * <p>
- * 次のように使います．
+ * Usage example:
  * </p>
  *
  * <pre>
@@ -45,21 +45,19 @@ public class ClassLoaderIterator implements Iterator<ClassLoader> {
     protected ClassLoader classLoader;
 
     /**
-     * for each構文で使用するために{@link ClassLoaderIterator}をラップした{@link Iterable}を返します。
+     * Returns an {@link Iterable} that wraps a {@link ClassLoaderIterator} for use in a for-each statement.
      *
-     * @param classLoader
-     *            クラスローダ。{@literal null}であってはいけません
-     * @return {@link ClassLoaderIterator}をラップした{@link Iterable}
+     * @param classLoader the class loader (must not be {@literal null})
+     * @return an {@link Iterable} wrapping a {@link ClassLoaderIterator}
      */
     public static Iterable<ClassLoader> iterable(final ClassLoader classLoader) {
         return () -> new ClassLoaderIterator(classLoader);
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
-     * @param classLoader
-     *            クラスローダ。{@literal null}であってはいけません
+     * @param classLoader the class loader (must not be {@literal null})
      */
     public ClassLoaderIterator(final ClassLoader classLoader) {
         assertArgumentNotNull("classLoader", classLoader);

--- a/src/main/java/org/codelibs/core/lang/ClassLoaderUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ClassLoaderUtil.java
@@ -32,34 +32,32 @@ import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.message.MessageFormatter;
 
 /**
- * {@link ClassLoader}を扱うためのユーティリティ・クラスです。
+ * Utility class for handling {@link ClassLoader}.
  *
  * @author koichik
  */
 public abstract class ClassLoaderUtil {
 
     /**
-     * クラスローダを返します。
+     * Returns the class loader.
      * <p>
-     * クラスローダは以下の順で検索します。
+     * The class loader is searched in the following order:
      * </p>
      * <ol>
-     * <li>呼び出されたスレッドにコンテキスト・クラスローダが設定されている場合はそのコンテキスト・クラスローダ</li>
-     * <li>ターゲット・クラスをロードしたクラスローダを取得できればそのクラスローダ</li>
-     * <li>このクラスをロードしたクラスローダを取得できればそのクラスローダ</li>
-     * <li>システムクラスローダを取得できればそのクラスローダ</li>
+     * <li>If the context class loader is set for the calling thread, that context class loader</li>
+     * <li>If the class loader that loaded the target class can be obtained, that class loader</li>
+     * <li>If the class loader that loaded this class can be obtained, that class loader</li>
+     * <li>If the system class loader can be obtained, that class loader</li>
      * </ol>
      * <p>
-     * ただし、ターゲット・クラスをロードしたクラスローダとこのクラスをロードしたクラスローダの両方が取得できた場合で、
-     * ターゲット・クラスをロードしたクラスローダがこのクラスをロードしたクラスローダの祖先であった場合は、
-     * このクラスをロードしたクラスローダを返します。
+     * However, if both the class loader that loaded the target class and the class loader that loaded this class can be obtained,
+     * and the class loader that loaded the target class is an ancestor of the class loader that loaded this class,
+     * the class loader that loaded this class is returned.
      * </p>
      *
-     * @param targetClass
-     *            ターゲット・クラス。{@literal null}であってはいけません
-     * @return クラスローダ
-     * @throws IllegalStateException
-     *             クラスローダを取得できなかった場合
+     * @param targetClass the target class (must not be {@literal null})
+     * @return the class loader
+     * @throws IllegalStateException if the class loader could not be obtained
      */
     public static ClassLoader getClassLoader(final Class<?> targetClass) {
         assertArgumentNotNull("targetClass", targetClass);
@@ -93,15 +91,13 @@ public abstract class ClassLoaderUtil {
     }
 
     /**
-     * クラスローダ<code>other</code>がクラスローダ<code>cl</code>の祖先なら<code>true</code>
-     * を返します。
+     * Returns <code>true</code> if the class loader <code>other</code> is an ancestor of the class loader <code>cl</code>.
      *
      * @param cl
-     *            クラスローダ
+     *            the class loader
      * @param other
-     *            クラスローダ
-     * @return クラスローダ<code>other</code>がクラスローダ<code>cl</code>の祖先なら
-     *         <code>true</code>
+     *            the class loader to check as ancestor
+     * @return <code>true</code> if <code>other</code> is an ancestor of <code>cl</code>
      */
     protected static boolean isAncestor(final ClassLoader cl, final ClassLoader other) {
         for (final ClassLoader loader : iterable(cl)) {
@@ -113,12 +109,12 @@ public abstract class ClassLoaderUtil {
     }
 
     /**
-     * コンテキストクラスローダから指定された名前を持つすべてのリソースを探します。
+     * Searches for all resources with the specified name from the context class loader.
      *
      * @param name
-     *            リソース名。{@literal null}や空文字列であってはいけません
-     * @return リソースに対する URL
-     *         オブジェクトの列挙。リソースが見つからなかった場合、列挙は空になる。クラスローダがアクセスを持たないリソースは列挙に入らない
+     *            The resource name. Must not be {@literal null} or an empty string.
+     * @return An iterator of URL objects for the resources. If no resources are found, the iterator will be empty.
+     *         Resources that the class loader does not have access to will not be included.
      * @see java.lang.ClassLoader#getResources(String)
      */
     public static Iterator<URL> getResources(final String name) {
@@ -128,14 +124,14 @@ public abstract class ClassLoaderUtil {
     }
 
     /**
-     * {@link #getClassLoader(Class)}が返すクラスローダから指定された名前を持つすべてのリソースを探します。
+     * Searches for all resources with the specified name from the class loader returned by {@link #getClassLoader(Class)}.
      *
      * @param targetClass
-     *            ターゲット・クラス。{@literal null}であってはいけません
+     *            The target class. Must not be {@literal null}.
      * @param name
-     *            リソース名。{@literal null}や空文字列であってはいけません
-     * @return リソースに対する URL
-     *         オブジェクトの列挙。リソースが見つからなかった場合、列挙は空になる。クラスローダがアクセスを持たないリソースは列挙に入らない
+     *            The resource name. Must not be {@literal null} or an empty string.
+     * @return An iterator of URL objects for the resources. If no resources are found, the iterator will be empty.
+     *         Resources that the class loader does not have access to will not be included.
      * @see java.lang.ClassLoader#getResources(String)
      */
     public static Iterator<URL> getResources(final Class<?> targetClass, final String name) {
@@ -146,14 +142,14 @@ public abstract class ClassLoaderUtil {
     }
 
     /**
-     * 指定のクラスローダから指定された名前を持つすべてのリソースを探します。
+     * Searches for all resources with the specified name from the specified class loader.
      *
      * @param loader
-     *            クラスローダ。{@literal null}であってはいけません
+     *            The class loader. Must not be {@literal null}.
      * @param name
-     *            リソース名。{@literal null}や空文字列であってはいけません
-     * @return リソースに対する URL
-     *         オブジェクトの列挙。リソースが見つからなかった場合、列挙は空になる。クラスローダがアクセスを持たないリソースは列挙に入らない
+     *            The resource name. Must not be {@literal null} or an empty string.
+     * @return An enumeration of URL objects for the resources. If no resources are found, the enumeration will be empty.
+     *         Resources that the class loader does not have access to will not be included.
      * @see java.lang.ClassLoader#getResources(String)
      */
     public static Iterator<URL> getResources(final ClassLoader loader, final String name) {
@@ -169,15 +165,15 @@ public abstract class ClassLoaderUtil {
     }
 
     /**
-     * 指定されたバイナリ名を持つクラスをロードします。
+     * Loads the class with the specified binary name.
      *
      * @param loader
-     *            クラスローダ。{@literal null}であってはいけません
+     *            The class loader. Must not be {@literal null}.
      * @param className
-     *            クラスのバイナリ名。{@literal null}や空文字列であってはいけません
-     * @return 結果の<code>Class</code>オブジェクト
+     *            The binary name of the class. Must not be {@literal null} or an empty string.
+     * @return The resulting <code>Class</code> object.
      * @throws ClassNotFoundRuntimeException
-     *             クラスが見つからなかった場合
+     *             If the class could not be found.
      * @see java.lang.ClassLoader#loadClass(String)
      */
     public static Class<?> loadClass(final ClassLoader loader, final String className) {

--- a/src/main/java/org/codelibs/core/lang/ClassUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ClassUtil.java
@@ -33,19 +33,19 @@ import org.codelibs.core.exception.NoSuchFieldRuntimeException;
 import org.codelibs.core.exception.NoSuchMethodRuntimeException;
 
 /**
- * {@link Class}用のユーティリティクラスです。
+ * Utility class for {@link Class} operations.
  *
  * @author higa
  */
 public abstract class ClassUtil {
 
-    /** ラッパー型からプリミティブ型へのマップ */
+    /** Map from wrapper types to primitive types */
     protected static final Map<Class<?>, Class<?>> wrapperToPrimitiveMap = newHashMap();
 
-    /** プリミティブ型からラッパー型へのマップ */
+    /** Map from primitive types to wrapper types */
     protected static final Map<Class<?>, Class<?>> primitiveToWrapperMap = newHashMap();
 
-    /** プリミティブ型の名前からクラスへのマップ */
+    /** Map from primitive type names to classes */
     protected static final Map<String, Class<?>> primitiveNameToClassMap = newHashMap();
 
     static {
@@ -78,16 +78,16 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 現在のスレッドのコンテキストクラスローダを使って、 指定された文字列名を持つクラスまたはインタフェースに関連付けられた、
-     * {@link Class}オブジェクトを返します。
+     * Returns the {@link Class} object associated with the class or interface with the given string name,
+     * using the current thread's context class loader.
      *
      * @param <T>
-     *            {@link Class}オブジェクトが表すクラス
+     *            The class represented by the returned {@link Class} object
      * @param className
-     *            要求するクラスの完全修飾名。{@literal null}や空文字列であってはいけません
-     * @return 指定された名前を持つクラスの{@link Class}オブジェクト
+     *            The fully qualified name of the desired class. Must not be {@literal null} or empty.
+     * @return The {@link Class} object for the class with the specified name
      * @throws ClassNotFoundRuntimeException
-     *             クラスが見つからなかった場合
+     *             If the class cannot be found
      * @see Class#forName(String, boolean, ClassLoader)
      */
     public static <T> Class<T> forName(final String className) throws ClassNotFoundRuntimeException {
@@ -97,20 +97,20 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 指定されたクラスローダを使って、 指定された文字列名を持つクラスまたはインタフェースに関連付けられた{@link Class}
-     * オブジェクトを返します。
+     * Returns the {@link Class} object associated with the class or interface with the given string name,
+     * using the specified class loader.
      *
      * @param <T>
-     *            {@link Class}オブジェクトが表すクラス
+     *            The class represented by the returned {@link Class} object
      * @param className
-     *            要求するクラスの完全修飾名。{@literal null}や空文字列であってはいけません
+     *            The fully qualified name of the desired class. Must not be {@literal null} or empty.
      * @param loader
-     *            クラスのロード元である必要があるクラスローダ
-     * @return 指定された名前を持つクラスの{@link Class}オブジェクト
+     *            The class loader to use to load the class
+     * @return The {@link Class} object for the class with the specified name
      * @throws EmptyArgumentException
-     *             クラス名が{@literal null}または空文字列だった場合
+     *             If the class name is {@literal null} or empty
      * @throws ClassNotFoundRuntimeException
-     *             クラスが見つからなかった場合
+     *             If the class cannot be found
      * @see Class#forName(String, boolean, ClassLoader)
      */
     @SuppressWarnings("unchecked")
@@ -124,17 +124,17 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 現在のスレッドのコンテキストクラスローダを使って、 指定された文字列名を持つクラスまたはインタフェースに関連付けられた、
-     * {@link Class}オブジェクトを返します。
+     * Returns the {@link Class} object associated with the class or interface with the given string name,
+     * using the current thread's context class loader.
      * <p>
-     * クラスが見つからなかった場合は{@code null}を返します。
+     * Returns {@code null} if the class cannot be found.
      * </p>
      *
      * @param <T>
-     *            {@link Class}オブジェクトが表すクラス
+     *            The class represented by the returned {@link Class} object
      * @param className
-     *            要求するクラスの完全修飾名
-     * @return 指定された名前を持つクラスの{@link Class}オブジェクト
+     *            The fully qualified name of the desired class
+     * @return The {@link Class} object for the class with the specified name, or {@code null} if not found
      * @see Class#forName(String)
      */
     public static <T> Class<T> forNameNoException(final String className) {
@@ -142,19 +142,19 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 指定されたクラスローダを使って、 指定された文字列名を持つクラスまたはインタフェースに関連付けられた、 {@link Class}
-     * オブジェクトを返します。
+     * Returns the {@link Class} object associated with the class or interface with the given string name,
+     * using the specified class loader.
      * <p>
-     * クラスが見つからなかった場合は{@code null}を返します。
+     * Returns {@code null} if the class cannot be found.
      * </p>
      *
      * @param <T>
-     *            {@link Class}オブジェクトが表すクラス
+     *            The class represented by the returned {@link Class} object
      * @param className
-     *            要求するクラスの完全修飾名
+     *            The fully qualified name of the desired class
      * @param loader
-     *            クラスのロード元である必要があるクラスローダ
-     * @return 指定された名前を持つクラスの{@link Class}オブジェクト
+     *            The class loader to use to load the class
+     * @return The {@link Class} object for the class with the specified name, or {@code null} if not found
      * @see Class#forName(String)
      */
     @SuppressWarnings("unchecked")
@@ -170,15 +170,15 @@ public abstract class ClassUtil {
     }
 
     /**
-     * プリミティブクラスの場合は、ラッパークラスに変換して返します。
+     * If the class is a primitive type, returns its wrapper class.
      *
      * @param className
-     *            クラス名。{@literal null}や空文字列であってはいけません
+     *            The class name. Must not be {@literal null} or empty.
      * @return {@link Class}
      * @throws EmptyArgumentException
-     *             クラス名が{@literal null}または空文字列だった場合
+     *             If the class name is {@literal null} or empty.
      * @throws ClassNotFoundRuntimeException
-     *             {@link ClassNotFoundException}がおきた場合
+     *             If a {@link ClassNotFoundException} occurs.
      * @see #forName(String)
      */
     public static Class<?> convertClass(final String className) throws ClassNotFoundRuntimeException {
@@ -191,19 +191,19 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 指定されたクラスのデフォルトコンストラクタで、クラスの新しいインスタンスを作成および初期化します。
+     * Creates and initializes a new instance of the class using its default constructor.
      *
      * @param <T>
-     *            {@link Class}オブジェクトが表すクラス
+     *            The class represented by the {@link Class} object
      * @param clazz
-     *            クラスを表す{@link Class}オブジェクト。{@literal null}であってはいけません
-     * @return デフォルトコンストラクタを呼び出すことで作成される新規オブジェクト
+     *            The {@link Class} object representing the class. Must not be {@literal null}.
+     * @return A new object created by invoking the default constructor
      * @throws InstantiationRuntimeException
-     *             基本となるコンストラクタを宣言するクラスが{@code abstract}クラスを表す場合
+     *             If the underlying constructor represents an abstract class
      * @throws IllegalAccessRuntimeException
-     *             実パラメータ数と仮パラメータ数が異なる場合、 プリミティブ引数のラップ解除変換が失敗した場合、 またはラップ解除後、
-     *             メソッド呼び出し変換によってパラメータ値を対応する仮パラメータ型に変換できない場合、
-     *             このコンストラクタが列挙型に関連している場合
+     *             If the number of actual and formal parameters differ, if unwrapping of primitive arguments fails,
+     *             or if after unwrapping, the parameter values cannot be converted to the corresponding formal parameter types,
+     *             or if the constructor is related to an enum type
      * @see Constructor#newInstance(Object[])
      */
     public static <T> T newInstance(final Class<T> clazz) throws InstantiationRuntimeException, IllegalAccessRuntimeException {
@@ -219,21 +219,20 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 指定されたクラスをコンテキストクラスローダから取得し、デフォルトコンストラクタで、クラスの新しいインスタンスを作成および初期化します。
+     * Retrieves the specified class using the context class loader and creates and initializes a new instance of the class using its default constructor.
      *
      * @param <T>
-     *            生成するインスタンスの型
+     *            The type of the instance to be created
      * @param className
-     *            クラス名。{@literal null}や空文字列であってはいけません
-     * @return デフォルトコンストラクタを呼び出すことで作成される新規オブジェクト
+     *            The class name. Must not be {@literal null} or empty.
+     * @return A new object created by invoking the default constructor
      * @throws ClassNotFoundRuntimeException
-     *             クラスが見つからなかった場合
+     *             If the class cannot be found
      * @throws InstantiationRuntimeException
-     *             基本となるコンストラクタを宣言するクラスが{@code abstract}クラスを表す場合
+     *             If the underlying constructor represents an abstract class
      * @throws IllegalAccessRuntimeException
-     *             実パラメータ数と仮パラメータ数が異なる場合、 プリミティブ引数のラップ解除変換が失敗した場合、 またはラップ解除後、
-     *             メソッド呼び出し変換によってパラメータ値を対応する仮パラメータ型に変換できない場合、
-     *             このコンストラクタが列挙型に関連している場合
+     *             If the number of actual and formal parameters differ, if unwrapping of primitive arguments fails, or if after unwrapping,
+     *             the parameter values cannot be converted to the corresponding formal parameter types, or if the constructor is related to an enum type
      * @see #newInstance(Class)
      * @see #forName(String)
      */
@@ -246,21 +245,22 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 指定されたクラスを指定のクラスローダから取得し、デフォルトコンストラクタで、クラスの新しいインスタンスを作成および初期化します。
+     * Retrieves the specified class using the given class loader and creates and initializes a new instance of the class using its default constructor.
      *
      * @param <T>
-     *            生成するインスタンスの型
+     *            The type of the instance to be created
      * @param className
-     *            クラス名。{@literal null}や空文字列であってはいけません
+     *            The class name. Must not be {@literal null} or empty.
      * @param loader
-     *            クラスローダ
-     * @return 新しいインスタンス
+     *            The class loader to use to load the class
+     * @return A new object created by invoking the default constructor
      * @throws ClassNotFoundRuntimeException
-     *             {@link ClassNotFoundException}がおきた場合
+     *             If the class cannot be found
      * @throws InstantiationRuntimeException
-     *             {@link InstantiationException}がおきた場合
+     *             If the underlying constructor represents an abstract class
      * @throws IllegalAccessRuntimeException
-     *             {@link IllegalAccessException}がおきた場合
+     *             If the number of actual and formal parameters differ, if unwrapping of primitive arguments fails, or if after unwrapping,
+     *             the parameter values cannot be converted to the corresponding formal parameter types, or if the constructor is related to an enum type
      * @see #newInstance(Class)
      * @see #forName(String, ClassLoader)
      */
@@ -273,13 +273,13 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 代入可能かどうかを返します。
+     * Returns whether the class can be assigned from another class.
      *
      * @param toClass
-     *            代入先のクラス。{@literal null}であってはいけません
+     *            The target class. Must not be {@literal null}.
      * @param fromClass
-     *            代入元のクラス。{@literal null}であってはいけません
-     * @return 代入可能かどうか
+     *            The source class. Must not be {@literal null}.
+     * @return Whether assignment is possible.
      * @see Class#isAssignableFrom(Class)
      */
     public static boolean isAssignableFrom(final Class<?> toClass, Class<?> fromClass) {
@@ -296,11 +296,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * ラッパークラスをプリミティブクラスに変換します。
+     * Converts a wrapper class to its corresponding primitive class.
      *
      * @param clazz
-     *            ラッパークラス。{@literal null}であってはいけません
-     * @return 引数がラッパークラスならプリミティブクラス、それ以外の場合は{@literal null}
+     *            The wrapper class. Must not be {@literal null}.
+     * @return The primitive class if the argument is a wrapper class, otherwise {@literal null}.
      */
     public static Class<?> getPrimitiveClass(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -309,11 +309,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * ラッパークラスならプリミティブクラスに、 そうでなければそのままクラスを返します。
+     * If the class is a wrapper class, returns its corresponding primitive class; otherwise, returns the class itself.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return 引数がラッパークラスならプリミティブクラス、それ以外の場合は引数で渡されたクラス
+     *            The class. Must not be {@literal null}.
+     * @return The primitive class if the argument is a wrapper class, otherwise the class passed as the argument.
      */
     public static Class<?> getPrimitiveClassIfWrapper(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -326,11 +326,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * プリミティブクラスをラッパークラスに変換します。
+     * Converts a primitive class to its corresponding wrapper class.
      *
      * @param clazz
-     *            プリミティブクラス。{@literal null}であってはいけません
-     * @return 引数がプリミティブクラスならラッパークラス、それ以外の場合は{@literal null}
+     *            The primitive class. Must not be {@literal null}.
+     * @return The wrapper class if the argument is a primitive class, otherwise {@literal null}.
      */
     public static Class<?> getWrapperClass(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -339,11 +339,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * クラスがプリミティブの場合はラッパークラス、そうでない場合はもとのクラスを返します。
+     * If the class is a primitive type, returns its wrapper class; otherwise, returns the class itself.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return 引数がプリミティブクラスならラッパークラス、それ以外の場合は引数で渡されたクラス
+     *            The class. Must not be {@literal null}.
+     * @return The wrapper class if the argument is a primitive class, otherwise the class passed as the argument.
      */
     public static Class<?> getWrapperClassIfPrimitive(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -356,19 +356,17 @@ public abstract class ClassUtil {
     }
 
     /**
-     * {@link Class}オブジェクトが表すクラスの指定された{@code public}コンストラクタをリフレクトする
-     * {@link Constructor}オブジェクトを返します。
+     * Returns a {@link Constructor} object that reflects the specified {@code public} constructor of the class represented by the {@link Class} object.
      *
      * @param <T>
-     *            {@link Class}オブジェクトが表すクラス
+     *            The class represented by the {@link Class} object
      * @param clazz
-     *            クラスの{@link Class}オブジェクト。{@literal null}であってはいけません
+     *            The {@link Class} object representing the class. Must not be {@literal null}.
      * @param argTypes
-     *            パラメータ配列
-     * @return 指定された{@code argTypes}と一致する{@code public}コンストラクタの
-     *         {@link Constructor}オブジェクト
+     *            The parameter types array
+     * @return The {@link Constructor} object for the {@code public} constructor matching the specified {@code argTypes}
      * @throws NoSuchConstructorRuntimeException
-     *             一致するコンストラクタが見つからない場合
+     *             If a matching constructor is not found
      * @see Class#getConstructor(Class...)
      */
     public static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argTypes)
@@ -383,18 +381,17 @@ public abstract class ClassUtil {
     }
 
     /**
-     * {@link Class}オブジェクトが表すクラスまたはインタフェースの指定されたコンストラクタをリフレクトする
-     * {@link Constructor}オブジェクトを返します。
+     * Returns a {@link Constructor} object that reflects the specified constructor of the class represented by the {@link Class} object.
      *
      * @param <T>
-     *            {@link Class}オブジェクトが表すクラス
+     *            The class represented by the {@link Class} object
      * @param clazz
-     *            クラスの{@link Class}オブジェクト。{@literal null}であってはいけません
+     *            The {@link Class} object representing the class. Must not be {@literal null}.
      * @param argTypes
-     *            パラメータ配列
-     * @return 指定された{@code argTypes}と一致するコンストラクタの{@link Constructor}オブジェクト
+     *            The parameter types array
+     * @return The {@link Constructor} object for the constructor matching the specified {@code argTypes}
      * @throws NoSuchConstructorRuntimeException
-     *             一致するコンストラクタが見つからない場合
+     *             If a matching constructor is not found
      * @see Class#getDeclaredConstructor(Class...)
      */
     public static <T> Constructor<T> getDeclaredConstructor(final Class<T> clazz, final Class<?>... argTypes)
@@ -409,18 +406,17 @@ public abstract class ClassUtil {
     }
 
     /**
-     * {@link Class}オブジェクトが表すクラスまたはインタフェースの指定された{@code public}メンバフィールドをリフレクトする
-     * {@link Field}オブジェクトを返します。
+     * Returns a {@link Field} object that reflects the specified {@code public} member field of the class or interface represented by the {@link Class} object.
      *
      * @param clazz
-     *            クラスの{@link Class}オブジェクト。{@literal null}であってはいけません
+     *            The {@link Class} object representing the class. Must not be {@literal null}.
      * @param name
-     *            フィールド名。{@literal null}や空文字列であってはいけません
-     * @return {@code name}で指定されたこのクラスの{@link Field}オブジェクト
+     *            The field name. Must not be {@literal null} or empty.
+     * @return The {@link Field} object for the field specified by {@code name} in this class.
      * @throws EmptyArgumentException
-     *             フィールド名が{@literal null}または空文字列だった場合
+     *             If the field name is {@literal null} or empty.
      * @throws NoSuchFieldRuntimeException
-     *             指定された名前のフィールドが見つからない場合
+     *             If a field with the specified name cannot be found.
      * @see Class#getField(String)
      */
     public static Field getField(final Class<?> clazz, final String name) throws NoSuchFieldRuntimeException {
@@ -435,16 +431,15 @@ public abstract class ClassUtil {
     }
 
     /**
-     * {@link Class}オブジェクトが表すクラスまたはインタフェースの指定された宣言フィールドをリフレクトする{@link Field}
-     * オブジェクトを返します。
+     * Returns a {@link Field} object that reflects the specified declared field of the class or interface represented by the {@link Class} object.
      *
      * @param clazz
-     *            クラスの{@link Class}オブジェクト。{@literal null}であってはいけません
+     *            The {@link Class} object representing the class. Must not be {@literal null}.
      * @param name
-     *            フィールド名。{@literal null}や空文字列であってはいけません
-     * @return {@code name}で指定されたこのクラスの{@link Field}オブジェクト
+     *            The field name. Must not be {@literal null} or empty.
+     * @return The {@link Field} object for the field specified by {@code name} in this class.
      * @throws NoSuchFieldRuntimeException
-     *             指定された名前のフィールドが見つからない場合
+     *             If a field with the specified name cannot be found.
      * @see Class#getDeclaredField(String)
      */
     public static Field getDeclaredField(final Class<?> clazz, final String name) throws NoSuchFieldRuntimeException {
@@ -459,20 +454,19 @@ public abstract class ClassUtil {
     }
 
     /**
-     * {@link Class}オブジェクトが表すクラスまたはインタフェースの指定された{@code public}メンバメソッドをリフレクトする
-     * {@link Method}オブジェクトを返します。
+     * Returns a {@link Method} object that reflects the specified {@code public} member method of the class or interface represented by the {@link Class} object.
      *
      * @param clazz
-     *            クラスの{@link Class}オブジェクト。{@literal null}であってはいけません
+     *            The {@link Class} object representing the class. Must not be {@literal null}.
      * @param name
-     *            メソッドの名前。{@literal null}や空文字列であってはいけません
+     *            The method name. Must not be {@literal null} or empty.
      * @param argTypes
-     *            パラメータのリスト
-     * @return 指定された{@code name}および{@code argTypes}と一致する{@link Method}オブジェクト
+     *            The list of parameter types.
+     * @return The {@link Method} object matching the specified {@code name} and {@code argTypes}.
      * @throws EmptyArgumentException
-     *             メソッド名が{@literal null}または空文字列だった場合
+     *             If the method name is {@literal null} or empty.
      * @throws NoSuchMethodRuntimeException
-     *             一致するメソッドが見つからない場合
+     *             If a matching method cannot be found.
      * @see Class#getMethod(String, Class...)
      */
     public static Method getMethod(final Class<?> clazz, final String name, final Class<?>... argTypes)
@@ -488,18 +482,17 @@ public abstract class ClassUtil {
     }
 
     /**
-     * {@link Class}オブジェクトが表すクラスまたはインタフェースの指定されたメンバメソッドをリフレクトする{@link Method}
-     * オブジェクトを返します。
+     * Returns a {@link Method} object that reflects the specified declared member method of the class or interface represented by the {@link Class} object.
      *
      * @param clazz
-     *            クラスの{@link Class}オブジェクト。{@literal null}であってはいけません
+     *            The {@link Class} object representing the class. Must not be {@literal null}.
      * @param name
-     *            メソッドの名前。{@literal null}や空文字列であってはいけません
+     *            The method name. Must not be {@literal null} or empty.
      * @param argTypes
-     *            パラメータのリスト
-     * @return 指定された{@code name}および{@code argTypes}と一致する{@link Method}オブジェクト
+     *            The list of parameter types.
+     * @return The {@link Method} object matching the specified {@code name} and {@code argTypes}.
      * @throws NoSuchMethodRuntimeException
-     *             一致するメソッドが見つからない場合
+     *             If a matching method cannot be found.
      * @see Class#getDeclaredMethod(String, Class...)
      */
     public static Method getDeclaredMethod(final Class<?> clazz, final String name, final Class<?>... argTypes)
@@ -515,11 +508,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * パッケージ名を返します。
+     * Returns the package name of the specified class.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return パッケージ名
+     *            The class. Must not be {@literal null}.
+     * @return The package name.
      */
     public static String getPackageName(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -533,11 +526,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * FQCNからパッケージ名を除いた名前を返します。
+     * Returns the class name without the package name from the fully qualified class name (FQCN).
      *
      * @param className
-     *            クラス名。{@literal null}や空文字列であってはいけません
-     * @return FQCNからパッケージ名を除いた名前
+     *            The class name. Must not be {@literal null} or empty.
+     * @return The class name without the package name from the FQCN.
      */
     public static String getShortClassName(final String className) {
         assertArgumentNotEmpty("className", className);
@@ -550,11 +543,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * FQCNをパッケージ名とFQCNからパッケージ名を除いた名前に分けます。
+     * Splits a fully qualified class name (FQCN) into the package name and the class name without the package.
      *
      * @param className
-     *            クラス名。{@literal null}や空文字列であってはいけません
-     * @return パッケージ名とFQCNからパッケージ名を除いた名前
+     *            The class name. Must not be {@literal null} or empty.
+     * @return An array containing the package name and the class name without the package.
      */
     public static String[] splitPackageAndShortClassName(final String className) {
         assertArgumentNotEmpty("className", className);
@@ -571,11 +564,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * 配列の場合は要素のクラス名に{@literal []}を加えた文字列、それ以外はクラス名そのものを返します。
+     * Returns the class name itself, or for arrays, the element class name with {@literal []} appended.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return クラス名
+     *            The class. Must not be {@literal null}.
+     * @return The class name.
      */
     public static String getSimpleClassName(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -587,11 +580,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * クラス名をリソースパスとして表現します。
+     * Returns the resource path representation of the class name.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return リソースパス
+     *            The class. Must not be {@literal null}.
+     * @return The resource path.
      * @see #getResourcePath(String)
      */
     public static String getResourcePath(final Class<?> clazz) {
@@ -601,11 +594,11 @@ public abstract class ClassUtil {
     }
 
     /**
-     * クラス名をリソースパスとして表現します。
+     * Returns the resource path representation of the class name.
      *
      * @param className
-     *            クラス名。{@literal null}や空文字列であってはいけません
-     * @return リソースパス
+     *            The class name. Must not be {@literal null} or empty.
+     * @return The resource path.
      */
     public static String getResourcePath(final String className) {
         assertArgumentNotEmpty("className", className);
@@ -614,13 +607,13 @@ public abstract class ClassUtil {
     }
 
     /**
-     * クラス名の要素を結合します。
+     * Concatenates elements of a class name.
      *
      * @param s1
-     *            クラス名の要素1
+     *            The first element of the class name
      * @param s2
-     *            クラス名の要素2
-     * @return 結合された名前
+     *            The second element of the class name
+     * @return The concatenated name
      */
     public static String concatName(final String s1, final String s2) {
         if (StringUtil.isEmpty(s1) && StringUtil.isEmpty(s2)) {

--- a/src/main/java/org/codelibs/core/lang/ConstructorUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ConstructorUtil.java
@@ -26,28 +26,21 @@ import org.codelibs.core.exception.InstantiationRuntimeException;
 import org.codelibs.core.exception.InvocationTargetRuntimeException;
 
 /**
- * {@link Constructor}用のユーティリティクラスです。
+ * Utility class for {@link Constructor} operations.
  *
  * @author higa
  */
 public abstract class ConstructorUtil {
 
     /**
-     * 指定された初期化パラメータで、コンストラクタの宣言クラスの新しいインスタンスを作成および初期化します。
+     * Creates and initializes a new instance of the class declared by the specified constructor with the given initialization parameters.
      *
-     * @param <T>
-     *            コンストラクタの宣言クラス
-     * @param constructor
-     *            コンストラクタ。{@literal null}であってはいけません
-     * @param args
-     *            コンストラクタ呼び出しに引数として渡すオブジェクトの配列
-     * @return コンストラクタを呼び出すことで作成される新規オブジェクト
-     * @throws InstantiationRuntimeException
-     *             基本となるコンストラクタを宣言するクラスが{@code abstract}クラスを表す場合
-     * @throws IllegalAccessRuntimeException
-     *             実パラメータ数と仮パラメータ数が異なる場合、 プリミティブ引数のラップ解除変換が失敗した場合、 またはラップ解除後、
-     *             メソッド呼び出し変換によってパラメータ値を対応する仮パラメータ型に変換できない場合、
-     *             このコンストラクタが列挙型に関連している場合
+     * @param <T> the type of the object
+     * @param constructor the constructor (must not be {@literal null})
+     * @param args the array of objects to be passed as arguments to the constructor invocation
+     * @return a new object created by invoking the constructor
+     * @throws InstantiationRuntimeException if the class declaring the constructor is abstract
+     * @throws IllegalAccessRuntimeException if the number of actual and formal parameters differ, if primitive arguments cannot be converted, or if the class is related to enums
      * @see Constructor#newInstance(Object[])
      */
     public static <T> T newInstance(final Constructor<T> constructor, final Object... args)
@@ -66,11 +59,10 @@ public abstract class ConstructorUtil {
     }
 
     /**
-     * <code>public</code>かどうかを返します。
+     * Returns whether the constructor is <code>public</code>.
      *
-     * @param constructor
-     *            コンストラクタ。{@literal null}や空文字列であってはいけません
-     * @return <code>public</code>かどうか
+     * @param constructor the constructor (must not be {@literal null} or empty string)
+     * @return whether the constructor is <code>public</code>
      */
     public static boolean isPublic(final Constructor<?> constructor) {
         assertArgumentNotNull("constructor", constructor);

--- a/src/main/java/org/codelibs/core/lang/FieldUtil.java
+++ b/src/main/java/org/codelibs/core/lang/FieldUtil.java
@@ -26,22 +26,19 @@ import org.codelibs.core.exception.ClIllegalArgumentException;
 import org.codelibs.core.exception.IllegalAccessRuntimeException;
 
 /**
- * {@link Field}用のユーティリティクラスです。
+ * Utility class for {@link Field} operations.
  *
  * @author higa
  */
 public abstract class FieldUtil {
 
     /**
-     * {@link Field}によって表される{@code static}フィールドの値を返します。
+     * Returns the value of a {@code static} field represented by the given {@link Field}.
      *
-     * @param <T>
-     *            フィールドの型
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return {@code static}フィールドで表現される値
-     * @throws IllegalAccessRuntimeException
-     *             基本となるフィールドにアクセスできない場合
+     * @param <T> the type of the field
+     * @param field the field (must not be {@literal null})
+     * @return the value represented by the {@code static} field
+     * @throws IllegalAccessRuntimeException if the field cannot be accessed
      * @see Field#get(Object)
      */
     @SuppressWarnings("unchecked")
@@ -52,18 +49,13 @@ public abstract class FieldUtil {
     }
 
     /**
-     * 指定されたオブジェクトについて、{@link Field}によって表されるフィールドの値を返します。
+     * Returns the value of the field represented by the given {@link Field} for the specified object.
      *
-     * @param <T>
-     *            フィールドの型
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @param target
-     *            表現されるフィールド値の抽出元オブジェクト。フィールドが{@literal static}の場合は
-     *            {@literal null}
-     * @return オブジェクト{@code obj}内で表現される値
-     * @throws IllegalAccessRuntimeException
-     *             基本となるフィールドにアクセスできない場合
+     * @param <T> the type of the field
+     * @param field the field (must not be {@literal null})
+     * @param target the object from which to extract the field value; {@literal null} if the field is static
+     * @return the value represented by the field in the object
+     * @throws IllegalAccessRuntimeException if the field cannot be accessed
      * @see Field#get(Object)
      */
     @SuppressWarnings("unchecked")
@@ -78,13 +70,11 @@ public abstract class FieldUtil {
     }
 
     /**
-     * {@literal static}な {@link Field}の値をintとして取得します。
+     * Returns the value of a {@literal static} {@link Field} as an int.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return フィールドの値
-     * @throws IllegalAccessRuntimeException
-     *             {@link IllegalAccessException}が発生した場合
+     * @param field the field (must not be {@literal null})
+     * @return the field value
+     * @throws IllegalAccessRuntimeException {@link IllegalAccessException} if an error occurs
      * @see #getInt(Field, Object)
      */
     public static int getInt(final Field field) throws IllegalAccessRuntimeException {
@@ -94,15 +84,12 @@ public abstract class FieldUtil {
     }
 
     /**
-     * {@link Field}の値をintとして取得します。
+     * Returns the value of a {@link Field} as an int.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @param target
-     *            ターゲットオブジェクト。フィールドが{@literal static}の場合は{@literal null}
-     * @return フィールドの値
-     * @throws IllegalAccessRuntimeException
-     *             {@link IllegalAccessException}が発生した場合
+     * @param field the field (must not be {@literal null})
+     * @param target the target object; {@literal null} if the field is static
+     * @return the field value
+     * @throws IllegalAccessRuntimeException {@link IllegalAccessException} if an error occurs
      * @see Field#getInt(Object)
      */
     public static int getInt(final Field field, final Object target) throws IllegalAccessRuntimeException {
@@ -116,13 +103,11 @@ public abstract class FieldUtil {
     }
 
     /**
-     * {@literal static}な {@link Field}の値を {@link String}として取得します。
+     * Returns the value of a {@literal static} {@link Field} as a {@link String}.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return フィールドの値
-     * @throws IllegalAccessRuntimeException
-     *             {@link IllegalAccessException}が発生した場合
+     * @param field the field (must not be {@literal null})
+     * @return the field value
+     * @throws IllegalAccessRuntimeException {@link IllegalAccessException} if an error occurs
      * @see #getString(Field, Object)
      */
     public static String getString(final Field field) throws IllegalAccessRuntimeException {
@@ -132,15 +117,12 @@ public abstract class FieldUtil {
     }
 
     /**
-     * {@link Field}の値を {@link String}として取得します。
+     * Returns the value of a {@link Field} as a {@link String}.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @param target
-     *            ターゲットオブジェクト。フィールドが{@literal static}の場合は{@literal null}
-     * @return フィールドの値
-     * @throws IllegalAccessRuntimeException
-     *             {@link IllegalAccessException}が発生した場合
+     * @param field the field (must not be {@literal null})
+     * @param target the target object; {@literal null} if the field is static
+     * @return the field value
+     * @throws IllegalAccessRuntimeException {@link IllegalAccessException} if an error occurs
      * @see Field#get(Object)
      */
     public static String getString(final Field field, final Object target) throws IllegalAccessRuntimeException {
@@ -154,14 +136,11 @@ public abstract class FieldUtil {
     }
 
     /**
-     * {@link Field}オブジェクトによって表される{@code static}フィールドを、指定された新しい値に設定します。
+     * Sets the value of the given {@link Field} representing a {@code static} field to the specified new value.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @param value
-     *            {@literal static}フィールドの新しい値
-     * @throws IllegalAccessRuntimeException
-     *             基本となるフィールドにアクセスできない場合
+     * @param field the field (must not be {@literal null})
+     * @param value the new value for the {@literal static} field
+     * @throws IllegalAccessRuntimeException if the field cannot be accessed
      * @see Field#set(Object, Object)
      */
     public static void set(final Field field, final Object value) throws IllegalAccessRuntimeException {
@@ -171,16 +150,12 @@ public abstract class FieldUtil {
     }
 
     /**
-     * {@link Field}オブジェクトによって表される指定されたオブジェクト引数のフィールドを、指定された新しい値に設定します。
+     * Sets the value of the given {@link Field} representing the specified object argument's field to the specified new value.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @param target
-     *            フィールドを変更するオブジェクト。フィールドが{@literal static}の場合は{@literal null}
-     * @param value
-     *            変更中の{@code target}の新しいフィールド値
-     * @throws IllegalAccessRuntimeException
-     *             基本となるフィールドにアクセスできない場合
+     * @param field the field (must not be {@literal null})
+     * @param target the object whose field is to be modified; {@literal null} if the field is static
+     * @param value the new value for the field of the {@code target} object
+     * @throws IllegalAccessRuntimeException if the field cannot be accessed
      * @see Field#set(Object, Object)
      */
     public static void set(final Field field, final Object target, final Object value) throws IllegalAccessRuntimeException {
@@ -205,11 +180,10 @@ public abstract class FieldUtil {
     }
 
     /**
-     * インスタンスフィールドかどうか返します。
+     * Checks if the given field is an instance field.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return インスタンスフィールドなら{@literal true}
+     * @param field the field (must not be {@literal null})
+     * @return {@literal true} if it is an instance field
      */
     public static boolean isInstanceField(final Field field) {
         assertArgumentNotNull("field", field);
@@ -218,11 +192,10 @@ public abstract class FieldUtil {
     }
 
     /**
-     * パブリックフィールドかどうか返します。
+     * Checks if the given field is a public field.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return パブリックフィールドなら{@literal true}
+     * @param field the field (must not be {@literal null})
+     * @return {@literal true} if it is a public field
      */
     public static boolean isPublicField(final Field field) {
         assertArgumentNotNull("field", field);
@@ -231,11 +204,10 @@ public abstract class FieldUtil {
     }
 
     /**
-     * ファイナルフィールドかどうか返します。
+     * Checks if the given field is a final field.
      *
-     * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return ファイナルフィールドなら{@literal true}
+     * @param field the field (must not be {@literal null})
+     * @return {@literal true} if it is a final field
      */
     public static boolean isFinalField(final Field field) {
         assertArgumentNotNull("field", field);
@@ -244,11 +216,10 @@ public abstract class FieldUtil {
     }
 
     /**
-     * パラメタ化されたコレクション型のフィールドの要素型を返します。
+     * Returns the element type of a parameterized collection field.
      *
-     * @param field
-     *            パラメタ化されたコレクション型のフィールド。{@literal null}であってはいけません
-     * @return コレクションの要素型
+     * @param field a field of a parameterized collection type (must not be {@literal null})
+     * @return the element type of the collection
      */
     public static Class<?> getElementTypeOfCollection(final Field field) {
         assertArgumentNotNull("field", field);
@@ -258,11 +229,10 @@ public abstract class FieldUtil {
     }
 
     /**
-     * パラメタ化されたマップ型のフィールドのキー型を返します。
+     * Returns the key type of a parameterized map field.
      *
-     * @param field
-     *            パラメタ化されたマップ型のフィールド。{@literal null}であってはいけません
-     * @return マップのキー型
+     * @param field a field of a parameterized map type (must not be {@literal null})
+     * @return the key type of the map
      */
     public static Class<?> getKeyTypeOfMap(final Field field) {
         assertArgumentNotNull("field", field);
@@ -272,11 +242,10 @@ public abstract class FieldUtil {
     }
 
     /**
-     * パラメタ化されたマップ型のフィールドの値型を返します。
+     * Returns the value type of a parameterized map field.
      *
-     * @param field
-     *            パラメタ化されたマップ型のフィールド。{@literal null}であってはいけません
-     * @return マップの値型
+     * @param field a field of a parameterized map type (must not be {@literal null})
+     * @return the value type of the map
      */
     public static Class<?> getValueTypeOfMap(final Field field) {
         assertArgumentNotNull("field", field);

--- a/src/main/java/org/codelibs/core/lang/GenericsUtil.java
+++ b/src/main/java/org/codelibs/core/lang/GenericsUtil.java
@@ -127,9 +127,9 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * Returns the generic type of the specified class for the given index.
+     * Returns the generic type of the specified type for the given index.
      *
-     * @param clazz the class to analyze
+     * @param type the type to analyze
      * @param index the index of the generic type
      * @return the generic type class, or null if not found
      */
@@ -146,9 +146,9 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * Returns the generic type of the specified class for the given index, or the default class if not found.
+     * Returns the generic type of the specified type for the given index, or the default class if not found.
      *
-     * @param clazz the class to analyze
+     * @param type the type to analyze
      * @param index the index of the generic type
      * @param defaultClass the default class to return if not found
      * @return the generic type class, or the default class

--- a/src/main/java/org/codelibs/core/lang/GenericsUtil.java
+++ b/src/main/java/org/codelibs/core/lang/GenericsUtil.java
@@ -33,21 +33,21 @@ import java.util.Set;
 import org.codelibs.core.collection.CollectionsUtil;
 
 /**
- * genericsを扱うためのユーティリティ・クラスです。
+ * Utility class for handling generics in Java.
  *
  * @author koichik
  */
 public abstract class GenericsUtil {
 
     /**
-     * <code>type</code>の原型が<code>clazz</code>に代入可能であれば<code>true</code>を、
-     * それ以外の場合は<code>false</code>を返します。
+     * Returns <code>true</code> if the raw type of <code>type</code> can be assigned to <code>clazz</code>,
+     * <code>false</code> otherwise.
      *
      * @param type
-     *            タイプ。{@literal null}であってはいけません
+     *            the type to check. Cannot be null.
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return <code>type</code>の原型が<code>clazz</code>に代入可能であれば<code>true</code>
+     *            the class to check against. Cannot be null.
+     * @return <code>true</code> if the raw type of <code>type</code> can be assigned to <code>clazz</code>
      */
     public static boolean isTypeOf(final Type type, final Class<?> clazz) {
         assertArgumentNotNull("type", type);
@@ -64,18 +64,18 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * <code>type</code>の原型を返します。
+     * Returns the raw class of the specified type.
      * <ul>
-     * <li><code>type</code>が<code>Class</code>の場合はそのまま返します。</li>
-     * <li><code>type</code>がパラメータ化された型の場合はその原型を返します。</li>
-     * <li><code>type</code>がワイルドカード型の場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が配列の場合はその要素の実際の型の配列を返します。</li>
-     * <li>その他の場合は<code>null</code>を返します。</li>
+     * <li>If <code>type</code> is a <code>Class</code>, it is returned as-is.</li>
+     * <li>If <code>type</code> is a parameterized type, its raw type is returned.</li>
+     * <li>If <code>type</code> is a wildcard type, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is an array, the raw class of its elements is returned.</li>
+     * <li>Otherwise, <code>null</code> is returned.</li>
      * </ul>
      *
      * @param type
-     *            タイプ
-     * @return <code>type</code>の原型
+     *            the type to analyze
+     * @return the raw class of the specified type
      */
     public static Class<?> getRawClass(final Type type) {
         if (type instanceof Class) {
@@ -99,21 +99,21 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * <code>type</code>の型引数の配列を返します。
+     * Returns the array of type arguments for the specified type.
      * <p>
-     * <code>type</code>が配列型の場合はその要素型(それが配列の場合はさらにその要素型)を対象とします。
+     * If <code>type</code> is an array type, the element type(s) of the array are analyzed recursively.
      * </p>
      * <p>
-     * <code>type</code>がパラメータ化された型であっても、直接型引数を持たない場合は空の配列を返します。
-     * パラメータ化された型の中にネストされた、型引数を持たない型などがその例です。
+     * If <code>type</code> is a parameterized type but has no direct type arguments, an empty array is returned.
+     * This includes cases where the parameterized type contains nested types without type arguments.
      * </p>
      * <p>
-     * <code>type</code>がパラメータ化された型でない場合は<code>null</code>を返します。
+     * If <code>type</code> is not a parameterized type, <code>null</code> is returned.
      * </p>
      *
      * @param type
-     *            タイプ
-     * @return <code>type</code>の型引数の配列
+     *            the type to analyze
+     * @return the array of type arguments for the specified type
      * @see ParameterizedType#getActualTypeArguments()
      */
     public static Type[] getGenericParameters(final Type type) {
@@ -127,16 +127,11 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * 指定された位置の<code>type</code>の型引数を返します。
-     * <p>
-     * <code>type</code>がパラメータ化された型でない場合は<code>null</code>を返します。
-     * </p>
+     * Returns the generic type of the specified class for the given index.
      *
-     * @param type
-     *            タイプ
-     * @param index
-     *            位置
-     * @return 指定された位置の<code>type</code>の型引数
+     * @param clazz the class to analyze
+     * @param index the index of the generic type
+     * @return the generic type class, or null if not found
      */
     public static Type getGenericParameter(final Type type, final int index) {
         if (!(type instanceof ParameterizedType)) {
@@ -151,14 +146,73 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された型を要素とする配列の要素型を返します。
+     * Returns the generic type of the specified class for the given index, or the default class if not found.
+     *
+     * @param clazz the class to analyze
+     * @param index the index of the generic type
+     * @param defaultClass the default class to return if not found
+     * @return the generic type class, or the default class
+     */
+    public static Type getGenericParameter(final Type type, final int index, final Class<?> defaultClass) {
+        final Type genericParameter = getGenericParameter(type, index);
+        return genericParameter != null ? genericParameter : defaultClass;
+    }
+
+    /**
+     * Returns the generic type of the specified field for the given index.
+     *
+     * @param field the field to analyze
+     * @param index the index of the generic type
+     * @return the generic type class, or null if not found
+     */
+    public static Type getGenericParameter(final java.lang.reflect.Field field, final int index) {
+        return getGenericParameter(field.getGenericType(), index);
+    }
+
+    /**
+     * Returns the generic type of the specified field for the given index, or the default class if not found.
+     *
+     * @param field the field to analyze
+     * @param index the index of the generic type
+     * @param defaultClass the default class to return if not found
+     * @return the generic type class, or the default class
+     */
+    public static Type getGenericParameter(final java.lang.reflect.Field field, final int index, final Class<?> defaultClass) {
+        return getGenericParameter(field.getGenericType(), index, defaultClass);
+    }
+
+    /**
+     * Returns the generic type of the specified method for the given index.
+     *
+     * @param method the method to analyze
+     * @param index the index of the generic type
+     * @return the generic type class, or null if not found
+     */
+    public static Type getGenericParameter(final java.lang.reflect.Method method, final int index) {
+        return getGenericParameter(method.getGenericReturnType(), index);
+    }
+
+    /**
+     * Returns the generic type of the specified method for the given index, or the default class if not found.
+     *
+     * @param method the method to analyze
+     * @param index the index of the generic type
+     * @param defaultClass the default class to return if not found
+     * @return the generic type class, or the default class
+     */
+    public static Type getGenericParameter(final java.lang.reflect.Method method, final int index, final Class<?> defaultClass) {
+        return getGenericParameter(method.getGenericReturnType(), index, defaultClass);
+    }
+
+    /**
+     * Returns the element type of an array with parameterized types.
      * <p>
-     * <code>type</code>がパラメータ化された型の配列でない場合は<code>null</code>を返します。
+     * If <code>type</code> is not an array of parameterized types, <code>null</code> is returned.
      * </p>
      *
      * @param type
-     *            パラメータ化された型を要素とする配列
-     * @return パラメータ化された型を要素とする配列の要素型
+     *            the type to analyze
+     * @return the element type of the array, or null if not an array of parameterized types
      */
     public static Type getElementTypeOfArray(final Type type) {
         if (!(type instanceof GenericArrayType)) {
@@ -168,14 +222,14 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link Collection}の要素型を返します。
+     * Returns the element type of a parameterized {@link Collection}.
      * <p>
-     * <code>type</code>がパラメータ化された{@link List}でない場合は<code>null</code>を返します。
+     * If <code>type</code> is not a parameterized {@link Collection}, <code>null</code> is returned.
      * </p>
      *
      * @param type
-     *            パラメータ化された{@link List}
-     * @return パラメータ化された{@link List}の要素型
+     *            the type to analyze
+     * @return the element type of the collection, or null if not a parameterized collection
      */
     public static Type getElementTypeOfCollection(final Type type) {
         if (!isTypeOf(type, Collection.class)) {
@@ -185,14 +239,14 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link List}の要素型を返します。
+     * Returns the element type of a parameterized {@link List}.
      * <p>
-     * <code>type</code>がパラメータ化された{@link List}でない場合は<code>null</code>を返します。
+     * If <code>type</code> is not a parameterized {@link List}, <code>null</code> is returned.
      * </p>
      *
      * @param type
-     *            パラメータ化された{@link List}
-     * @return パラメータ化された{@link List}の要素型
+     *            the type to analyze
+     * @return the element type of the list, or null if not a parameterized list
      */
     public static Type getElementTypeOfList(final Type type) {
         if (!isTypeOf(type, List.class)) {
@@ -202,14 +256,14 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link Set}の要素型を返します。
+     * Returns the element type of a parameterized {@link Set}.
      * <p>
-     * <code>type</code>がパラメータ化された{@link Set}でない場合は<code>null</code>を返します。
+     * If <code>type</code> is not a parameterized {@link Set}, <code>null</code> is returned.
      * </p>
      *
      * @param type
-     *            パラメータ化された{@link Set}
-     * @return パラメータ化された{@link Set}の要素型
+     *            the type to analyze
+     * @return the element type of the set, or null if not a parameterized set
      */
     public static Type getElementTypeOfSet(final Type type) {
         if (!isTypeOf(type, Set.class)) {
@@ -219,14 +273,14 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link Map}のキーの型を返します。
+     * Returns the key type of a parameterized {@link Map}.
      * <p>
-     * <code>type</code>がパラメータ化された{@link Map}でない場合は<code>null</code>を返します。
+     * If <code>type</code> is not a parameterized {@link Map}, <code>null</code> is returned.
      * </p>
      *
      * @param type
-     *            パラメータ化された{@link Map}
-     * @return パラメータ化された{@link Map}のキーの型
+     *            the type to analyze
+     * @return the key type of the map, or null if not a parameterized map
      */
     public static Type getKeyTypeOfMap(final Type type) {
         if (!isTypeOf(type, Map.class)) {
@@ -236,14 +290,14 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link Map}の値の型を返します。
+     * Returns the value type of a parameterized {@link Map}.
      * <p>
-     * <code>type</code>がパラメータ化された{@link Map}でない場合は<code>null</code>を返します。
+     * If <code>type</code> is not a parameterized {@link Map}, <code>null</code> is returned.
      * </p>
      *
      * @param type
-     *            パラメータ化された{@link Map}
-     * @return パラメータ化された{@link Map}の値の型
+     *            the type to analyze
+     * @return the value type of the map, or null if not a parameterized map
      */
     public static Type getValueTypeOfMap(final Type type) {
         if (!isTypeOf(type, Map.class)) {
@@ -253,11 +307,12 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された型(クラスまたはインタフェース)が持つ型変数をキー、型引数を値とする{@link Map}を返します。
+     * Returns a {@link Map} where the keys are the type variables and the values are the type arguments
+     * of the specified parameterized type (class or interface).
      *
      * @param clazz
-     *            パラメータ化された型(クラスまたはインタフェース)。{@literal null}であってはいけません
-     * @return パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
+     *            the parameterized type (class or interface) to analyze. Cannot be null.
+     * @return a {@link Map} where the keys are the type variables and the values are the type arguments
      */
     public static Map<TypeVariable<?>, Type> getTypeVariableMap(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -285,14 +340,15 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された型(クラスまたはインタフェース)が持つ型変数および型引数を集めて<code>map</code>に追加します。
+     * Gathers the type variables and type arguments of the specified parameterized type (class or interface)
+     * and adds them to the given map.
      *
      * @param clazz
-     *            クラス
+     *            the class to analyze
      * @param type
-     *            型
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
+     *            the map to which the type variables and type arguments are added
      */
     protected static void gatherTypeVariables(final Class<?> clazz, final Type type, final Map<TypeVariable<?>, Type> map) {
         if (clazz == null) {
@@ -314,12 +370,12 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された型(クラスまたはインタフェース)が持つ型変数および型引数を集めて<code>map</code>に追加します。
+     * Gathers the type variables and type arguments of the specified type and adds them to the given map.
      *
      * @param type
-     *            型
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
+     *            the map to which the type variables and type arguments are added
      */
     protected static void gatherTypeVariables(final Type type, final Map<TypeVariable<?>, Type> map) {
         if (type instanceof ParameterizedType) {
@@ -333,22 +389,22 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * <code>type</code>の実際の型を返します。
+     * Returns the actual class of the specified type.
      * <ul>
-     * <li><code>type</code>が<code>Class</code>の場合はそのまま返します。</li>
-     * <li><code>type</code>がパラメータ化された型の場合はその原型を返します。</li>
-     * <li><code>type</code>がワイルドカード型の場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が型変数で引数{@code map}のキーとして含まれている場合はその変数の実際の型引数を返します。</li>
-     * <li><code>type</code>が型変数で引数{@code map}のキーとして含まれていない場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が配列の場合はその要素の実際の型の配列を返します。</li>
-     * <li>その他の場合は<code>null</code>を返します。</li>
+     * <li>If <code>type</code> is a <code>Class</code>, it is returned as-is.</li>
+     * <li>If <code>type</code> is a parameterized type, its raw type is returned.</li>
+     * <li>If <code>type</code> is a wildcard type, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is a type variable and is a key in the given map, its actual type argument is returned.</li>
+     * <li>If <code>type</code> is a type variable and is not a key in the given map, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is an array, the actual class of its elements is returned.</li>
+     * <li>Otherwise, <code>null</code> is returned.</li>
      * </ul>
      *
      * @param type
-     *            タイプ
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
-     * @return <code>type</code>の実際の型
+     *            the map that contains the type variables and type arguments
+     * @return the actual class of the specified type
      */
     public static Class<?> getActualClass(final Type type, final Map<TypeVariable<?>, Type> map) {
         if (type instanceof Class) {
@@ -376,22 +432,22 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された型を要素とする配列の実際の要素型を返します。
+     * Returns the actual element type of an array with parameterized types.
      * <ul>
-     * <li><code>type</code>がパラメータ化された型の配列でない場合は<code>null</code>を返します。</li>
-     * <li><code>type</code>が<code>Class</code>の場合はそのまま返します。</li>
-     * <li><code>type</code>がパラメータ化された型の場合はその原型を返します。</li>
-     * <li><code>type</code>がワイルドカード型の場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が型変数の場合はその変数の実際の型引数を返します。</li>
-     * <li><code>type</code>が配列の場合はその要素の実際の型の配列を返します。</li>
-     * <li>その他の場合は<code>null</code>を返します。</li>
+     * <li>If <code>type</code> is not an array of parameterized types, <code>null</code> is returned.</li>
+     * <li>If <code>type</code> is a <code>Class</code>, it is returned as-is.</li>
+     * <li>If <code>type</code> is a parameterized type, its raw type is returned.</li>
+     * <li>If <code>type</code> is a wildcard type, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is a type variable, its actual type argument is returned.</li>
+     * <li>If <code>type</code> is an array, the actual class of its elements is returned.</li>
+     * <li>Otherwise, <code>null</code> is returned.</li>
      * </ul>
      *
      * @param type
-     *            パラメータ化された型を要素とする配列
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
-     * @return パラメータ化された型を要素とする配列の実際の要素型
+     *            the map that contains the type variables and type arguments
+     * @return the actual element type of the array, or null if not an array of parameterized types
      */
     public static Class<?> getActualElementClassOfArray(final Type type, final Map<TypeVariable<?>, Type> map) {
         if (!(type instanceof GenericArrayType)) {
@@ -401,23 +457,22 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link Collection}の実際の要素型を返します。
+     * Returns the actual element type of a parameterized {@link Collection}.
      * <ul>
-     * <li><code>type</code>がパラメータ化された{@link Collection}でない場合は<code>null</code>
-     * を返します。</li>
-     * <li><code>type</code>が<code>Class</code>の場合はそのまま返します。</li>
-     * <li><code>type</code>がパラメータ化された型の場合はその原型を返します。</li>
-     * <li><code>type</code>がワイルドカード型の場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が型変数の場合はその変数の実際の型引数を返します。</li>
-     * <li><code>type</code>が配列の場合はその要素の実際の型の配列を返します。</li>
-     * <li>その他の場合は<code>null</code>を返します。</li>
+     * <li>If <code>type</code> is not a parameterized {@link Collection}, <code>null</code> is returned.</li>
+     * <li>If <code>type</code> is a <code>Class</code>, it is returned as-is.</li>
+     * <li>If <code>type</code> is a parameterized type, its raw type is returned.</li>
+     * <li>If <code>type</code> is a wildcard type, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is a type variable, its actual type argument is returned.</li>
+     * <li>If <code>type</code> is an array, the actual class of its elements is returned.</li>
+     * <li>Otherwise, <code>null</code> is returned.</li>
      * </ul>
      *
      * @param type
-     *            パラメータ化された{@link Collection}
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
-     * @return パラメータ化された{@link Collection}の実際の要素型
+     *            the map that contains the type variables and type arguments
+     * @return the actual element type of the collection, or null if not a parameterized collection
      */
     public static Class<?> getActualElementClassOfCollection(final Type type, final Map<TypeVariable<?>, Type> map) {
         if (!isTypeOf(type, Collection.class)) {
@@ -427,22 +482,22 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link List}の実際の要素型を返します。
+     * Returns the actual element type of a parameterized {@link List}.
      * <ul>
-     * <li><code>type</code>がパラメータ化された{@link List}でない場合は<code>null</code>を返します。</li>
-     * <li><code>type</code>が<code>Class</code>の場合はそのまま返します。</li>
-     * <li><code>type</code>がパラメータ化された型の場合はその原型を返します。</li>
-     * <li><code>type</code>がワイルドカード型の場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が型変数の場合はその変数の実際の型引数を返します。</li>
-     * <li><code>type</code>が配列の場合はその要素の実際の型の配列を返します。</li>
-     * <li>その他の場合は<code>null</code>を返します。</li>
+     * <li>If <code>type</code> is not a parameterized {@link List}, <code>null</code> is returned.</li>
+     * <li>If <code>type</code> is a <code>Class</code>, it is returned as-is.</li>
+     * <li>If <code>type</code> is a parameterized type, its raw type is returned.</li>
+     * <li>If <code>type</code> is a wildcard type, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is a type variable, its actual type argument is returned.</li>
+     * <li>If <code>type</code> is an array, the actual class of its elements is returned.</li>
+     * <li>Otherwise, <code>null</code> is returned.</li>
      * </ul>
      *
      * @param type
-     *            パラメータ化された{@link List}
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
-     * @return パラメータ化された{@link List}の実際の要素型
+     *            the map that contains the type variables and type arguments
+     * @return the actual element type of the list, or null if not a parameterized list
      */
     public static Class<?> getActualElementClassOfList(final Type type, final Map<TypeVariable<?>, Type> map) {
         if (!isTypeOf(type, List.class)) {
@@ -452,22 +507,22 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link Set}の実際の要素型を返します。
+     * Returns the actual element type of a parameterized {@link Set}.
      * <ul>
-     * <li><code>type</code>がパラメータ化された{@link Set}でない場合は<code>null</code>を返します。</li>
-     * <li><code>type</code>が<code>Class</code>の場合はそのまま返します。</li>
-     * <li><code>type</code>がパラメータ化された型の場合はその原型を返します。</li>
-     * <li><code>type</code>がワイルドカード型の場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が型変数の場合はその変数の実際の型引数を返します。</li>
-     * <li><code>type</code>が配列の場合はその要素の実際の型の配列を返します。</li>
-     * <li>その他の場合は<code>null</code>を返します。</li>
+     * <li>If <code>type</code> is not a parameterized {@link Set}, <code>null</code> is returned.</li>
+     * <li>If <code>type</code> is a <code>Class</code>, it is returned as-is.</li>
+     * <li>If <code>type</code> is a parameterized type, its raw type is returned.</li>
+     * <li>If <code>type</code> is a wildcard type, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is a type variable, its actual type argument is returned.</li>
+     * <li>If <code>type</code> is an array, the actual class of its elements is returned.</li>
+     * <li>Otherwise, <code>null</code> is returned.</li>
      * </ul>
      *
      * @param type
-     *            パラメータ化された{@link Set}
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
-     * @return パラメータ化された{@link Set}の実際の要素型
+     *            the map that contains the type variables and type arguments
+     * @return the actual element type of the set, or null if not a parameterized set
      */
     public static Class<?> getActualElementClassOfSet(final Type type, final Map<TypeVariable<?>, Type> map) {
         if (!isTypeOf(type, Set.class)) {
@@ -477,22 +532,22 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link Map}のキーの実際の型を返します。
+     * Returns the actual key type of a parameterized {@link Map}.
      * <ul>
-     * <li>キー型がパラメータ化された{@link Map}でない場合は<code>null</code>を返します。</li>
-     * <li><code>type</code>が<code>Class</code>の場合はそのまま返します。</li>
-     * <li><code>type</code>がパラメータ化された型の場合はその原型を返します。</li>
-     * <li><code>type</code>がワイルドカード型の場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が型変数の場合はその変数の実際の型引数を返します。</li>
-     * <li><code>type</code>が配列の場合はその要素の実際の型の配列を返します。</li>
-     * <li>その他の場合は<code>null</code>を返します。</li>
+     * <li>If the key type is not a parameterized {@link Map}, <code>null</code> is returned.</li>
+     * <li>If <code>type</code> is a <code>Class</code>, it is returned as-is.</li>
+     * <li>If <code>type</code> is a parameterized type, its raw type is returned.</li>
+     * <li>If <code>type</code> is a wildcard type, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is a type variable, its actual type argument is returned.</li>
+     * <li>If <code>type</code> is an array, the actual class of its elements is returned.</li>
+     * <li>Otherwise, <code>null</code> is returned.</li>
      * </ul>
      *
      * @param type
-     *            パラメータ化された{@link Map}
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
-     * @return パラメータ化された{@link Map}のキーの実際の型
+     *            the map that contains the type variables and type arguments
+     * @return the actual key type of the map, or null if not a parameterized map
      */
     public static Class<?> getActualKeyClassOfMap(final Type type, final Map<TypeVariable<?>, Type> map) {
         if (!isTypeOf(type, Map.class)) {
@@ -502,22 +557,22 @@ public abstract class GenericsUtil {
     }
 
     /**
-     * パラメータ化された{@link Map}の値の実際の型を返します。
+     * Returns the actual value type of a parameterized {@link Map}.
      * <ul>
-     * <li><code>type</code>がパラメータ化された{@link Map}でない場合は<code>null</code>を返します。</li>
-     * <li><code>type</code>が<code>Class</code>の場合はそのまま返します。</li>
-     * <li><code>type</code>がパラメータ化された型の場合はその原型を返します。</li>
-     * <li><code>type</code>がワイルドカード型の場合は(最初の)上限境界を返します。</li>
-     * <li><code>type</code>が型変数の場合はその変数の実際の型引数を返します。</li>
-     * <li><code>type</code>が配列の場合はその要素の実際の型の配列を返します。</li>
-     * <li>その他の場合は<code>null</code>を返します。</li>
+     * <li>If <code>type</code> is not a parameterized {@link Map}, <code>null</code> is returned.</li>
+     * <li>If <code>type</code> is a <code>Class</code>, it is returned as-is.</li>
+     * <li>If <code>type</code> is a parameterized type, its raw type is returned.</li>
+     * <li>If <code>type</code> is a wildcard type, its (first) upper bound is returned.</li>
+     * <li>If <code>type</code> is a type variable, its actual type argument is returned.</li>
+     * <li>If <code>type</code> is an array, the actual class of its elements is returned.</li>
+     * <li>Otherwise, <code>null</code> is returned.</li>
      * </ul>
      *
      * @param type
-     *            パラメータ化された{@link Map}
+     *            the type to analyze
      * @param map
-     *            パラメータ化された型が持つ型変数をキー、型引数を値とする{@link Map}
-     * @return パラメータ化された{@link Map}の値の実際の型
+     *            the map that contains the type variables and type arguments
+     * @return the actual value type of the map, or null if not a parameterized map
      */
     public static Class<?> getActualValueClassOfMap(final Type type, final Map<TypeVariable<?>, Type> map) {
         if (!isTypeOf(type, Map.class)) {

--- a/src/main/java/org/codelibs/core/lang/MethodUtil.java
+++ b/src/main/java/org/codelibs/core/lang/MethodUtil.java
@@ -27,28 +27,28 @@ import org.codelibs.core.exception.IllegalAccessRuntimeException;
 import org.codelibs.core.exception.InvocationTargetRuntimeException;
 
 /**
- * {@link Method}用のユーティリティクラスです。
+ * Utility class for method operations.
  *
  * @author higa
  */
 public abstract class MethodUtil {
 
     /**
-     * {@link Method}オブジェクトによって表される基本となるメソッドを、指定したオブジェクトに対して指定したパラメータで呼び出します。
+     * Invokes the underlying method represented by the {@link Method} object, with the specified object and parameters.
      *
      * @param <T>
-     *            メソッドの戻り値の型
+     *            The return type of the method
      * @param method
-     *            メソッド。{@literal null}であってはいけません
+     *            The method. Cannot be {@literal null}
      * @param target
-     *            基本となるメソッドの呼び出し元のオブジェクト。{@literal static}メソッドの場合は{@literal null}
+     *            The object on which the underlying method is to be called. {@literal null} for {@literal static} methods
      * @param args
-     *            メソッド呼び出しに使用される引数
-     * @return このオブジェクトが表すメソッドを、パラメータ{@code args}を使用して{@code obj}にディスパッチした結果
+     *            The arguments used for the method call
+     * @return The result of dispatching the method to the object using the parameters {@code args}
      * @throws IllegalAccessRuntimeException
-     *             この{@link Method}オブジェクトがJava言語アクセス制御を実施し、 基本となるメソッドにアクセスできない場合
+     *             If this {@link Method} object enforces Java language access control and the underlying method is not accessible
      * @throws InvocationTargetRuntimeException
-     *             基本となるメソッドが例外をスローする場合
+     *             If the underlying method throws an exception
      * @see Method#invoke(Object, Object[])
      */
     @SuppressWarnings("unchecked")
@@ -73,19 +73,19 @@ public abstract class MethodUtil {
     }
 
     /**
-     * {@link Method}オブジェクトによって表される基本となる{@code static}メソッドを、指定したパラメータで呼び出します。
+     * Invokes the underlying {@code static} method represented by the {@link Method} object, with the specified parameters.
      *
      * @param <T>
-     *            メソッドの戻り値の型
+     *            The return type of the method
      * @param method
-     *            メソッド。{@literal null}であってはいけません
+     *            The method. Cannot be {@literal null}
      * @param args
-     *            メソッド呼び出しに使用される引数
-     * @return このオブジェクトが表す{@code static}メソッドを、パラメータ{@code args}を使用してディスパッチした結果
+     *            The arguments used for the method call
+     * @return The result of dispatching the {@code static} method using the parameters {@code args}
      * @throws IllegalAccessRuntimeException
-     *             この{@link Method}オブジェクトがJava言語アクセス制御を実施し、 基本となるメソッドにアクセスできない場合
+     *             If this {@link Method} object enforces Java language access control and the underlying method is not accessible
      * @throws InvocationTargetRuntimeException
-     *             基本となるメソッドが例外をスローする場合
+     *             If the underlying method throws an exception
      * @see Method#invoke(Object, Object[])
      */
     @SuppressWarnings("unchecked")
@@ -97,22 +97,22 @@ public abstract class MethodUtil {
     }
 
     /**
-     * <code>abstract</code>かどうかを返します。
+     * Returns whether the method is <code>abstract</code>.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return <code>abstract</code>かどうか
+     *            The method. Cannot be {@literal null}
+     * @return <code>abstract</code> if the method is abstract
      */
     public static boolean isAbstract(final Method method) {
         return Modifier.isAbstract(method.getModifiers());
     }
 
     /**
-     * <code>public</code>かどうかを返します。
+     * Returns whether the method is <code>public</code>.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return <code>public</code>なら{@literal true}
+     *            The method. Cannot be {@literal null}
+     * @return <code>public</code> if the method is public
      */
     public static boolean isPublic(final Method method) {
         assertArgumentNotNull("method", method);
@@ -121,11 +121,11 @@ public abstract class MethodUtil {
     }
 
     /**
-     * <code>static</code>かどうかを返します。
+     * Returns whether the method is <code>static</code>.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return <code>static</code>かどうか
+     *            The method. Cannot be {@literal null}
+     * @return <code>static</code> if the method is static
      */
     public static boolean isStatic(final Method method) {
         assertArgumentNotNull("method", method);
@@ -134,11 +134,11 @@ public abstract class MethodUtil {
     }
 
     /**
-     * <code>final</code>かどうかを返します。
+     * Returns whether the method is <code>final</code>.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return <code>final </code>かどうか
+     *            The method. Cannot be {@literal null}
+     * @return <code>final </code> if the method is final
      */
     public static boolean isFinal(final Method method) {
         assertArgumentNotNull("method", method);
@@ -147,13 +147,13 @@ public abstract class MethodUtil {
     }
 
     /**
-     * シグニチャの文字列表現を返します。
+     * Returns the string representation of the method signature.
      *
      * @param methodName
-     *            メソッド名。{@literal null}や空文字列であってはいけません
+     *            The method name. Cannot be {@literal null} or empty
      * @param argTypes
-     *            引数型のな並び
-     * @return シグニチャの文字列表現
+     *            The argument types
+     * @return The string representation of the method signature
      */
     public static String getSignature(final String methodName, final Class<?>... argTypes) {
         assertArgumentNotEmpty("methodName", methodName);
@@ -171,13 +171,13 @@ public abstract class MethodUtil {
     }
 
     /**
-     * シグニチャの文字列表現を返します。
+     * Returns the string representation of the method signature.
      *
      * @param methodName
-     *            メソッド名。{@literal null}や空文字列であってはいけません
+     *            The method name. Cannot be {@literal null} or empty
      * @param methodArgs
-     *            引数の並び
-     * @return シグニチャの文字列表現
+     *            The method arguments
+     * @return The string representation of the method signature
      */
     public static String getSignature(final String methodName, final Object... methodArgs) {
         assertArgumentNotEmpty("methodName", methodName);
@@ -195,11 +195,11 @@ public abstract class MethodUtil {
     }
 
     /**
-     * {@literal equals(Object)}メソッドかどうかを返します。
+     * Returns whether the method is the {@literal equals(Object)} method.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return {@literal equals(Object)}メソッドなら{@literal true}
+     *            The method. Cannot be {@literal null}
+     * @return {@literal true} if the method is {@literal equals(Object)}
      */
     public static boolean isEqualsMethod(final Method method) {
         assertArgumentNotNull("method", method);
@@ -209,11 +209,11 @@ public abstract class MethodUtil {
     }
 
     /**
-     * {@literal hashCode()}メソッドかどうか返します。
+     * Returns whether the method is the {@literal hashCode()} method.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return {@literal hashCode()}メソッドなら{@literal true}
+     *            The method. Cannot be {@literal null}
+     * @return {@literal true} if the method is {@literal hashCode()}
      */
     public static boolean isHashCodeMethod(final Method method) {
         assertArgumentNotNull("method", method);
@@ -223,11 +223,11 @@ public abstract class MethodUtil {
     }
 
     /**
-     * {@literal toString()}メソッドかどうか返します。
+     * Returns whether the method is the {@literal toString()} method.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return {@literal toString()}メソッドなら{@literal true}
+     *            The method. Cannot be {@literal null}
+     * @return {@literal true} if the method is {@literal toString()}
      */
     public static boolean isToStringMethod(final Method method) {
         assertArgumentNotNull("method", method);
@@ -237,13 +237,13 @@ public abstract class MethodUtil {
     }
 
     /**
-     * メソッドの引数型 (パラメタ化されたコレクション) の要素型を返します。
+     * Returns the element type of the parameterized collection declared as the method's argument type.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
+     *            The method. Cannot be {@literal null}
      * @param position
-     *            パラメタ化されたコレクションが宣言されているメソッド引数の位置
-     * @return 指定されたメソッドの引数型として宣言されているパラメタ化されたコレクションの要素型
+     *            The position of the parameterized collection in the method's argument list
+     * @return The element type of the parameterized collection
      */
     public static Class<?> getElementTypeOfCollectionFromParameterType(final Method method, final int position) {
         assertArgumentNotNull("method", method);
@@ -253,11 +253,11 @@ public abstract class MethodUtil {
     }
 
     /**
-     * 指定されたメソッドの戻り値型として宣言されているパラメタ化されたコレクションの要素型を返します。
+     * Returns the element type of the parameterized collection declared as the method's return type.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return 指定されたメソッドの戻り値型として宣言されているパラメタ化されたコレクションの要素型
+     *            The method. Cannot be {@literal null}
+     * @return The element type of the parameterized collection
      */
     public static Class<?> getElementTypeOfCollectionFromReturnType(final Method method) {
         assertArgumentNotNull("method", method);
@@ -267,13 +267,13 @@ public abstract class MethodUtil {
     }
 
     /**
-     * メソッドの引数型 (パラメタ化されたマップ) のキー型を返します。
+     * Returns the key type of the parameterized map declared as the method's argument type.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
+     *            The method. Cannot be {@literal null}
      * @param position
-     *            パラメタ化されたマップが宣言されているメソッド引数の位置
-     * @return 指定されたメソッドの引数型として宣言されているパラメタ化されたマップのキー型
+     *            The position of the parameterized map in the method's argument list
+     * @return The key type of the parameterized map
      */
     public static Class<?> getKeyTypeOfMapFromParameterType(final Method method, final int position) {
         assertArgumentNotNull("method", method);
@@ -283,11 +283,11 @@ public abstract class MethodUtil {
     }
 
     /**
-     * 指定されたメソッドの戻り値型として宣言されているパラメタ化されたマップのキー型を返します。
+     * Returns the key type of the parameterized map declared as the method's return type.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return 指定されたメソッドの戻り値型として宣言されているパラメタ化されたマップのキー型
+     *            The method. Cannot be {@literal null}
+     * @return The key type of the parameterized map
      */
     public static Class<?> getKeyTypeOfMapFromReturnType(final Method method) {
         assertArgumentNotNull("method", method);
@@ -297,13 +297,13 @@ public abstract class MethodUtil {
     }
 
     /**
-     * メソッドの引数型 (パラメタ化されたマップ) の値型を返します。
+     * Returns the value type of the parameterized map declared as the method's argument type.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
+     *            The method. Cannot be {@literal null}
      * @param position
-     *            パラメタ化されたマップが宣言されているメソッド引数の位置
-     * @return 指定されたメソッドの引数型として宣言されているパラメタ化されたマップの値型
+     *            The position of the parameterized map in the method's argument list
+     * @return The value type of the parameterized map
      */
     public static Class<?> getValueTypeOfMapFromParameterType(final Method method, final int position) {
         assertArgumentNotNull("method", method);
@@ -313,11 +313,11 @@ public abstract class MethodUtil {
     }
 
     /**
-     * 指定されたメソッドの戻り値型として宣言されているパラメタ化されたマップの値型を返します。
+     * Returns the value type of the parameterized map declared as the method's return type.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return 指定されたメソッドの戻り値型として宣言されているパラメタ化されたマップの値型
+     *            The method. Cannot be {@literal null}
+     * @return The value type of the parameterized map
      */
     public static Class<?> getValueTypeOfMapFromReturnType(final Method method) {
         assertArgumentNotNull("method", method);

--- a/src/main/java/org/codelibs/core/lang/ModifierUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ModifierUtil.java
@@ -22,18 +22,18 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 /**
- * {@link Modifier}用のユーティリティクラスです。
+ * Utility class for modifier operations.
  *
  * @author shot
  */
 public abstract class ModifierUtil {
 
     /**
-     * <code>public</code>かどうか返します。
+     * Checks if the specified method is public.
      *
      * @param method
-     *            メソッド。{@literal null}であってはいけません
-     * @return パブリックかどうか
+     *            the method to check. Must not be null.
+     * @return true if public, false otherwise
      */
     public static boolean isPublic(final Method method) {
         assertArgumentNotNull("method", method);
@@ -42,11 +42,11 @@ public abstract class ModifierUtil {
     }
 
     /**
-     * <code>public</code>かどうか返します。
+     * Checks if the specified field is public.
      *
      * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return パブリックかどうか
+     *            the field to check. Must not be null.
+     * @return true if public, false otherwise
      */
     public static boolean isPublic(final Field field) {
         assertArgumentNotNull("field", field);
@@ -55,11 +55,11 @@ public abstract class ModifierUtil {
     }
 
     /**
-     * <code>public</code>,<code>static</code>,<code>final</code>かどうか返します。
+     * Checks if the specified field is public, static, and final.
      *
      * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return <code>public</code>,<code>static</code>,<code>final</code>かどうか
+     *            the field to check. Must not be null.
+     * @return true if public, static, and final, false otherwise
      */
     public static boolean isPublicStaticFinalField(final Field field) {
         assertArgumentNotNull("field", field);
@@ -68,33 +68,33 @@ public abstract class ModifierUtil {
     }
 
     /**
-     * <code>public</code>,<code>static</code>,<code>final</code>かどうか返します。
+     * Checks if the specified modifier is public, static, and final.
      *
      * @param modifier
-     *            モディファイヤ
-     * @return <code>public</code>,<code>static</code>,<code>final</code>かどうか
+     *            the modifier to check
+     * @return true if public, static, and final, false otherwise
      */
     public static boolean isPublicStaticFinal(final int modifier) {
         return isPublic(modifier) && isStatic(modifier) && isFinal(modifier);
     }
 
     /**
-     * <code>public</code>かどうか返します。
+     * Checks if the specified modifier is public.
      *
      * @param modifier
-     *            モディファイヤ
-     * @return <code>public</code>かどうか
+     *            the modifier to check
+     * @return true if public, false otherwise
      */
     public static boolean isPublic(final int modifier) {
         return Modifier.isPublic(modifier);
     }
 
     /**
-     * <code>abstract</code>かどうか返します。
+     * Checks if the specified class is abstract.
      *
      * @param clazz
-     *            クラス。{@literal null}であってはいけません
-     * @return <code>abstract</code>なら{@literal true}
+     *            the class to check. Must not be null.
+     * @return true if abstract, false otherwise
      */
     public static boolean isAbstract(final Class<?> clazz) {
         assertArgumentNotNull("clazz", clazz);
@@ -103,55 +103,55 @@ public abstract class ModifierUtil {
     }
 
     /**
-     * <code>abstract</code>かどうか返します。
+     * Checks if the specified modifier is abstract.
      *
      * @param modifier
-     *            モディファイヤ
-     * @return <code>abstract</code>なら{@literal true}
+     *            the modifier to check
+     * @return true if abstract, false otherwise
      */
     public static boolean isAbstract(final int modifier) {
         return Modifier.isAbstract(modifier);
     }
 
     /**
-     * <code>static</code>かどうか返します。
+     * Checks if the specified modifier is static.
      *
      * @param modifier
-     *            モディファイヤ
-     * @return <code>static</code>なら{@literal true}
+     *            the modifier to check
+     * @return true if static, false otherwise
      */
     public static boolean isStatic(final int modifier) {
         return Modifier.isStatic(modifier);
     }
 
     /**
-     * <code>final</code>かどうか返します。
+     * Checks if the specified modifier is final.
      *
      * @param modifier
-     *            モディファイヤ
-     * @return <code>final</code>なら{@literal true}
+     *            the modifier to check
+     * @return true if final, false otherwise
      */
     public static boolean isFinal(final int modifier) {
         return Modifier.isFinal(modifier);
     }
 
     /**
-     * <code>final</code>かどうか返します。
+     * Checks if the specified method is final.
      *
      * @param method
-     *            メソッド
-     * @return <code>final</code>なら{@literal true}
+     *            the method to check
+     * @return true if final, false otherwise
      */
     public static boolean isFinal(final Method method) {
         return isFinal(method.getModifiers());
     }
 
     /**
-     * <code>transient</code>かどうか返します。
+     * Checks if the specified field is transient.
      *
      * @param field
-     *            フィールド
-     * @return <code>transient</code>なら{@literal true}
+     *            the field to check
+     * @return true if transient, false otherwise
      * @see #isTransient(int)
      */
     public static boolean isTransient(final Field field) {
@@ -159,22 +159,22 @@ public abstract class ModifierUtil {
     }
 
     /**
-     * <code>transient</code>かどうか返します。
+     * Checks if the specified modifier is transient.
      *
      * @param modifier
-     *            モディファイヤ
-     * @return <code>transient</code>なら{@literal true}
+     *            the modifier to check
+     * @return true if transient, false otherwise
      */
     public static boolean isTransient(final int modifier) {
         return Modifier.isTransient(modifier);
     }
 
     /**
-     * インスタンスフィールドかどうかを返します。
+     * Checks if the specified field is an instance field.
      *
      * @param field
-     *            フィールド。{@literal null}であってはいけません
-     * @return インスタンスフィールドなら{@literal true}
+     *            the field to check. Must not be null.
+     * @return true if instance field, false otherwise
      */
     public static boolean isInstanceField(final Field field) {
         assertArgumentNotNull("field", field);

--- a/src/main/java/org/codelibs/core/lang/ObjectUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ObjectUtil.java
@@ -25,8 +25,8 @@ public abstract class ObjectUtil {
     /**
      * Returns true if the two objects are equal, or both are null.
      *
-     * @param o1 the first object
-     * @param o2 the second object
+     * @param object1 the first object
+     * @param object2 the second object
      * @return true if equal or both null, false otherwise
      */
     public static boolean equals(final Object object1, final Object object2) {

--- a/src/main/java/org/codelibs/core/lang/ObjectUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ObjectUtil.java
@@ -16,35 +16,18 @@
 package org.codelibs.core.lang;
 
 /**
- *
- * {@link Object}用のユーティリティクラスです。
+ * Utility class for object operations.
  *
  * @author wyukawa
  */
 public abstract class ObjectUtil {
 
     /**
-     * オブジェクトが等しいかどうか返します。どちらも<code>null</code>の場合は、<code>true</code>を返します。
-     * <p>
-     * 次のように使います．
-     * </p>
+     * Returns true if the two objects are equal, or both are null.
      *
-     * <pre>
-     * ObjectUtil.equals(null, null)                  = true
-     * ObjectUtil.equals(null, "")                    = false
-     * ObjectUtil.equals("", null)                    = false
-     * ObjectUtil.equals("", "")                      = true
-     * ObjectUtil.equals(Boolean.TRUE, null)          = false
-     * ObjectUtil.equals(Boolean.TRUE, "true")        = false
-     * ObjectUtil.equals(Boolean.TRUE, Boolean.TRUE)  = true
-     * ObjectUtil.equals(Boolean.TRUE, Boolean.FALSE) = false
-     * </pre>
-     *
-     * @param object1
-     *            オブジェクト(<code>null</code>可)
-     * @param object2
-     *            オブジェクト(<code>null</code>可)
-     * @return 引数の2つのオブジェクトが等しい場合は<code>true</code>を返します。
+     * @param o1 the first object
+     * @param o2 the second object
+     * @return true if equal or both null, false otherwise
      */
     public static boolean equals(final Object object1, final Object object2) {
         if (object1 == object2) {
@@ -57,9 +40,29 @@ public abstract class ObjectUtil {
     }
 
     /**
-     * オブジェクトを返します。オブジェクトが<code>null</code>だったら<code>defaultValue</code>を返します。
+     * Returns the hash code of the specified object, or 0 if the object is null.
+     *
+     * @param obj the object
+     * @return the hash code or 0
+     */
+    public static int hashCode(final Object obj) {
+        return obj == null ? 0 : obj.hashCode();
+    }
+
+    /**
+     * Returns the string representation of the specified object, or null if the object is null.
+     *
+     * @param obj the object
+     * @return the string representation or null
+     */
+    public static String toString(final Object obj) {
+        return obj == null ? null : obj.toString();
+    }
+
+    /**
+     * Returns the object, or the defaultValue if the object is <code>null</code>.
      * <p>
-     * 次のように使います．
+     * Usage example:
      * </p>
      *
      * <pre>
@@ -69,17 +72,24 @@ public abstract class ObjectUtil {
      * ObjectUtil.defaultValue(null, null) = null
      * </pre>
      *
-     * @param <T>
-     *            オブジェクトの型
-     * @param t
-     *            オブジェクト(<code>null</code>可)
-     * @param defaultValue
-     *            引数のオブジェクトが<code>null</code>だったら返すオブジェクト(<code>null</code>可)
-     * @return オブジェクトを返します。オブジェクトが<code>null</code>だったら<code>defaultValue</code>
-     *         を返します。
+     * @param <T> the type of the object
+     * @param t the object (can be <code>null</code>)
+     * @param defaultValue the object to return if t is <code>null</code> (can be <code>null</code>)
+     * @return t if not <code>null</code>, otherwise defaultValue
      */
     public static <T> T defaultValue(final T t, final T defaultValue) {
         return t == null ? defaultValue : t;
+    }
+
+    /**
+     * Returns true if the two objects are not equal.
+     *
+     * @param o1 the first object
+     * @param o2 the second object
+     * @return true if not equal, false otherwise
+     */
+    public static boolean notEquals(final Object o1, final Object o2) {
+        return !equals(o1, o2);
     }
 
 }

--- a/src/main/java/org/codelibs/core/lang/StringUtil.java
+++ b/src/main/java/org/codelibs/core/lang/StringUtil.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 /**
- * {@link String}用のユーティリティクラスです。
+ * Utility class for string operations.
  *
  * @author higa
  * @author shinsuke
@@ -35,12 +35,12 @@ public abstract class StringUtil {
     public static final String RETURN_STRING = System.getProperty("line.separator");
 
     /**
-     * 空文字<code>""</code>です。
+     * An empty string <code>""</code>.
      */
     public static final String EMPTY = "";
 
     /**
-     * 文字列型の空の配列です。
+     * An empty array of strings.
      */
     public static final String[] EMPTY_STRINGS = new String[0];
 
@@ -61,37 +61,35 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列が<code>null</code>または空文字列なら<code>true</code>を返します。
+     * Checks if the string is empty or null.
      *
-     * @param text
-     *            文字列
-     * @return 文字列が<code>null</code>または空文字列なら<code>true</code>
+     * @param str the string to check
+     * @return true if empty or null, false otherwise
      */
     public static final boolean isEmpty(final String text) {
         return text == null || text.length() == 0;
     }
 
     /**
-     * 文字列が<code>null</code>でも空文字列でもなければ<code>true</code>を返します。
+     * Checks if the string is not empty.
      *
-     * @param text
-     *            文字列
-     * @return 文字列が<code>null</code>でも空文字列でもなければ<code>true</code>
+     * @param str the string to check
+     * @return true if not empty, false otherwise
      */
     public static final boolean isNotEmpty(final String text) {
         return !isEmpty(text);
     }
 
     /**
-     * 文字列を置き換えます。
+     * Replaces all occurrences of a substring within a string with another string.
      *
      * @param text
-     *            テキスト
+     *            The original string.
      * @param fromText
-     *            置き換え対象のテキスト
+     *            The substring to be replaced.
      * @param toText
-     *            置き換えるテキスト
-     * @return 結果
+     *            The replacement substring.
+     * @return The resulting string after replacements.
      */
     public static final String replace(final String text, final String fromText, final String toText) {
         if (text == null || fromText == null || toText == null) {
@@ -118,13 +116,13 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列を分割します。
+     * Splits the string by the specified delimiter.
      *
      * @param str
-     *            文字列
+     *            the string to split
      * @param delim
-     *            分割するためのデリミタ
-     * @return 分割された文字列の配列
+     *            the delimiter to use for splitting
+     * @return an array of split strings
      */
     public static String[] split(final String str, final String delim) {
         if (isEmpty(str)) {
@@ -139,24 +137,24 @@ public abstract class StringUtil {
     }
 
     /**
-     * 左側の空白を削ります。
+     * Removes whitespace from the left side of the string.
      *
      * @param text
-     *            テキスト
-     * @return 結果の文字列
+     *            The text to trim
+     * @return The resulting string
      */
     public static final String ltrim(final String text) {
         return ltrim(text, null);
     }
 
     /**
-     * 左側の指定した文字列を削ります。
+     * Removes the specified characters from the left side of the string.
      *
      * @param text
-     *            テキスト
+     *            The text to trim
      * @param trimText
-     *            削るテキスト
-     * @return 結果の文字列
+     *            The characters to remove
+     * @return The resulting string
      */
     public static final String ltrim(final String text, String trimText) {
         if (text == null) {
@@ -175,24 +173,24 @@ public abstract class StringUtil {
     }
 
     /**
-     * 右側の空白を削ります。
+     * Removes whitespace from the right side of the string.
      *
      * @param text
-     *            テキスト
-     * @return 結果の文字列
+     *            The text to trim
+     * @return The resulting string
      */
     public static final String rtrim(final String text) {
         return rtrim(text, null);
     }
 
     /**
-     * 右側の指定した文字列を削ります。
+     * Removes the specified characters from the right side of the string.
      *
      * @param text
-     *            テキスト
+     *            The text to trim
      * @param trimText
-     *            削る文字列
-     * @return 結果の文字列
+     *            The characters to remove
+     * @return The resulting string
      */
     public static final String rtrim(final String text, String trimText) {
         if (text == null) {
@@ -211,13 +209,13 @@ public abstract class StringUtil {
     }
 
     /**
-     * サフィックスを削ります。
+     * Removes the suffix from the string if it is present.
      *
      * @param text
-     *            テキスト
+     *            The text
      * @param suffix
-     *            サフィックス
-     * @return 結果の文字列
+     *            The suffix to remove
+     * @return The resulting string
      */
     public static final String trimSuffix(final String text, final String suffix) {
         if (text == null) {
@@ -233,13 +231,13 @@ public abstract class StringUtil {
     }
 
     /**
-     * プレフィックスを削ります。
+     * Removes the prefix from the string if it is present.
      *
      * @param text
-     *            テキスト
+     *            The text
      * @param prefix
-     *            プレフィックス
-     * @return 結果の文字列
+     *            The prefix to remove
+     * @return The resulting string
      */
     public static final String trimPrefix(final String text, final String prefix) {
         if (text == null) {
@@ -255,19 +253,20 @@ public abstract class StringUtil {
     }
 
     /**
-     * JavaBeansの仕様にしたがってデキャピタライズを行ないます。大文字が2つ以上続く場合は、小文字にならないので注意してください。
+     * Decapitalizes a string according to JavaBeans conventions.
+     * Note: If the first two characters are uppercase, the string will not be decapitalized.
      * <p>
-     * 次のように使います．
+     * Usage example:
      * </p>
      *
      * <pre>
-     * StringUtil.capitalize("UserId")  = "userId"
-     * StringUtil.capitalize("ABC")  = "ABC"
+     * StringUtil.decapitalize("UserId")  = "userId"
+     * StringUtil.decapitalize("ABC")     = "ABC"
      * </pre>
      *
      * @param name
-     *            名前
-     * @return 結果の文字列
+     *            the string to decapitalize
+     * @return the decapitalized string
      */
     public static String decapitalize(final String name) {
         if (isEmpty(name)) {
@@ -282,19 +281,20 @@ public abstract class StringUtil {
     }
 
     /**
-     * JavaBeansの仕様にしたがってキャピタライズを行ないます。大文字が2つ以上続く場合は、小文字にならないので注意してください。
+     * Capitalizes a string according to JavaBeans conventions.
+     * Note: If the first two characters are uppercase, the string will not be capitalized.
      * <p>
-     * 次のように使います．
+     * Usage example:
      * </p>
      *
      * <pre>
      * StringUtil.capitalize("userId")  = "UserId"
-     * StringUtil.capitalize("ABC")  = "ABC"
+     * StringUtil.capitalize("ABC")     = "ABC"
      * </pre>
      *
      * @param name
-     *            名前
-     * @return 結果の文字列
+     *            the string to capitalize
+     * @return the capitalized string
      */
     public static String capitalize(final String name) {
         if (isEmpty(name)) {
@@ -306,11 +306,11 @@ public abstract class StringUtil {
     }
 
     /**
-     * ブランクかどうか返します。
+     * Returns true if the string is blank.
      *
      * @param str
-     *            文字列
-     * @return ブランクなら{@literal true}
+     *            the string to check
+     * @return {@literal true} if the string is blank
      */
     public static boolean isBlank(final String str) {
         if (str == null || str.length() == 0) {
@@ -325,11 +325,11 @@ public abstract class StringUtil {
     }
 
     /**
-     * ブランクではないかどうか返します。
+     * Returns true if the string is not blank.
      *
      * @param str
-     *            文字列
-     * @return ブランクではなければ{@literal true}
+     *            the string to check
+     * @return {@literal true} if the string is not blank
      * @see #isBlank(String)
      */
     public static boolean isNotBlank(final String str) {
@@ -337,13 +337,13 @@ public abstract class StringUtil {
     }
 
     /**
-     * charを含んでいるかどうか返します。
+     * Returns true if the string contains the specified character.
      *
      * @param str
-     *            文字列
+     *            the string to check
      * @param ch
-     *            char
-     * @return charを含んでいるかどうか
+     *            the character to find
+     * @return true if the character is contained in the string, false otherwise
      */
     public static boolean contains(final String str, final char ch) {
         if (isEmpty(str)) {
@@ -353,13 +353,13 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列を含んでいるかどうか返します。
+     * Returns true if the string contains the specified substring.
      *
      * @param s1
-     *            文字列
+     *            the string to check
      * @param s2
-     *            比較する対象となる文字列
-     * @return 文字列を含んでいるかどうか
+     *            the substring to find
+     * @return true if the string contains the substring, false otherwise
      */
     public static boolean contains(final String s1, final String s2) {
         if (isEmpty(s1)) {
@@ -369,39 +369,39 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列同士が等しいかどうか返します。どちらもnullの場合は、<code>true</code>を返します。
+     * Returns whether two strings are equal. If both are null, returns <code>true</code>.
      *
      * @param target1
-     *            文字列1
+     *            the first string
      * @param target2
-     *            文字列2
-     * @return 文字列同士が等しいかどうか
+     *            the second string
+     * @return true if the strings are equal, false otherwise
      */
     public static boolean equals(final String target1, final String target2) {
         return target1 == null ? target2 == null : target1.equals(target2);
     }
 
     /**
-     * 大文字小文字を無視して文字列同士が等しいかどうか返します。どちらもnullの場合は、<code>true</code>を返します。
+     * Returns whether two strings are equal ignoring case. If both are null, returns <code>true</code>.
      *
      * @param target1
-     *            文字列1
+     *            the first string
      * @param target2
-     *            文字列2
-     * @return 大文字小文字を無視して文字列同士が等しければ{@literal true}
+     *            the second string
+     * @return {@literal true} if the strings are equal ignoring case
      */
     public static boolean equalsIgnoreCase(final String target1, final String target2) {
         return target1 == null ? target2 == null : target1.equalsIgnoreCase(target2);
     }
 
     /**
-     * 大文字小文字を無視して特定の文字で終わっているのかどうかを返します。
+     * Returns true if the string ends with the specified substring, ignoring case.
      *
      * @param target1
-     *            テキスト
+     *            the text to check
      * @param target2
-     *            比較する文字列
-     * @return 大文字小文字を無視して特定の文字で終わっていれば{@literal true}
+     *            the substring to compare
+     * @return {@literal true} if the string ends with the specified substring, ignoring case
      */
     public static boolean endsWithIgnoreCase(final String target1, final String target2) {
         if (target1 == null || target2 == null) {
@@ -417,13 +417,13 @@ public abstract class StringUtil {
     }
 
     /**
-     * 大文字小文字を無視して特定の文字で始まっているのかどうかを返します。
+     * Returns true if the string starts with the specified substring, ignoring case.
      *
      * @param target1
-     *            テキスト
+     *            the text to check
      * @param target2
-     *            比較する文字列
-     * @return 大文字小文字を無視して特定の文字で始まっていれば{@literal true}
+     *            the substring to compare
+     * @return {@literal true} if the string starts with the specified substring, ignoring case
      */
     public static boolean startsWithIgnoreCase(final String target1, final String target2) {
         if (target1 == null || target2 == null) {
@@ -439,13 +439,13 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列の最後から指定した文字列で始まっている部分より手前を返します。
+     * Returns the part of the string before the last occurrence of the specified separator.
      *
      * @param str
-     *            文字列
+     *            the string
      * @param separator
-     *            セパレータ
-     * @return 結果の文字列
+     *            the separator
+     * @return the resulting string
      */
     public static String substringFromLast(final String str, final String separator) {
         if (isEmpty(str) || isEmpty(separator)) {
@@ -459,13 +459,13 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列の最後から指定した文字列で始まっている部分より後ろを返します。
+     * Returns the part of the string after the last occurrence of the specified separator.
      *
      * @param str
-     *            文字列
+     *            the string
      * @param separator
-     *            セパレータ
-     * @return 結果の文字列
+     *            the separator
+     * @return the resulting string
      */
     public static String substringToLast(final String str, final String separator) {
         if (isEmpty(str) || isEmpty(separator)) {
@@ -479,11 +479,11 @@ public abstract class StringUtil {
     }
 
     /**
-     * 16進数の文字列に変換します。
+     * Converts a byte array to a hexadecimal string.
      *
      * @param bytes
-     *            バイトの配列
-     * @return 16進数の文字列
+     *            the byte array
+     * @return the hexadecimal string
      */
     public static String toHex(final byte[] bytes) {
         if (bytes == null) {
@@ -497,11 +497,11 @@ public abstract class StringUtil {
     }
 
     /**
-     * {@literal int}の値を16進数の文字列に変換します。
+     * Converts an {@literal int} value to a hexadecimal string.
      *
      * @param i
-     *            {@literal int}の値
-     * @return 16進数の文字列
+     *            the {@literal int} value
+     * @return the hexadecimal string
      */
     public static String toHex(final int i) {
         final StringBuilder buf = new StringBuilder();
@@ -510,12 +510,12 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列に、数値を16進数に変換した文字列を追加します。
+     * Appends the hexadecimal string representation of a number to the given StringBuilder.
      *
      * @param buf
-     *            追加先の文字列
+     *            the StringBuilder to append to
      * @param i
-     *            数値
+     *            the number to convert
      */
     public static void appendHex(final StringBuilder buf, final byte i) {
         buf.append(Character.forDigit((i & 0xf0) >> 4, 16));
@@ -523,12 +523,12 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列に、数値を16進数に変換した文字列を追加します。
+     * Appends the hexadecimal string representation of a number to the given StringBuilder.
      *
      * @param buf
-     *            追加先の文字列
+     *            the StringBuilder to append to
      * @param i
-     *            数値
+     *            the number to convert
      */
     public static void appendHex(final StringBuilder buf, final int i) {
         buf.append(Integer.toHexString(i >> 24 & 0xff));
@@ -538,9 +538,9 @@ public abstract class StringUtil {
     }
 
     /**
-     * _記法をキャメル記法に変換します。
+     * Converts an underscore-separated string to camel case.
      * <p>
-     * 次のように使います．
+     * Usage example:
      * </p>
      *
      * <pre>
@@ -548,8 +548,8 @@ public abstract class StringUtil {
      * </pre>
      *
      * @param s
-     *            テキスト
-     * @return 結果の文字列
+     *            the text
+     * @return the resulting string
      */
     public static String camelize(String s) {
         if (s == null) {
@@ -568,9 +568,9 @@ public abstract class StringUtil {
     }
 
     /**
-     * キャメル記法を_記法に変換します。
+     * Converts a camel case string to an underscore-separated string.
      * <p>
-     * 次のように使います．
+     * Usage example:
      * </p>
      *
      * <pre>
@@ -578,8 +578,8 @@ public abstract class StringUtil {
      * </pre>
      *
      * @param s
-     *            テキスト
-     * @return 結果の文字列
+     *            the text
+     * @return the resulting string
      */
     public static String decamelize(final String s) {
         if (s == null) {
@@ -607,11 +607,11 @@ public abstract class StringUtil {
     }
 
     /**
-     * 文字列が数値のみで構成されているかどうかを返します。
+     * Returns true if the string consists only of numeric characters.
      *
      * @param s
-     *            文字列
-     * @return 数値のみで構成されている場合、<code>true</code>
+     *            the string to check
+     * @return <code>true</code> if the string consists only of numeric characters
      */
     public static boolean isNumber(final String s) {
         if (isEmpty(s)) {
@@ -630,9 +630,9 @@ public abstract class StringUtil {
     }
 
     /**
-     * 引数の文字列を返します。引数の文字列が<code>null</code>だったら空文字を返します。
+     * Returns the given string, or an empty string if the argument is <code>null</code>.
      * <p>
-     * 次のように使います．
+     * Usage example:
      * </p>
      *
      * <pre>
@@ -642,33 +642,32 @@ public abstract class StringUtil {
      * </pre>
      *
      * @param str
-     *            文字列(<code>null</code>可)
-     * @return 引数の文字列を返します。引数の文字列が<code>null</code>だったら空文字を返します。
+     *            the string (can be <code>null</code>)
+     * @return the given string, or an empty string if the argument is <code>null</code>
      */
     public static String defaultString(final String str) {
         return str == null ? EMPTY : str;
     }
 
     /**
-     * 引数の文字列を返します。引数の文字列が<code>null</code>だったら<code>defaultStr</code>を返します。
+     * Returns the given string, or the specified default string if the argument is <code>null</code>.
      * <p>
-     * 次のように使います．
+     * Usage example:
      * </p>
      *
      * <pre>
      * StringUtil.defaultString(null, "NULL")  = "NULL"
      * StringUtil.defaultString("", "NULL")    = ""
      * StringUtil.defaultString("aaa", "NULL") = "aaa"
-     * StringUtil.defaultString("aaa", null) = "aaa"
-     * StringUtil.defaultString(null, null) = null
+     * StringUtil.defaultString("aaa", null)   = "aaa"
+     * StringUtil.defaultString(null, null)    = null
      * </pre>
      *
      * @param str
-     *            文字列(<code>null</code>可)
+     *            the string (can be <code>null</code>)
      * @param defaultStr
-     *            引数の文字列が<code>null</code>だったら返す文字列(<code>null</code>可)
-     * @return 引数の文字列を返します。引数の文字列が<code>null</code>だったら<code>defaultStr</code>
-     *         を返します。
+     *            the string to return if the argument is <code>null</code> (can be <code>null</code>)
+     * @return the given string, or the specified default string if the argument is <code>null</code>
      */
     public static String defaultString(final String str, final String defaultStr) {
         return str == null ? defaultStr : str;

--- a/src/main/java/org/codelibs/core/lang/StringUtil.java
+++ b/src/main/java/org/codelibs/core/lang/StringUtil.java
@@ -63,7 +63,7 @@ public abstract class StringUtil {
     /**
      * Checks if the string is empty or null.
      *
-     * @param str the string to check
+     * @param text the string to check
      * @return true if empty or null, false otherwise
      */
     public static final boolean isEmpty(final String text) {
@@ -73,7 +73,7 @@ public abstract class StringUtil {
     /**
      * Checks if the string is not empty.
      *
-     * @param str the string to check
+     * @param text the string to check
      * @return true if not empty, false otherwise
      */
     public static final boolean isNotEmpty(final String text) {

--- a/src/main/java/org/codelibs/core/lang/SystemUtil.java
+++ b/src/main/java/org/codelibs/core/lang/SystemUtil.java
@@ -16,7 +16,7 @@
 package org.codelibs.core.lang;
 
 /**
- * システムプロパティ用のユーティリティクラスです。
+ * Utility class for system operations.
  *
  * @author wyukawa
  * @author shinsuke
@@ -25,41 +25,81 @@ package org.codelibs.core.lang;
 public abstract class SystemUtil {
 
     /**
-     * <code>file.encoding</code>システムプロパティ。例:UTF-8
+     * <code>file.encoding</code> system property. Example: UTF-8
      */
     public static final String FILE_ENCODING = System.getProperty("file.encoding");
 
     /**
-     * <code>line.separator</code> システムプロパティ。例えばMac OS Xなら
-     * <code>&quot;\n&quot;</code>
+     * <code>line.separator</code> system property. For example, on Mac OS X: <code>"\n"</code>
      */
     public static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
     /**
-     * <code>path.separator</code> システムプロパティ。例えばMac OS Xなら
-     * <code>&quot;:&quot;</code>
+     * <code>path.separator</code> system property. For example, on Mac OS X: <code>":"</code>
      */
     public static final String PATH_SEPARATOR = System.getProperty("path.separator");
 
     /**
-     * <code>os.name</code> システムプロパティ。例:<code>Mac OS X</code>
+     * <code>os.name</code> system property. Example: <code>Mac OS X</code>
      */
     public static final String OS_NAME = System.getProperty("os.name");
 
     /**
-     * <code>java.io.tmpdir</code> システムプロパティ。例：/tmp
+     * <code>java.io.tmpdir</code> system property. Example: /tmp
      */
     public static final String JAVA_IO_TMPDIR = System.getProperty("java.io.tmpdir");
 
     /**
-     * <code>user.dir</code> システムプロパティ。
+     * <code>user.dir</code> system property.
      */
     public static final String USER_DIR = System.getProperty("user.dir");
 
     /**
-     * <code>user.home</code> システムプロパティ。
+     * <code>user.home</code> system property.
      */
     public static final String USER_HOME = System.getProperty("user.home");
+
+    /**
+     * Returns the system property value for the specified key.
+     *
+     * @param key the property key
+     * @return the property value, or null if not found
+     */
+    public static String getProperty(String key) {
+        return System.getProperty(key);
+    }
+
+    /**
+     * Returns the system property value for the specified key, or the default value if not found.
+     *
+     * @param key the property key
+     * @param defaultValue the default value
+     * @return the property value, or the default value if not found
+     */
+    public static String getProperty(String key, String defaultValue) {
+        return System.getProperty(key, defaultValue);
+    }
+
+    /**
+     * Returns the system environment variable value for the specified key.
+     *
+     * @param key the environment variable key
+     * @return the environment variable value, or null if not found
+     */
+    public static String getEnv(String key) {
+        return System.getenv(key);
+    }
+
+    /**
+     * Returns the system environment variable value for the specified key, or the default value if not found.
+     *
+     * @param key the environment variable key
+     * @param defaultValue the default value
+     * @return the environment variable value, or the default value if not found
+     */
+    public static String getEnv(String key, String defaultValue) {
+        return System.getenv().getOrDefault(key, defaultValue);
+    }
 
     public static long currentTimeMillis() {
         // TODO provider

--- a/src/main/java/org/codelibs/core/log/JclLoggerAdapter.java
+++ b/src/main/java/org/codelibs/core/log/JclLoggerAdapter.java
@@ -19,7 +19,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * (Jakarta) Commons Loggingのロガーを利用するアダプタです。
+ * Logger adapter for Jakarta Commons Logging.
  *
  * @author koichik
  */
@@ -29,6 +29,11 @@ class JclLoggerAdapter implements LoggerAdapter {
 
     protected final Log logger;
 
+    /**
+     * Creates a new instance of JclLoggerAdapter.
+     *
+     * @param name the logger name
+     */
     public JclLoggerAdapter(final Class<?> clazz) {
         sourceClass = clazz.getName();
         logger = LogFactory.getLog(clazz);

--- a/src/main/java/org/codelibs/core/log/JclLoggerAdapterFactory.java
+++ b/src/main/java/org/codelibs/core/log/JclLoggerAdapterFactory.java
@@ -18,7 +18,7 @@ package org.codelibs.core.log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * (Jakarta) Commons Loggingのロガーを利用するアダプタを生成するファクトリです。
+ * Factory for creating adapters that use (Jakarta) Commons Logging loggers.
  *
  * @author koichik
  */

--- a/src/main/java/org/codelibs/core/log/JulLoggerAdapter.java
+++ b/src/main/java/org/codelibs/core/log/JulLoggerAdapter.java
@@ -18,7 +18,7 @@ package org.codelibs.core.log;
 import java.util.logging.Level;
 
 /**
- * java.util.logのロガーを利用するアダプタです。
+ * Adapter that uses java.util.logging loggers.
  *
  * @author koichik
  */

--- a/src/main/java/org/codelibs/core/log/JulLoggerAdapterFactory.java
+++ b/src/main/java/org/codelibs/core/log/JulLoggerAdapterFactory.java
@@ -16,7 +16,7 @@
 package org.codelibs.core.log;
 
 /**
- * java.util.logのロガーを利用するアダプタを生成するファクトリです。
+ * Factory for creating adapters that use java.util.logging loggers.
  *
  * @author koichik
  */

--- a/src/main/java/org/codelibs/core/log/Logger.java
+++ b/src/main/java/org/codelibs/core/log/Logger.java
@@ -27,45 +27,45 @@ import org.codelibs.core.message.MessageFormatter;
 import org.codelibs.core.misc.DisposableUtil;
 
 /**
- * ログ出力を提供するクラスです。
+ * Logger interface.
  *
  * @author higa
  */
 public class Logger {
 
     /**
-     * ログの出力レベルです。
+     * Log output levels.
      */
     public enum LogLevel {
-        /** デバッグ */
+        /** Debug */
         DEBUG,
-        /** 情報 */
+        /** Info */
         INFO,
-        /** 警告 */
+        /** Warning */
         WARN,
-        /** エラー */
+        /** Error */
         ERROR,
-        /** 致命的 */
+        /** Fatal */
         FATAL,
     }
 
-    /** ロガーアダプタのファクトリ */
+    /** Factory for LoggerAdapter */
     protected static final LoggerAdapterFactory factory = getLoggerAdapterFactory();
 
-    /** クラスをキーとするロガー のマップ */
+    /** Map of loggers keyed by class */
     protected static final Map<Class<?>, Logger> loggers = newHashMap();
 
-    /** 初期化済みを示すフラグ */
+    /** Flag indicating initialization is complete. */
     private static boolean initialized;
 
-    /** ロガーアダプタ */
+    /** Logger adapter. */
     private final LoggerAdapter log;
 
     /**
-     * {@link Logger}を返します。
+     * Returns a {@link Logger}.
      *
      * @param clazz
-     *            ロガーのカテゴリとなるクラス。{@literal null}であってはいけません
+     *            Class to be used as the logger category. Must not be {@literal null}.
      * @return {@link Logger}
      */
     public static synchronized Logger getLogger(final Class<?> clazz) {
@@ -83,13 +83,13 @@ public class Logger {
     }
 
     /**
-     * フォーマットされたメッセージ文字列を返します。
+     * Returns a formatted message string.
      *
      * @param messageCode
-     *            メッセージコード。{@literal null}や空文字列であってはいけません
+     *            Message code. Must not be {@literal null} or empty string.
      * @param args
-     *            引数
-     * @return フォーマットされたメッセージ文字列
+     *            Arguments
+     * @return Formatted message string
      */
     public static LogMessage format(final String messageCode, final Object... args) {
         assertArgumentNotEmpty("messageCode", messageCode);
@@ -113,7 +113,7 @@ public class Logger {
     }
 
     /**
-     * {@link Logger}を初期化します。
+     * Initializes the {@link Logger}.
      */
     protected static synchronized void initialize() {
         DisposableUtil.addFirst(() -> {
@@ -125,13 +125,13 @@ public class Logger {
     }
 
     /**
-     * ログアダプタのファクトリを返します。
+     * Returns the logger adapter factory.
      * <p>
-     * Commons Loggingが使える場合はCommons Loggingを利用するためのファクトリを返します。
-     * 使えない場合はjava.util.loggingロガーを利用するためのファクトリを返します。
+     * If Commons Logging is available, returns a factory for using Commons Logging.
+     * If not available, returns a factory for using java.util.logging logger.
      * </p>
      *
-     * @return ログアダプタのファクトリ
+     * @return the logger adapter factory
      */
     protected static LoggerAdapterFactory getLoggerAdapterFactory() {
         // TODO
@@ -144,31 +144,31 @@ public class Logger {
     }
 
     /**
-     * インスタンスを構築します。
+     * Constructs an instance.
      *
      * @param clazz
-     *            ログ出力のカテゴリとなるクラス
+     *            The class to be used as the logging category.
      */
     protected Logger(final Class<?> clazz) {
         log = factory.getLoggerAdapter(clazz);
     }
 
     /**
-     * DEBUG情報が出力されるかどうかを返します。
+     * Checks if debug level is enabled.
      *
-     * @return DEBUG情報が出力されるかどうか
+     * @return true if debug is enabled, false otherwise
      */
     public boolean isDebugEnabled() {
         return log.isDebugEnabled();
     }
 
     /**
-     * DEBUG情報を出力します。
+     * Outputs DEBUG information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      * @param throwable
-     *            例外
+     *            Exception
      */
     public void debug(final Object message, final Throwable throwable) {
         if (isDebugEnabled()) {
@@ -177,10 +177,10 @@ public class Logger {
     }
 
     /**
-     * DEBUG情報を出力します。
+     * Outputs DEBUG information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      */
     public void debug(final Object message) {
         if (isDebugEnabled()) {
@@ -189,21 +189,21 @@ public class Logger {
     }
 
     /**
-     * INFO情報が出力されるかどうかを返します。
+     * Checks if info level is enabled.
      *
-     * @return INFO情報が出力されるかどうか
+     * @return true if info is enabled, false otherwise
      */
     public boolean isInfoEnabled() {
         return log.isInfoEnabled();
     }
 
     /**
-     * INFO情報を出力します。
+     * Outputs INFO information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      * @param throwable
-     *            例外
+     *            Exception
      */
     public void info(final Object message, final Throwable throwable) {
         if (isInfoEnabled()) {
@@ -212,10 +212,10 @@ public class Logger {
     }
 
     /**
-     * INFO情報を出力します。
+     * Outputs INFO information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      */
     public void info(final Object message) {
         if (isInfoEnabled()) {
@@ -224,76 +224,76 @@ public class Logger {
     }
 
     /**
-     * WARN情報を出力します。
+     * Outputs WARN information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      * @param throwable
-     *            例外
+     *            Exception
      */
     public void warn(final Object message, final Throwable throwable) {
         log.warn(toString(message), throwable);
     }
 
     /**
-     * WARN情報を出力します。
+     * Outputs WARN information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      */
     public void warn(final Object message) {
         log.warn(message.toString());
     }
 
     /**
-     * ERROR情報を出力します。
+     * Outputs ERROR information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      * @param throwable
-     *            例外
+     *            Exception
      */
     public void error(final Object message, final Throwable throwable) {
         log.error(message.toString(), throwable);
     }
 
     /**
-     * ERROR情報を出力します。
+     * Outputs ERROR information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      */
     public void error(final Object message) {
         log.error(message.toString());
     }
 
     /**
-     * FATAL情報を出力します。
+     * Outputs FATAL information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      * @param throwable
-     *            例外
+     *            Exception
      */
     public void fatal(final Object message, final Throwable throwable) {
         log.fatal(message.toString(), throwable);
     }
 
     /**
-     * FATAL情報を出力します。
+     * Outputs FATAL information.
      *
      * @param message
-     *            メッセージ
+     *            Message
      */
     public void fatal(final Object message) {
         log.fatal(message.toString());
     }
 
     /**
-     * ログを出力します。
+     * Outputs a log entry.
      *
      * @param throwable
-     *            例外。{@literal null}であってはいけません
+     *            Exception. Must not be {@literal null}.
      */
     public void log(final Throwable throwable) {
         assertArgumentNotNull("throwable", throwable);
@@ -302,12 +302,12 @@ public class Logger {
     }
 
     /**
-     * ログを出力します。
+     * Outputs a log entry.
      *
      * @param messageCode
-     *            メッセージコード。{@literal null}や空文字列であってはいけません
+     *            Message code. Must not be {@literal null} or empty string.
      * @param args
-     *            引数
+     *            Arguments
      */
     public void log(final String messageCode, final Object... args) {
         assertArgumentNotEmpty("messageCode", messageCode);
@@ -316,10 +316,10 @@ public class Logger {
     }
 
     /**
-     * ログを出力します。
+     * Outputs a log entry.
      * <p>
-     * ログメッセージは{@link #format(String, Object...)}メソッドで作成します。
-     * {@link #format(String, Object...)}を{@literal static import}しておくと便利です。
+     * The log message should be created using the {@link #format(String, Object...)} method.
+     * It is convenient to use a static import for {@link #format(String, Object...)}.
      * </p>
      *
      * <pre>
@@ -330,7 +330,7 @@ public class Logger {
      * </pre>
      *
      * @param logMessage
-     *            ログメッセージ。{@literal null}であってはいけません
+     *            Log message. Must not be {@literal null}.
      */
     public void log(final LogMessage logMessage) {
         assertArgumentNotNull("logMessage", logMessage);
@@ -339,10 +339,10 @@ public class Logger {
     }
 
     /**
-     * ログを出力します。
+     * Outputs a log entry.
      * <p>
-     * ログメッセージは{@link #format(String, Object...)}メソッドで作成します。
-     * {@link #format(String, Object...)}を{@literal static import}しておくと便利です。
+     * The log message should be created using the {@link #format(String, Object...)} method.
+     * It is convenient to use a static import for {@link #format(String, Object...)}.
      * </p>
      *
      * <pre>
@@ -353,9 +353,9 @@ public class Logger {
      * </pre>
      *
      * @param logMessage
-     *            ログメッセージ。{@literal null}であってはいけません
+     *            Log message. Must not be {@literal null}.
      * @param throwable
-     *            例外
+     *            Exception
      */
     public void log(final LogMessage logMessage, final Throwable throwable) {
         assertArgumentNotNull("logMessage", logMessage);
@@ -384,11 +384,11 @@ public class Logger {
     }
 
     /**
-     * 指定のログレベルが有効なら{@literal true}を返します．
+     * Returns {@literal true} if the specified log level is enabled.
      *
      * @param logLevel
-     *            ログレベル
-     * @return 指定のログレベルが有効なら{@literal true}
+     *            Log level
+     * @return {@literal true} if the specified log level is enabled
      */
     protected boolean isEnabledFor(final LogLevel logLevel) {
         switch (logLevel) {
@@ -408,11 +408,11 @@ public class Logger {
     }
 
     /**
-     * メッセージオブジェクトの文字列表現を返します。
+     * Returns the string representation of the message object.
      *
      * @param message
-     *            メッセージオブジェクト
-     * @return メッセージオブジェクトの文字列表現
+     *            Message object
+     * @return String representation of the message object
      */
     protected static String toString(final Object message) {
         if (message == null) {
@@ -425,24 +425,24 @@ public class Logger {
     }
 
     /**
-     * ログ出力するメッセージです。
+     * The message to be logged.
      *
      * @author koichik
      */
     public static class LogMessage {
-        /** ログレベル */
+        /** Log level */
         protected final LogLevel level;
 
-        /** ログメッセージ */
+        /** Log message */
         protected final String message;
 
         /**
-         * インスタンスを構築します。
+         * Constructs an instance.
          *
          * @param level
-         *            ログレベル。{@literal null}であってはいけません
+         *            Log level. Must not be {@literal null}.
          * @param message
-         *            ログメッセージ
+         *            Log message.
          */
         public LogMessage(final LogLevel level, final String message) {
             assertArgumentNotNull("level", level);
@@ -452,18 +452,18 @@ public class Logger {
         }
 
         /**
-         * 出力レベルを返します。
+         * Returns the log level.
          *
-         * @return 出力レベル
+         * @return the log level
          */
         public LogLevel getLevel() {
             return level;
         }
 
         /**
-         * メッセージを返します。
+         * Returns the message.
          *
-         * @return メッセージ
+         * @return the message
          */
         public String getMessage() {
             return message;

--- a/src/main/java/org/codelibs/core/log/LoggerAdapter.java
+++ b/src/main/java/org/codelibs/core/log/LoggerAdapter.java
@@ -16,7 +16,7 @@
 package org.codelibs.core.log;
 
 /**
- * 任意のロギングフレームワークを利用するためのアダプタです。
+ * Adapter for using any logging framework.
  *
  * @author koichik
  */

--- a/src/main/java/org/codelibs/core/log/LoggerAdapterFactory.java
+++ b/src/main/java/org/codelibs/core/log/LoggerAdapterFactory.java
@@ -16,7 +16,7 @@
 package org.codelibs.core.log;
 
 /**
- * ロガーアダプタを生成するファクトリです。
+ * Factory for creating logger adapters.
  *
  * @author koichik
  */

--- a/src/main/java/org/codelibs/core/message/MessageFormatter.java
+++ b/src/main/java/org/codelibs/core/message/MessageFormatter.java
@@ -25,55 +25,55 @@ import org.codelibs.core.misc.DisposableUtil;
 import org.codelibs.core.misc.LocaleUtil;
 
 /**
- * メッセージコードと引数からメッセージを組み立てるクラスです。
+ * Class for assembling messages from message codes and arguments.
  *
  * @author higa
  */
 public abstract class MessageFormatter {
 
-    /** メッセージコードの数値部の長さ */
+    /** Length of the numeric part of the message code */
     protected static final int CODE_NUMBER_LENGTH = 4;
 
-    /** メッセージコードに対応するリソースバンドル名の接尾辞 */
+    /** Suffix of the resource bundle name corresponding to the message code */
     protected static final String MESSAGES = "Messages";
 
-    /** 初期化済みを示すフラグ */
+    /** Flag indicating initialization */
     protected static volatile boolean initialized;
 
     /**
-     * メッセージを返します。
+     * Returns the message.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数
-     * @return メッセージ
+     *            Arguments
+     * @return Message
      */
     public static String getMessage(final String messageCode, final Object... args) {
         return getFormattedMessage(messageCode == null ? "" : messageCode, getSimpleMessage(messageCode, args));
     }
 
     /**
-     * メッセージコードつきのメッセージを返します。
+     * Returns the message with the message code.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param simpleMessage
-     *            引数が展開された単純なメッセージ
-     * @return メッセージコードつきのメッセージ
+     *            Simple message with arguments expanded
+     * @return Message with message code
      */
     public static String getFormattedMessage(final String messageCode, final String simpleMessage) {
         return "[" + messageCode + "]" + simpleMessage;
     }
 
     /**
-     * 引数を展開してメッセージコードなしの単純なメッセージを返します。
+     * Expands arguments and returns a simple message without a message code.
      *
      * @param messageCode
-     *            メッセージコード
+     *            Message code
      * @param args
-     *            引数
-     * @return メッセージコードなしの単純なメッセージ
+     *            Arguments
+     * @return Simple message without a message code
      */
     public static String getSimpleMessage(final String messageCode, final Object... args) {
         try {
@@ -88,11 +88,11 @@ public abstract class MessageFormatter {
     }
 
     /**
-     * メッセージコードに対応するパターン文字列を返します。
+     * Returns the pattern string corresponding to the message code.
      *
      * @param messageCode
-     *            メッセージコード
-     * @return パターン文字列
+     *            Message code
+     * @return Pattern string
      */
     protected static String getPattern(final String messageCode) {
         if (isEmpty(messageCode)) {
@@ -115,22 +115,22 @@ public abstract class MessageFormatter {
     }
 
     /**
-     * システム名を返します。
+     * Returns the system name.
      *
      * @param messageCode
-     *            メッセージコード
-     * @return システム名
+     *            Message code
+     * @return System name
      */
     protected static String getSystemName(final String messageCode) {
         return messageCode.substring(1, Math.max(1, messageCode.length() - CODE_NUMBER_LENGTH));
     }
 
     /**
-     * リソースバンドルを返します。
+     * Returns the resource bundle.
      *
      * @param systemName
-     *            システム名
-     * @return リソースバンドル
+     *            System name
+     * @return Resource bundle
      */
     protected static ResourceBundle getResourceBundle(final String systemName) {
         if (!initialized) {
@@ -140,11 +140,11 @@ public abstract class MessageFormatter {
     }
 
     /**
-     * パターンを使用しないで引数を並べたメッセージを返します。
+     * Returns a message with arguments lined up without using a pattern.
      *
      * @param args
-     *            引数
-     * @return 引数を並べたメッセージ
+     *            Arguments
+     * @return Message with arguments lined up
      */
     protected static String getNoPatternMessage(final Object... args) {
         if (args == null || args.length == 0) {
@@ -159,7 +159,7 @@ public abstract class MessageFormatter {
     }
 
     /**
-     * 初期化します。
+     * Initializes the class.
      */
     protected static synchronized void initialize() {
         if (!initialized) {

--- a/src/main/java/org/codelibs/core/net/URLUtil.java
+++ b/src/main/java/org/codelibs/core/net/URLUtil.java
@@ -43,8 +43,8 @@ public abstract class URLUtil {
     /** Map for normalizing protocols */
     protected static final Map<String, String> CANONICAL_PROTOCOLS = newHashMap();
     static {
-        CANONICAL_PROTOCOLS.put("wsjar", "jar"); // WebSphereがJarファイルのために使用する固有のプロトコル
-        CANONICAL_PROTOCOLS.put("vfsfile", "file"); // JBossAS5がファイルシステムのために使用する固有のプロトコル
+        CANONICAL_PROTOCOLS.put("wsjar", "jar"); // Proprietary protocol used by WebSphere for jar files
+        CANONICAL_PROTOCOLS.put("vfsfile", "file"); // Proprietary protocol used by JBossAS5 for file system
     }
 
     /**


### PR DESCRIPTION
This pull request translates JavaDoc comments from Japanese to English across several classes, including BeanDescImpl, ArrayIterator, ArrayMap, and ArrayUtil. No changes were made to the Java code itself—only documentation comments were updated for better readability and internationalization.
