### PR TITLE
Fix JavaDoc warnings

### DIFF
--- a/src/main/java/org/codelibs/core/CoreLibConstants.java
+++ b/src/main/java/org/codelibs/core/CoreLibConstants.java
@@ -30,16 +30,34 @@ public class CoreLibConstants {
      */
     public static final String UTF_8 = "UTF-8";
 
+    /**
+     * UTF-8 Charset.
+     */
     public static final Charset CHARSET_UTF_8 = Charset.forName(UTF_8);
 
+    /**
+     * ISO 8601 basic format: yyyyMMdd'T'HHmmss.SSSZ
+     */
     public static final String DATE_FORMAT_ISO_8601_BASIC = "yyyyMMdd'T'HHmmss.SSSZ";
 
+    /**
+     * ISO 8601 extended format: yyyy-MM-dd'T'HH:mm:ss.SSSZ
+     */
     public static final String DATE_FORMAT_ISO_8601_EXTEND = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
+    /**
+     * ISO 8601 extended UTC format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+     */
     public static final String DATE_FORMAT_ISO_8601_EXTEND_UTC = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
+    /**
+     * Digit only date format: yyyyMMddHHmmss
+     */
     public static final String DATE_FORMAT_DIGIT_ONLY = "yyyyMMddHHmmss";
 
+    /**
+     * Do not instantiate.
+     */
     protected CoreLibConstants() {
     }
 }

--- a/src/main/java/org/codelibs/core/beans/factory/BeanDescFactory.java
+++ b/src/main/java/org/codelibs/core/beans/factory/BeanDescFactory.java
@@ -44,6 +44,12 @@ import org.codelibs.core.misc.DisposableUtil;
  */
 public abstract class BeanDescFactory {
 
+    /**
+     * Do not instantiate.
+     */
+    private BeanDescFactory() {
+    }
+
     /** True if initialized */
     private static volatile boolean initialized;
 

--- a/src/main/java/org/codelibs/core/beans/factory/ParameterizedClassDescFactory.java
+++ b/src/main/java/org/codelibs/core/beans/factory/ParameterizedClassDescFactory.java
@@ -56,6 +56,12 @@ import org.codelibs.core.collection.Indexed;
 public abstract class ParameterizedClassDescFactory {
 
     /**
+     * Do not instantiate.
+     */
+    private ParameterizedClassDescFactory() {
+    }
+
+    /**
      * Returns a {@link Map} with type variables as keys and type arguments as values for a parameterized type (class or interface).
      * <p>
      * If the type is not parameterized, an empty {@link Map} is returned.

--- a/src/main/java/org/codelibs/core/beans/util/BeanMap.java
+++ b/src/main/java/org/codelibs/core/beans/util/BeanMap.java
@@ -28,6 +28,12 @@ public class BeanMap extends LinkedHashMap<String, Object> {
 
     private static final long serialVersionUID = 1;
 
+    /**
+     * Creates a new {@link BeanMap}.
+     */
+    public BeanMap() {
+    }
+
     @Override
     public Object get(final Object key) {
         if (!containsKey(key)) {

--- a/src/main/java/org/codelibs/core/beans/util/BeanUtil.java
+++ b/src/main/java/org/codelibs/core/beans/util/BeanUtil.java
@@ -80,6 +80,12 @@ import org.codelibs.core.lang.ClassUtil;
  */
 public abstract class BeanUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private BeanUtil() {
+    }
+
     /** Default options */
     protected static final CopyOptions DEFAULT_OPTIONS = new CopyOptions();
 
@@ -93,6 +99,13 @@ public abstract class BeanUtil {
         copyBeanToBean(src, dest, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies properties from one Bean to another Bean.
+     *
+     * @param src The source Bean. Must not be {@literal null}.
+     * @param dest The destination Bean. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     */
     public static void copyBeanToBean(final Object src, final Object dest, final Consumer<CopyOptions> option) {
         copyBeanToBean(src, dest, buildCopyOptions(option));
     }
@@ -144,6 +157,13 @@ public abstract class BeanUtil {
         copyBeanToMap(src, dest, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies from a Bean to a {@literal Map}.
+     *
+     * @param src The source Bean. Must not be {@literal null}.
+     * @param dest The destination {@literal Map}. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     */
     public static void copyBeanToMap(final Object src, final Map<String, Object> dest, final Consumer<CopyOptions> option) {
         copyBeanToMap(src, dest, buildCopyOptions(option));
     }
@@ -187,6 +207,13 @@ public abstract class BeanUtil {
         copyMapToBean(src, dest, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies from a {@literal Map} to a Bean.
+     *
+     * @param src The source {@literal Map}. Must not be {@literal null}.
+     * @param dest The destination Bean. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     */
     public static void copyMapToBean(final Map<String, ? extends Object> src, final Object dest, final Consumer<CopyOptions> option) {
         copyMapToBean(src, dest, buildCopyOptions(option));
     }
@@ -237,6 +264,13 @@ public abstract class BeanUtil {
         copyMapToMap(src, dest, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies from a {@literal Map} to another {@literal Map}.
+     *
+     * @param src The source {@literal Map}. Must not be {@literal null}.
+     * @param dest The destination {@literal Map}. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     */
     public static void copyMapToMap(final Map<String, ? extends Object> src, final Map<String, Object> dest,
             final Consumer<CopyOptions> option) {
         copyMapToMap(src, dest, buildCopyOptions(option));
@@ -282,6 +316,15 @@ public abstract class BeanUtil {
         return copyBeanToNewBean(src, destClass, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies the source Bean to a new instance of the destination Bean and returns it.
+     *
+     * @param <T> The type of the destination Bean.
+     * @param src The source Bean. Must not be {@literal null}.
+     * @param destClass The type of the destination Bean. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     * @return The newly copied Bean.
+     */
     public static <T> T copyBeanToNewBean(final Object src, final Class<T> destClass, final Consumer<CopyOptions> option) {
         return copyBeanToNewBean(src, destClass, buildCopyOptions(option));
     }
@@ -318,6 +361,15 @@ public abstract class BeanUtil {
         return copyMapToNewBean(src, destClass, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies the source {@literal Map} to a new instance of the destination Bean and returns it.
+     *
+     * @param <T> The type of the destination Bean.
+     * @param src The source {@literal Map}. Must not be {@literal null}.
+     * @param destClass The type of the destination Bean. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     * @return The newly copied {@literal Map}.
+     */
     public static <T> T copyMapToNewBean(final Map<String, ? extends Object> src, final Class<T> destClass,
             final Consumer<CopyOptions> option) {
         return copyMapToNewBean(src, destClass, buildCopyOptions(option));
@@ -353,6 +405,13 @@ public abstract class BeanUtil {
         return copyBeanToNewMap(src, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies the source Bean to a new instance of {@literal LinkedHashMap} and returns it.
+     *
+     * @param src The source Bean. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     * @return The newly copied Bean.
+     */
     public static Map<String, Object> copyBeanToNewMap(final Object src, final Consumer<CopyOptions> option) {
         return copyBeanToNewMap(src, buildCopyOptions(option));
     }
@@ -386,6 +445,15 @@ public abstract class BeanUtil {
         return copyBeanToNewMap(src, destClass, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies the source Bean to a new instance of a {@literal Map} and returns it.
+     *
+     * @param <T> The type of the destination {@literal Map}.
+     * @param src The source Bean. Must not be {@literal null}.
+     * @param destClass The type of the destination {@literal Map}. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     * @return The newly copied {@literal Map}.
+     */
     public static <T extends Map<String, Object>> T copyBeanToNewMap(final Object src, final Class<? extends T> destClass,
             final Consumer<CopyOptions> option) {
         return copyBeanToNewMap(src, destClass, buildCopyOptions(option));
@@ -422,6 +490,13 @@ public abstract class BeanUtil {
         return copyMapToNewMap(src, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies the source {@literal Map} to a new instance of {@literal LinkedHashMap} and returns it.
+     *
+     * @param src The source {@literal Map}. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     * @return The newly copied {@literal Map}.
+     */
     public static Map<String, Object> copyMapToNewMap(final Map<String, ? extends Object> src, final Consumer<CopyOptions> option) {
         return copyMapToNewMap(src, buildCopyOptions(option));
     }
@@ -456,6 +531,15 @@ public abstract class BeanUtil {
         return copyMapToNewMap(src, destClass, DEFAULT_OPTIONS);
     }
 
+    /**
+     * Copies the source {@literal Map} to a new instance of a {@literal Map} and returns it.
+     *
+     * @param <T> The type of the destination {@literal Map}.
+     * @param src The source {@literal Map}. Must not be {@literal null}.
+     * @param destClass The type of the destination {@literal Map}. Must not be {@literal null}.
+     * @param option The consumer for copy options.
+     * @return The newly copied {@literal Map}.
+     */
     public static <T extends Map<String, Object>> T copyMapToNewMap(final Map<String, ? extends Object> src,
             final Class<? extends T> destClass, final Consumer<CopyOptions> option) {
         return copyMapToNewMap(src, destClass, buildCopyOptions(option));
@@ -482,6 +566,13 @@ public abstract class BeanUtil {
         return dest;
     }
 
+    /**
+     * Builds {@link CopyOptions} from a {@link Consumer}.
+     *
+     * @param option
+     *            the option
+     * @return the copy options
+     */
     protected static CopyOptions buildCopyOptions(final Consumer<CopyOptions> option) {
         final CopyOptions copyOptions = new CopyOptions();
         option.accept(copyOptions);

--- a/src/main/java/org/codelibs/core/beans/util/CopyOptions.java
+++ b/src/main/java/org/codelibs/core/beans/util/CopyOptions.java
@@ -45,6 +45,12 @@ import org.codelibs.core.exception.ConverterRuntimeException;
 public class CopyOptions {
 
     /**
+     * Creates a new {@link CopyOptions} instance.
+     */
+    public CopyOptions() {
+    }
+
+    /**
      * Default converter for dates.
      */
     protected static final Converter DEFAULT_DATE_CONVERTER = new DateConverter(DateConversionUtil.getMediumPattern());

--- a/src/main/java/org/codelibs/core/beans/util/CopyOptionsUtil.java
+++ b/src/main/java/org/codelibs/core/beans/util/CopyOptionsUtil.java
@@ -46,6 +46,12 @@ import org.codelibs.core.beans.converter.TimestampConverter;
 public abstract class CopyOptionsUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private CopyOptionsUtil() {
+    }
+
+    /**
      * Returns a {@link CopyOptions} with the specified property names to include in the operation.
      *
      * @param propertyNames

--- a/src/main/java/org/codelibs/core/collection/ArrayMap.java
+++ b/src/main/java/org/codelibs/core/collection/ArrayMap.java
@@ -563,6 +563,12 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
         /** Index of the last accessed element */
         protected int last = -1;
 
+        /**
+         * Constructs an instance.
+         */
+        protected ArrayMapIterator() {
+        }
+
         @Override
         public boolean hasNext() {
             return current != size;

--- a/src/main/java/org/codelibs/core/collection/ArrayUtil.java
+++ b/src/main/java/org/codelibs/core/collection/ArrayUtil.java
@@ -35,6 +35,12 @@ import org.codelibs.core.message.MessageFormatter;
 public abstract class ArrayUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ArrayUtil() {
+    }
+
+    /**
      * Returns an array of {@literal boolean}.
      *
      * @param elements the elements of the array

--- a/src/main/java/org/codelibs/core/collection/CollectionsUtil.java
+++ b/src/main/java/org/codelibs/core/collection/CollectionsUtil.java
@@ -59,6 +59,12 @@ import java.util.concurrent.SynchronousQueue;
 public abstract class CollectionsUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private CollectionsUtil() {
+    }
+
+    /**
      * Creates and returns a new instance of {@link ArrayBlockingQueue}.
      *
      * @param <E> the element type of {@link ArrayBlockingQueue}

--- a/src/main/java/org/codelibs/core/collection/LruHashSet.java
+++ b/src/main/java/org/codelibs/core/collection/LruHashSet.java
@@ -21,17 +21,31 @@ import java.util.Iterator;
 import java.util.Set;
 
 /**
+ * A {@link Set} implementation that stores its elements in a {@link LruHashMap}.
+ * <p>
+ * This set has a fixed maximum capacity. When the capacity is reached and a new element is added,
+ * the least recently used element is removed.
+ * </p>
  * @author shinsuke
- *
+ * @param <E> the type of elements maintained by this set
  */
 public class LruHashSet<E> extends AbstractSet<E> implements Set<E>, java.io.Serializable {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The internal LRU hash map used to store elements.
+     */
     private final LruHashMap<E, Object> map;
 
     // Dummy value to associate with an Object in the backing Map
     private static final Object PRESENT = new Object();
 
+    /**
+     * Creates a new {@link LruHashSet} with the specified limit size.
+     *
+     * @param limitSize
+     *            the maximum number of elements to retain in the set
+     */
     public LruHashSet(final int limitSize) {
         map = new LruHashMap<>(limitSize);
     }

--- a/src/main/java/org/codelibs/core/concurrent/CommonPoolUtil.java
+++ b/src/main/java/org/codelibs/core/concurrent/CommonPoolUtil.java
@@ -19,6 +19,9 @@ import java.util.concurrent.ForkJoinPool;
 
 import org.codelibs.core.log.Logger;
 
+/**
+ * Utility for common pool operations.
+ */
 public class CommonPoolUtil {
     private static final Logger logger = Logger.getLogger(CommonPoolUtil.class);
 
@@ -26,6 +29,12 @@ public class CommonPoolUtil {
         // nothing
     }
 
+    /**
+     * Executes the given task in the common ForkJoinPool.
+     *
+     * @param task
+     *            the task to execute
+     */
     public static void execute(final Runnable task) {
         ForkJoinPool.commonPool().execute(() -> {
             final Thread currentThread = Thread.currentThread();

--- a/src/main/java/org/codelibs/core/convert/BigDecimalConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BigDecimalConversionUtil.java
@@ -28,6 +28,12 @@ import org.codelibs.core.lang.StringUtil;
 public abstract class BigDecimalConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private BigDecimalConversionUtil() {
+    }
+
+    /**
      * Converts to {@link BigDecimal}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/BigIntegerConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BigIntegerConversionUtil.java
@@ -25,6 +25,12 @@ import java.math.BigInteger;
 public abstract class BigIntegerConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private BigIntegerConversionUtil() {
+    }
+
+    /**
      * Converts to {@link BigInteger}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/BinaryConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BinaryConversionUtil.java
@@ -25,6 +25,12 @@ import static org.codelibs.core.misc.AssertionUtil.assertArgument;
 public abstract class BinaryConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private BinaryConversionUtil() {
+    }
+
+    /**
      * Converts to a {@literal byte} array.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/BooleanConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BooleanConversionUtil.java
@@ -23,6 +23,12 @@ package org.codelibs.core.convert;
 public abstract class BooleanConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private BooleanConversionUtil() {
+    }
+
+    /**
      * Converts to {@link Boolean}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/ByteConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/ByteConversionUtil.java
@@ -28,6 +28,12 @@ import org.codelibs.core.text.DecimalFormatUtil;
 public abstract class ByteConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ByteConversionUtil() {
+    }
+
+    /**
      * Converts to {@link Byte}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/CalendarConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/CalendarConversionUtil.java
@@ -29,6 +29,12 @@ import java.util.TimeZone;
 public abstract class CalendarConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private CalendarConversionUtil() {
+    }
+
+    /**
      * Converts to {@link Calendar}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/DateConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/DateConversionUtil.java
@@ -104,6 +104,12 @@ import org.codelibs.core.misc.LocaleUtil;
  */
 public abstract class DateConversionUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private DateConversionUtil() {
+    }
+
     /** Array of styles held by {@link DateFormat}. */
     protected static final int[] STYLES = new int[] { SHORT, MEDIUM, LONG, FULL };
 

--- a/src/main/java/org/codelibs/core/convert/DoubleConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/DoubleConversionUtil.java
@@ -28,6 +28,12 @@ import org.codelibs.core.text.DecimalFormatUtil;
 public abstract class DoubleConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private DoubleConversionUtil() {
+    }
+
+    /**
      * Converts to {@link Double}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/FloatConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/FloatConversionUtil.java
@@ -28,6 +28,12 @@ import org.codelibs.core.text.DecimalFormatUtil;
 public abstract class FloatConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private FloatConversionUtil() {
+    }
+
+    /**
      * Converts to {@link Float}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/IntegerConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/IntegerConversionUtil.java
@@ -28,6 +28,12 @@ import org.codelibs.core.text.DecimalFormatUtil;
 public abstract class IntegerConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private IntegerConversionUtil() {
+    }
+
+    /**
      * Converts to {@link Integer}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/LongConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/LongConversionUtil.java
@@ -28,6 +28,12 @@ import org.codelibs.core.text.DecimalFormatUtil;
 public abstract class LongConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private LongConversionUtil() {
+    }
+
+    /**
      * Converts the given object to a {@link Long}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/NumberConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/NumberConversionUtil.java
@@ -31,6 +31,12 @@ import org.codelibs.core.text.DecimalFormatSymbolsUtil;
 public abstract class NumberConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private NumberConversionUtil() {
+    }
+
+    /**
      * Converts to the appropriate {@link Number}.
      *
      * @param type

--- a/src/main/java/org/codelibs/core/convert/ShortConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/ShortConversionUtil.java
@@ -28,6 +28,12 @@ import org.codelibs.core.text.DecimalFormatUtil;
 public abstract class ShortConversionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ShortConversionUtil() {
+    }
+
+    /**
      * Converts to {@link Short}.
      *
      * @param o

--- a/src/main/java/org/codelibs/core/convert/StringConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/StringConversionUtil.java
@@ -29,6 +29,12 @@ import org.codelibs.core.misc.Base64Util;
  */
 public abstract class StringConversionUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private StringConversionUtil() {
+    }
+
     /** WAVE DASH */
     public static final char WAVE_DASH = '\u301C';
 

--- a/src/main/java/org/codelibs/core/convert/TimeConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/TimeConversionUtil.java
@@ -107,6 +107,12 @@ import org.codelibs.core.misc.LocaleUtil;
  */
 public abstract class TimeConversionUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private TimeConversionUtil() {
+    }
+
     /** Array of styles held by {@link DateFormat} */
     protected static final int[] STYLES = new int[] { SHORT, MEDIUM, LONG, FULL };
 

--- a/src/main/java/org/codelibs/core/convert/TimestampConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/TimestampConversionUtil.java
@@ -83,6 +83,12 @@ import org.codelibs.core.misc.LocaleUtil;
  */
 public abstract class TimestampConversionUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private TimestampConversionUtil() {
+    }
+
     /** Array of styles held by {@link DateFormat} */
     protected static final int[] STYLES = new int[] { SHORT, MEDIUM, LONG, FULL };
 

--- a/src/main/java/org/codelibs/core/crypto/CachedCipher.java
+++ b/src/main/java/org/codelibs/core/crypto/CachedCipher.java
@@ -37,24 +37,58 @@ import org.codelibs.core.exception.NoSuchPaddingRuntimeException;
 import org.codelibs.core.exception.UnsupportedEncodingRuntimeException;
 import org.codelibs.core.misc.Base64Util;
 
+/**
+ * A utility class for encrypting and decrypting data using a cached {@link Cipher} instance.
+ */
 public class CachedCipher {
+
+    /**
+     * Creates a new {@link CachedCipher} instance.
+     */
+    public CachedCipher() {
+    }
 
     private static final String BLOWFISH = "Blowfish";
 
     private static final String RSA = "RSA";
 
+    /**
+     * The algorithm to use for the cipher.
+     */
     protected String algorithm = BLOWFISH;
 
+    /**
+     * The transformation to use for the cipher.
+     */
     protected String transformation = RSA;
 
+    /**
+     * The key to use for encryption/decryption.
+     */
     protected String key;
 
+    /**
+     * The character set name to use for encoding/decoding strings.
+     */
     protected String charsetName = CoreLibConstants.UTF_8;
 
+    /**
+     * The queue of ciphers for encryption.
+     */
     protected Queue<Cipher> encryptoQueue = new ConcurrentLinkedQueue<>();
 
+    /**
+     * The queue of ciphers for decryption.
+     */
     protected Queue<Cipher> decryptoQueue = new ConcurrentLinkedQueue<>();
 
+    /**
+     * Encrypts the given data.
+     *
+     * @param data
+     *            the data to encrypt
+     * @return the encrypted data
+     */
     public byte[] encrypto(final byte[] data) {
         final Cipher cipher = pollEncryptoCipher();
         byte[] encrypted;
@@ -70,6 +104,15 @@ public class CachedCipher {
         return encrypted;
     }
 
+    /**
+     * Encrypts the given data with the specified key.
+     *
+     * @param data
+     *            the data to encrypt
+     * @param key
+     *            the key to use for encryption
+     * @return the encrypted data
+     */
     public byte[] encrypto(final byte[] data, final Key key) {
         final Cipher cipher = pollEncryptoCipher(key);
         byte[] encrypted;
@@ -85,6 +128,13 @@ public class CachedCipher {
         return encrypted;
     }
 
+    /**
+     * Encrypts the given text.
+     *
+     * @param text
+     *            the text to encrypt
+     * @return the encrypted text
+     */
     public String encryptoText(final String text) {
         try {
             return Base64Util.encode(encrypto(text.getBytes(charsetName)));
@@ -93,6 +143,13 @@ public class CachedCipher {
         }
     }
 
+    /**
+     * Decrypts the given data.
+     *
+     * @param data
+     *            the data to decrypt
+     * @return the decrypted data
+     */
     public byte[] decrypto(final byte[] data) {
         final Cipher cipher = pollDecryptoCipher();
         byte[] decrypted;
@@ -108,6 +165,15 @@ public class CachedCipher {
         return decrypted;
     }
 
+    /**
+     * Decrypts the given data with the specified key.
+     *
+     * @param data
+     *            the data to decrypt
+     * @param key
+     *            the key to use for decryption
+     * @return the decrypted data
+     */
     public byte[] decrypto(final byte[] data, final Key key) {
         final Cipher cipher = pollDecryptoCipher(key);
         byte[] decrypted;
@@ -123,6 +189,13 @@ public class CachedCipher {
         return decrypted;
     }
 
+    /**
+     * Decrypts the given text.
+     *
+     * @param text
+     *            the text to decrypt
+     * @return the decrypted text
+     */
     public String decryptoText(final String text) {
         try {
             return new String(decrypto(Base64Util.decode(text)), charsetName);
@@ -131,6 +204,11 @@ public class CachedCipher {
         }
     }
 
+    /**
+     * Polls an encryption cipher from the queue, creating a new one if none are available.
+     *
+     * @return an encryption cipher
+     */
     protected Cipher pollEncryptoCipher() {
         Cipher cipher = encryptoQueue.poll();
         if (cipher == null) {
@@ -149,6 +227,13 @@ public class CachedCipher {
         return cipher;
     }
 
+    /**
+     * Polls an encryption cipher from the queue, creating a new one if none are available, using the specified key.
+     *
+     * @param key
+     *            the key to use for the cipher
+     * @return an encryption cipher
+     */
     protected Cipher pollEncryptoCipher(final Key key) {
         Cipher cipher = encryptoQueue.poll();
         if (cipher == null) {
@@ -166,10 +251,21 @@ public class CachedCipher {
         return cipher;
     }
 
+    /**
+     * Offers an encryption cipher back to the queue.
+     *
+     * @param cipher
+     *            the cipher to offer
+     */
     protected void offerEncryptoCipher(final Cipher cipher) {
         encryptoQueue.offer(cipher);
     }
 
+    /**
+     * Polls a decryption cipher from the queue, creating a new one if none are available.
+     *
+     * @return a decryption cipher
+     */
     protected Cipher pollDecryptoCipher() {
         Cipher cipher = decryptoQueue.poll();
         if (cipher == null) {
@@ -188,6 +284,13 @@ public class CachedCipher {
         return cipher;
     }
 
+    /**
+     * Polls a decryption cipher from the queue, creating a new one if none are available, using the specified key.
+     *
+     * @param key
+     *            the key to use for the cipher
+     * @return a decryption cipher
+     */
     protected Cipher pollDecryptoCipher(final Key key) {
         Cipher cipher = decryptoQueue.poll();
         if (cipher == null) {
@@ -205,38 +308,88 @@ public class CachedCipher {
         return cipher;
     }
 
+    /**
+     * Offers a decryption cipher back to the queue.
+     *
+     * @param cipher
+     *            the cipher to offer
+     */
     protected void offerDecryptoCipher(final Cipher cipher) {
         decryptoQueue.offer(cipher);
     }
 
+    /**
+     * Returns the algorithm.
+     *
+     * @return the algorithm
+     */
     public String getAlgorithm() {
         return algorithm;
     }
 
+    /**
+     * Sets the algorithm.
+     *
+     * @param algorithm
+     *            the algorithm
+     */
     public void setAlgorithm(final String algorithm) {
         this.algorithm = algorithm;
     }
 
+    /**
+     * Returns the transformation.
+     *
+     * @return the transformation
+     */
     public String getTransformation() {
         return transformation;
     }
 
+    /**
+     * Sets the transformation.
+     *
+     * @param transformation
+     *            the transformation
+     */
     public void setTransformation(final String transformation) {
         this.transformation = transformation;
     }
 
+    /**
+     * Returns the key.
+     *
+     * @return the key
+     */
     public String getKey() {
         return key;
     }
 
+    /**
+     * Sets the key.
+     *
+     * @param key
+     *            the key
+     */
     public void setKey(final String key) {
         this.key = key;
     }
 
+    /**
+     * Returns the charset name.
+     *
+     * @return the charset name
+     */
     public String getCharsetName() {
         return charsetName;
     }
 
+    /**
+     * Sets the charset name.
+     *
+     * @param charsetName
+     *            the charset name
+     */
     public void setCharsetName(final String charsetName) {
         this.charsetName = charsetName;
     }

--- a/src/main/java/org/codelibs/core/exception/BadPaddingRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/BadPaddingRuntimeException.java
@@ -18,13 +18,19 @@ package org.codelibs.core.exception;
 import javax.crypto.BadPaddingException;
 
 /**
+ * Signals that this exception has been thrown when a particular padding mechanism is expected for the input data but the data is not padded properly.
  * @author shinsuke
- *
  */
 public class BadPaddingRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new {@link BadPaddingRuntimeException} with the specified cause.
+     *
+     * @param cause
+     *            the cause
+     */
     public BadPaddingRuntimeException(final BadPaddingException cause) {
         super("ECL0105", new Object[] { cause.getMessage() }, cause);
     }

--- a/src/main/java/org/codelibs/core/exception/BeanFieldSetAccessibleFailureException.java
+++ b/src/main/java/org/codelibs/core/exception/BeanFieldSetAccessibleFailureException.java
@@ -17,23 +17,52 @@ package org.codelibs.core.exception;
 
 import java.lang.reflect.Field;
 
+/**
+ * Signals that a field could not be made accessible.
+ */
 public class BeanFieldSetAccessibleFailureException extends ClRuntimeException {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The target class.
+     */
     protected final Class<?> targetClass;
 
+    /**
+     * The target field.
+     */
     protected final transient Field targetField;
 
+    /**
+     * Creates a new {@link BeanFieldSetAccessibleFailureException} with the specified cause.
+     *
+     * @param componentClass
+     *            the component class
+     * @param targetField
+     *            the target field
+     * @param cause
+     *            the cause
+     */
     public BeanFieldSetAccessibleFailureException(final Class<?> componentClass, final Field targetField, final Throwable cause) {
         super("ECL0115", new Object[] { targetField }, cause);
         this.targetClass = componentClass;
         this.targetField = targetField;
     }
 
+    /**
+     * Returns the target class.
+     *
+     * @return the target class
+     */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
+    /**
+     * Returns the target field.
+     *
+     * @return the target field
+     */
     public Field getTargetField() {
         return targetField;
     }

--- a/src/main/java/org/codelibs/core/exception/BeanMethodSetAccessibleFailureException.java
+++ b/src/main/java/org/codelibs/core/exception/BeanMethodSetAccessibleFailureException.java
@@ -17,24 +17,53 @@ package org.codelibs.core.exception;
 
 import java.lang.reflect.Method;
 
+/**
+ * Signals that a method could not be made accessible.
+ */
 public class BeanMethodSetAccessibleFailureException extends ClRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The target class.
+     */
     protected final Class<?> targetClass;
 
+    /**
+     * The target method.
+     */
     protected final transient Method targetMethod;
 
+    /**
+     * Creates a new {@link BeanMethodSetAccessibleFailureException} with the specified cause.
+     *
+     * @param componentClass
+     *            the component class
+     * @param targetMethod
+     *            the target method
+     * @param cause
+     *            the cause
+     */
     public BeanMethodSetAccessibleFailureException(final Class<?> componentClass, final Method targetMethod, final Throwable cause) {
         super("ECL0116", new Object[] { targetMethod }, cause);
         this.targetClass = componentClass;
         this.targetMethod = targetMethod;
     }
 
+    /**
+     * Returns the target class.
+     *
+     * @return the target class
+     */
     public Class<?> getTargetClass() {
         return targetClass;
     }
 
+    /**
+     * Returns the target method.
+     *
+     * @return the target method
+     */
     public Method getTargetMethod() {
         return targetMethod;
     }

--- a/src/main/java/org/codelibs/core/exception/ClRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ClRuntimeException.java
@@ -27,12 +27,24 @@ public class ClRuntimeException extends RuntimeException {
 
     private static final long serialVersionUID = -4452607868694297329L;
 
+    /**
+     * The message code.
+     */
     private final String messageCode;
 
+    /**
+     * The arguments for the message.
+     */
     private final Object[] args;
 
+    /**
+     * The formatted message.
+     */
     private final String message;
 
+    /**
+     * The simple message without the message code.
+     */
     private final String simpleMessage;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/ClSQLException.java
+++ b/src/main/java/org/codelibs/core/exception/ClSQLException.java
@@ -28,10 +28,19 @@ public class ClSQLException extends SQLException {
 
     private static final long serialVersionUID = 4098267431221202677L;
 
+    /**
+     * The message code.
+     */
     private final String messageCode;
 
+    /**
+     * The arguments for the message.
+     */
     private final Object[] args;
 
+    /**
+     * The SQL string.
+     */
     private final String sql;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/ClassNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ClassNotFoundRuntimeException.java
@@ -26,6 +26,9 @@ public class ClassNotFoundRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = -9022468864937761059L;
 
+    /**
+     * The name of the class that could not be found.
+     */
     private final String className;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/ConstructorNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ConstructorNotFoundRuntimeException.java
@@ -28,10 +28,19 @@ public class ConstructorNotFoundRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 8584662068396978822L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The method arguments.
+     */
     private final Object[] methodArgs;
 
+    /**
+     * The parameter types.
+     */
     private final Class<?>[] paramTypes;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/ConverterRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ConverterRuntimeException.java
@@ -28,8 +28,14 @@ public class ConverterRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The name of the property.
+     */
     private final String propertyName;
 
+    /**
+     * The value that caused the conversion error.
+     */
     private final Object value;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/FieldNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/FieldNotFoundRuntimeException.java
@@ -29,8 +29,14 @@ public class FieldNotFoundRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = -2715036865146285893L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The name of the field.
+     */
     private final String fieldName;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/FieldNotStaticRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/FieldNotStaticRuntimeException.java
@@ -28,8 +28,14 @@ public class FieldNotStaticRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = -7791347225750660981L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The name of the field.
+     */
     private final String fieldName;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/FileAccessException.java
+++ b/src/main/java/org/codelibs/core/exception/FileAccessException.java
@@ -25,18 +25,50 @@ public class FileAccessException extends ClRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new {@link FileAccessException} with the specified message code, arguments, and cause.
+     *
+     * @param messageCode
+     *            the message code
+     * @param args
+     *            the message arguments
+     * @param cause
+     *            the cause
+     */
     public FileAccessException(final String messageCode, final Object[] args, final Throwable cause) {
         super(messageCode, args, cause);
     }
 
+    /**
+     * Creates a new {@link FileAccessException} with the specified message code and arguments.
+     *
+     * @param messageCode
+     *            the message code
+     * @param args
+     *            the message arguments
+     */
     public FileAccessException(final String messageCode, final Object[] args) {
         super(messageCode, args);
     }
 
+    /**
+     * Creates a new {@link FileAccessException} with the specified message code and cause.
+     *
+     * @param messageCode
+     *            the message code
+     * @param cause
+     *            the cause
+     */
     public FileAccessException(final String messageCode, final Throwable cause) {
         super(messageCode, new Object[0], cause);
     }
 
+    /**
+     * Creates a new {@link FileAccessException} with the specified message code.
+     *
+     * @param messageCode
+     *            the message code
+     */
     public FileAccessException(final String messageCode) {
         super(messageCode, new Object[0]);
     }

--- a/src/main/java/org/codelibs/core/exception/IllegalAccessRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/IllegalAccessRuntimeException.java
@@ -26,6 +26,9 @@ public class IllegalAccessRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = -3649900343028907465L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/IllegalBlockSizeRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/IllegalBlockSizeRuntimeException.java
@@ -18,13 +18,19 @@ package org.codelibs.core.exception;
 import javax.crypto.IllegalBlockSizeException;
 
 /**
+ * Signals that this exception has been thrown when a block cipher is supplied with input data whose length is not a multiple of the cipher's block size, or that has been padded to the wrong length.
  * @author shinsuke
- *
  */
 public class IllegalBlockSizeRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new {@link IllegalBlockSizeRuntimeException} with the specified cause.
+     *
+     * @param cause
+     *            the cause
+     */
     public IllegalBlockSizeRuntimeException(final IllegalBlockSizeException cause) {
         super("ECL0105", new Object[] { cause.getMessage() }, cause);
     }

--- a/src/main/java/org/codelibs/core/exception/IllegalPropertyRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/IllegalPropertyRuntimeException.java
@@ -27,8 +27,14 @@ public class IllegalPropertyRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 3584516316082904020L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The name of the property.
+     */
     private final String propertyName;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/InstantiationRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/InstantiationRuntimeException.java
@@ -26,6 +26,9 @@ public class InstantiationRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 5220902071756706607L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/InterruptedRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/InterruptedRuntimeException.java
@@ -25,6 +25,12 @@ public class InterruptedRuntimeException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new {@link InterruptedRuntimeException} with the specified cause.
+     *
+     * @param e
+     *            the cause
+     */
     public InterruptedRuntimeException(final InterruptedException e) {
         super(e);
     }

--- a/src/main/java/org/codelibs/core/exception/InvocationTargetRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/InvocationTargetRuntimeException.java
@@ -28,6 +28,9 @@ public class InvocationTargetRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 7760491787158046906L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/MethodNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/MethodNotFoundRuntimeException.java
@@ -31,10 +31,19 @@ public class MethodNotFoundRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = -3508955801981550317L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The name of the method.
+     */
     private final String methodName;
 
+    /**
+     * The classes of the method arguments.
+     */
     private final Class<?>[] methodArgClasses;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/MethodNotStaticRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/MethodNotStaticRuntimeException.java
@@ -28,8 +28,14 @@ public class MethodNotStaticRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 7186052234464152208L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The name of the method.
+     */
     private final String methodName;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/NoSuchConstructorRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NoSuchConstructorRuntimeException.java
@@ -30,8 +30,14 @@ public class NoSuchConstructorRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 8688818589925114466L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The parameter types.
+     */
     private final Class<?>[] argTypes;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/NoSuchFieldRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NoSuchFieldRuntimeException.java
@@ -26,8 +26,14 @@ public class NoSuchFieldRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 6609175673610180338L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The name of the field.
+     */
     private final String fieldName;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/NoSuchMethodRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/NoSuchMethodRuntimeException.java
@@ -28,10 +28,19 @@ public class NoSuchMethodRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = -5673845060079098617L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The name of the method.
+     */
     private final String methodName;
 
+    /**
+     * The argument types.
+     */
     private final Class<?>[] argTypes;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/PropertyNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/PropertyNotFoundRuntimeException.java
@@ -27,8 +27,14 @@ public class PropertyNotFoundRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = -5177019197796206774L;
 
+    /**
+     * The target class.
+     */
     private final Class<?> targetClass;
 
+    /**
+     * The name of the property.
+     */
     private final String propertyName;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/ResourceNotFoundRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/ResourceNotFoundRuntimeException.java
@@ -26,6 +26,9 @@ public class ResourceNotFoundRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 9033370905740809950L;
 
+    /**
+     * The path to the resource.
+     */
     private final String path;
 
     /**

--- a/src/main/java/org/codelibs/core/exception/UnsupportedEncodingRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/UnsupportedEncodingRuntimeException.java
@@ -18,13 +18,19 @@ package org.codelibs.core.exception;
 import java.io.UnsupportedEncodingException;
 
 /**
+ * Signals that a character encoding is not supported.
  * @author shinsuke
- *
  */
 public class UnsupportedEncodingRuntimeException extends ClRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new {@link UnsupportedEncodingRuntimeException} with the specified cause.
+     *
+     * @param cause
+     *            the cause
+     */
     public UnsupportedEncodingRuntimeException(final UnsupportedEncodingException cause) {
         super("ECL0105", new Object[] { cause.getMessage() }, cause);
     }

--- a/src/main/java/org/codelibs/core/io/ClassTraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/ClassTraversalUtil.java
@@ -36,6 +36,12 @@ import org.codelibs.core.zip.ZipInputStreamUtil;
  */
 public abstract class ClassTraversalUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private ClassTraversalUtil() {
+    }
+
     /** The file extension for class files. */
     protected static final String CLASS_SUFFIX = ".class";
 

--- a/src/main/java/org/codelibs/core/io/CloseableUtil.java
+++ b/src/main/java/org/codelibs/core/io/CloseableUtil.java
@@ -29,6 +29,12 @@ import org.codelibs.core.log.Logger;
  */
 public abstract class CloseableUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private CloseableUtil() {
+    }
+
     private static final Logger logger = Logger.getLogger(CloseableUtil.class);
 
     /**
@@ -62,6 +68,11 @@ public abstract class CloseableUtil {
         }
     }
 
+    /**
+     * Closes a {@link Closeable} quietly, suppressing any {@link IOException}.
+     *
+     * @param closeable the closeable object
+     */
     public static void closeQuietly(final Closeable closeable) {
         if (closeable == null) {
             return;

--- a/src/main/java/org/codelibs/core/io/CopyUtil.java
+++ b/src/main/java/org/codelibs/core/io/CopyUtil.java
@@ -116,6 +116,12 @@ import org.codelibs.core.nio.ChannelUtil;
  */
 public abstract class CopyUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private CopyUtil() {
+    }
+
     /** Buffer size used for copying. */
     protected static final int DEFAULT_BUF_SIZE = 4096;
 

--- a/src/main/java/org/codelibs/core/io/FileUtil.java
+++ b/src/main/java/org/codelibs/core/io/FileUtil.java
@@ -43,6 +43,12 @@ import org.codelibs.core.timer.TimeoutManager;
  */
 public abstract class FileUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private FileUtil() {
+    }
+
     /** The encoding name for UTF-8. */
     private static final String UTF8 = "UTF-8";
 
@@ -236,6 +242,14 @@ public abstract class FileUtil {
         }
     }
 
+    /**
+     * Writes the specified byte array to the file at the given pathname.
+     *
+     * @param pathname
+     *            The path to the file.
+     * @param bytes
+     *            The byte array to write.
+     */
     public static void writeBytes(final String pathname, final byte[] bytes) {
         try (FileOutputStream fos = OutputStreamUtil.create(new File(pathname))) {
             ChannelUtil.write(fos.getChannel(), ByteBuffer.wrap(bytes));
@@ -244,6 +258,12 @@ public abstract class FileUtil {
         }
     }
 
+    /**
+     * Deletes the specified file in a background thread.
+     *
+     * @param file
+     *            The file to delete.
+     */
     public static void deleteInBackground(final File file) {
         if (file != null) {
             TimeoutManager.getInstance().addTimeoutTarget(() -> {

--- a/src/main/java/org/codelibs/core/io/InputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/io/InputStreamUtil.java
@@ -32,6 +32,12 @@ import org.codelibs.core.exception.IORuntimeException;
  */
 public abstract class InputStreamUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private InputStreamUtil() {
+    }
+
     /** Default buffer size. */
     private static final int BUF_SIZE = 4096;
 

--- a/src/main/java/org/codelibs/core/io/OutputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/io/OutputStreamUtil.java
@@ -32,6 +32,12 @@ import org.codelibs.core.exception.IORuntimeException;
 public abstract class OutputStreamUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private OutputStreamUtil() {
+    }
+
+    /**
      * Creates a {@link FileOutputStream}.
      *
      * @param file the file (must not be {@literal null})

--- a/src/main/java/org/codelibs/core/io/PropertiesUtil.java
+++ b/src/main/java/org/codelibs/core/io/PropertiesUtil.java
@@ -39,6 +39,12 @@ import org.codelibs.core.net.URLUtil;
 public abstract class PropertiesUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private PropertiesUtil() {
+    }
+
+    /**
      * Wraps exception handling for {@link Properties#load(InputStream)}.
      * <p>
      * The input stream is not closed.

--- a/src/main/java/org/codelibs/core/io/ReaderUtil.java
+++ b/src/main/java/org/codelibs/core/io/ReaderUtil.java
@@ -36,6 +36,12 @@ import org.codelibs.core.exception.IORuntimeException;
  */
 public abstract class ReaderUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private ReaderUtil() {
+    }
+
     /** Default buffer size */
     private static final int BUF_SIZE = 4096;
 

--- a/src/main/java/org/codelibs/core/io/ResourceBundleUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceBundleUtil.java
@@ -35,6 +35,12 @@ import org.codelibs.core.misc.LocaleUtil;
 public abstract class ResourceBundleUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ResourceBundleUtil() {
+    }
+
+    /**
      * Returns the bundle. Returns <code>null</code> if not found.
      *
      * @param name the resource bundle name (must not be {@literal null} or empty)

--- a/src/main/java/org/codelibs/core/io/ResourceTraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceTraversalUtil.java
@@ -40,6 +40,12 @@ import org.codelibs.core.zip.ZipInputStreamUtil;
 public abstract class ResourceTraversalUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ResourceTraversalUtil() {
+    }
+
+    /**
      * Traverses resources contained in the file system.
      *
      * @param rootDir the root directory (must not be {@literal null})

--- a/src/main/java/org/codelibs/core/io/ResourceUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceUtil.java
@@ -37,6 +37,12 @@ import org.codelibs.core.net.URLUtil;
 public abstract class ResourceUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ResourceUtil() {
+    }
+
+    /**
      * Returns the resource path.
      *
      * @param path

--- a/src/main/java/org/codelibs/core/io/SerializeUtil.java
+++ b/src/main/java/org/codelibs/core/io/SerializeUtil.java
@@ -34,6 +34,12 @@ import org.codelibs.core.exception.IORuntimeException;
  */
 public abstract class SerializeUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private SerializeUtil() {
+    }
+
     private static final int BYTE_ARRAY_SIZE = 8 * 1024;
 
     /**

--- a/src/main/java/org/codelibs/core/io/TraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/TraversalUtil.java
@@ -66,6 +66,12 @@ import org.codelibs.core.zip.ZipInputStreamUtil;
  */
 public abstract class TraversalUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private TraversalUtil() {
+    }
+
     /** An empty array of {@link Traverser}. */
     protected static final Traverser[] EMPTY_ARRAY = new Traverser[0];
 

--- a/src/main/java/org/codelibs/core/io/WriterUtil.java
+++ b/src/main/java/org/codelibs/core/io/WriterUtil.java
@@ -36,6 +36,12 @@ import org.codelibs.core.exception.IORuntimeException;
 public abstract class WriterUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private WriterUtil() {
+    }
+
+    /**
      * Creates a {@link Writer} to output to a stream with the specified encoding.
      *
      * @param os the stream (must not be {@literal null})

--- a/src/main/java/org/codelibs/core/jar/JarFileUtil.java
+++ b/src/main/java/org/codelibs/core/jar/JarFileUtil.java
@@ -40,6 +40,12 @@ import org.codelibs.core.net.URLUtil;
  */
 public abstract class JarFileUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private JarFileUtil() {
+    }
+
     private static final Logger logger = Logger.getLogger(JarFileUtil.class);
 
     /**

--- a/src/main/java/org/codelibs/core/jar/JarInputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/jar/JarInputStreamUtil.java
@@ -32,6 +32,12 @@ import org.codelibs.core.exception.IORuntimeException;
 public abstract class JarInputStreamUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private JarInputStreamUtil() {
+    }
+
+    /**
      * Creates a {@link JarInputStream}.
      *
      * @param is the input stream (must not be {@literal null})

--- a/src/main/java/org/codelibs/core/lang/AnnotationUtil.java
+++ b/src/main/java/org/codelibs/core/lang/AnnotationUtil.java
@@ -33,6 +33,12 @@ import org.codelibs.core.beans.factory.BeanDescFactory;
 public abstract class AnnotationUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private AnnotationUtil() {
+    }
+
+    /**
      * Returns the elements of the annotation as a {@link Map} of names and values.
      *
      * @param annotation the annotation (must not be {@literal null})

--- a/src/main/java/org/codelibs/core/lang/ClassLoaderUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ClassLoaderUtil.java
@@ -39,6 +39,12 @@ import org.codelibs.core.message.MessageFormatter;
 public abstract class ClassLoaderUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ClassLoaderUtil() {
+    }
+
+    /**
      * Returns the class loader.
      * <p>
      * The class loader is searched in the following order:

--- a/src/main/java/org/codelibs/core/lang/ClassUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ClassUtil.java
@@ -39,6 +39,12 @@ import org.codelibs.core.exception.NoSuchMethodRuntimeException;
  */
 public abstract class ClassUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private ClassUtil() {
+    }
+
     /** Map from wrapper types to primitive types */
     protected static final Map<Class<?>, Class<?>> wrapperToPrimitiveMap = newHashMap();
 

--- a/src/main/java/org/codelibs/core/lang/ConstructorUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ConstructorUtil.java
@@ -33,6 +33,12 @@ import org.codelibs.core.exception.InvocationTargetRuntimeException;
 public abstract class ConstructorUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ConstructorUtil() {
+    }
+
+    /**
      * Creates and initializes a new instance of the class declared by the specified constructor with the given initialization parameters.
      *
      * @param <T> the type of the object

--- a/src/main/java/org/codelibs/core/lang/FieldUtil.java
+++ b/src/main/java/org/codelibs/core/lang/FieldUtil.java
@@ -33,6 +33,12 @@ import org.codelibs.core.exception.IllegalAccessRuntimeException;
 public abstract class FieldUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private FieldUtil() {
+    }
+
+    /**
      * Returns the value of a {@code static} field represented by the given {@link Field}.
      *
      * @param <T> the type of the field

--- a/src/main/java/org/codelibs/core/lang/GenericsUtil.java
+++ b/src/main/java/org/codelibs/core/lang/GenericsUtil.java
@@ -40,6 +40,12 @@ import org.codelibs.core.collection.CollectionsUtil;
 public abstract class GenericsUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private GenericsUtil() {
+    }
+
+    /**
      * Returns <code>true</code> if the raw type of <code>type</code> can be assigned to <code>clazz</code>,
      * <code>false</code> otherwise.
      *

--- a/src/main/java/org/codelibs/core/lang/MethodUtil.java
+++ b/src/main/java/org/codelibs/core/lang/MethodUtil.java
@@ -34,6 +34,12 @@ import org.codelibs.core.exception.InvocationTargetRuntimeException;
 public abstract class MethodUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private MethodUtil() {
+    }
+
+    /**
      * Invokes the underlying method represented by the {@link Method} object, with the specified object and parameters.
      *
      * @param <T>

--- a/src/main/java/org/codelibs/core/lang/ModifierUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ModifierUtil.java
@@ -29,6 +29,12 @@ import java.lang.reflect.Modifier;
 public abstract class ModifierUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ModifierUtil() {
+    }
+
+    /**
      * Checks if the specified method is public.
      *
      * @param method

--- a/src/main/java/org/codelibs/core/lang/ObjectUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ObjectUtil.java
@@ -23,6 +23,12 @@ package org.codelibs.core.lang;
 public abstract class ObjectUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ObjectUtil() {
+    }
+
+    /**
      * Returns true if the two objects are equal, or both are null.
      *
      * @param object1 the first object

--- a/src/main/java/org/codelibs/core/lang/StringUtil.java
+++ b/src/main/java/org/codelibs/core/lang/StringUtil.java
@@ -30,6 +30,12 @@ import java.util.StringTokenizer;
 public abstract class StringUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private StringUtil() {
+    }
+
+    /**
      * A system line separator.
      */
     public static final String RETURN_STRING = System.getProperty("line.separator");
@@ -713,6 +719,17 @@ public abstract class StringUtil {
         return ch >= 32 && ch < 127;
     }
 
+    /**
+     * Creates a new String from a char array without copying the array.
+     * <p>
+     * This method uses internal JDK APIs and may not be available in all Java versions.
+     * If the internal API is not available, it falls back to the standard String constructor.
+     * </p>
+     *
+     * @param chars
+     *            the char array
+     * @return a new String
+     */
     public static String newStringUnsafe(final char[] chars) {
         if (chars == null) {
             return null;

--- a/src/main/java/org/codelibs/core/lang/SystemUtil.java
+++ b/src/main/java/org/codelibs/core/lang/SystemUtil.java
@@ -25,6 +25,12 @@ package org.codelibs.core.lang;
 public abstract class SystemUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private SystemUtil() {
+    }
+
+    /**
      * <code>file.encoding</code> system property. Example: UTF-8
      */
     public static final String FILE_ENCODING = System.getProperty("file.encoding");
@@ -101,6 +107,11 @@ public abstract class SystemUtil {
         return System.getenv().getOrDefault(key, defaultValue);
     }
 
+    /**
+     * Returns the current time in milliseconds.
+     *
+     * @return the current time in milliseconds
+     */
     public static long currentTimeMillis() {
         // TODO provider
         return System.currentTimeMillis();

--- a/src/main/java/org/codelibs/core/lang/ThreadUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ThreadUtil.java
@@ -28,6 +28,20 @@ public abstract class ThreadUtil {
 
     private static final Logger logger = Logger.getLogger(ThreadUtil.class);
 
+    /**
+     * Do not instantiate.
+     */
+    private ThreadUtil() {
+    }
+
+    /**
+     * Causes the currently executing thread to sleep (temporarily cease execution) for the specified number of milliseconds.
+     *
+     * @param millis
+     *            the length of time to sleep in milliseconds
+     * @throws InterruptedRuntimeException
+     *             if any thread has interrupted the current thread.
+     */
     public static void sleep(final long millis) {
         if (millis < 1L) {
             return;
@@ -39,6 +53,13 @@ public abstract class ThreadUtil {
         }
     }
 
+    /**
+     * Causes the currently executing thread to sleep (temporarily cease execution) for the specified number of milliseconds.
+     * Any {@link InterruptedException} is caught and logged at debug level.
+     *
+     * @param millis
+     *            the length of time to sleep in milliseconds
+     */
     public static void sleepQuietly(final long millis) {
         if (millis < 1L) {
             return;

--- a/src/main/java/org/codelibs/core/message/MessageFormatter.java
+++ b/src/main/java/org/codelibs/core/message/MessageFormatter.java
@@ -31,6 +31,12 @@ import org.codelibs.core.misc.LocaleUtil;
  */
 public abstract class MessageFormatter {
 
+    /**
+     * Do not instantiate.
+     */
+    private MessageFormatter() {
+    }
+
     /** Length of the numeric part of the message code */
     protected static final int CODE_NUMBER_LENGTH = 4;
 

--- a/src/main/java/org/codelibs/core/misc/AssertionUtil.java
+++ b/src/main/java/org/codelibs/core/misc/AssertionUtil.java
@@ -36,6 +36,12 @@ import org.codelibs.core.lang.StringUtil;
 public abstract class AssertionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private AssertionUtil() {
+    }
+
+    /**
      * Asserts that the argument is not <code>null</code>.
      *
      * @param argName

--- a/src/main/java/org/codelibs/core/misc/Base64Util.java
+++ b/src/main/java/org/codelibs/core/misc/Base64Util.java
@@ -25,6 +25,12 @@ import org.codelibs.core.lang.StringUtil;
  */
 public abstract class Base64Util {
 
+    /**
+     * Do not instantiate.
+     */
+    private Base64Util() {
+    }
+
     private static final char[] ENCODE_TABLE = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
             'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
             'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/' };

--- a/src/main/java/org/codelibs/core/misc/DisposableUtil.java
+++ b/src/main/java/org/codelibs/core/misc/DisposableUtil.java
@@ -32,6 +32,12 @@ import java.util.Deque;
  */
 public abstract class DisposableUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private DisposableUtil() {
+    }
+
     /** Registered {@link Disposable} */
     protected static final Deque<Disposable> disposables = newLinkedList();
 

--- a/src/main/java/org/codelibs/core/misc/DynamicProperties.java
+++ b/src/main/java/org/codelibs/core/misc/DynamicProperties.java
@@ -73,24 +73,63 @@ public class DynamicProperties extends Properties {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The interval in milliseconds to check for file modifications. Default is 5000ms.
+     */
     protected long checkInterval = 5000L;
 
+    /**
+     * The timestamp of the last check for file modifications.
+     */
     protected volatile long lastChecked = 0L;
 
+    /**
+     * The timestamp of the last modification of the properties file.
+     */
     protected volatile long lastModified = 0L;
 
+    /**
+     * The properties file.
+     */
     protected volatile File propertiesFile;
 
+    /**
+     * The properties instance.
+     */
     protected volatile Properties properties;
 
+    /**
+     * Constructs a {@code DynamicProperties} instance with the specified file path.
+     *
+     * @param path
+     *            The path to the properties file. If {@code null}, a {@link FileAccessException} is thrown.
+     * @throws FileAccessException
+     *             If the file cannot be accessed or created.
+     */
     public DynamicProperties(final String path) {
         this(path == null ? null : new File(path));
     }
 
+    /**
+     * Constructs a {@code DynamicProperties} instance with the specified {@link Path}.
+     *
+     * @param path
+     *            The {@link Path} to the properties file. If {@code null}, a {@link FileAccessException} is thrown.
+     * @throws FileAccessException
+     *             If the file cannot be accessed or created.
+     */
     public DynamicProperties(final Path path) {
         this(path == null ? null : path.toFile());
     }
 
+    /**
+     * Constructs a {@code DynamicProperties} instance with the specified {@link File}.
+     *
+     * @param file
+     *            The {@link File} representing the properties file. If {@code null}, a {@link FileAccessException} is thrown.
+     * @throws FileAccessException
+     *             If the file cannot be accessed or created.
+     */
     public DynamicProperties(final File file) {
         // check path
         if (file == null) {
@@ -115,6 +154,14 @@ public class DynamicProperties extends Properties {
         load();
     }
 
+    /**
+     * Reloads the properties from the specified path.
+     *
+     * @param path
+     *            The path to the properties file.
+     * @throws FileAccessException
+     *             If the file cannot be accessed or created.
+     */
     public synchronized void reload(final String path) {
         final File file = new File(path);
         if (!file.exists()) {
@@ -136,6 +183,11 @@ public class DynamicProperties extends Properties {
         load();
     }
 
+    /**
+     * Checks if the properties file has been updated since the last load.
+     *
+     * @return {@code true} if the file has been updated, {@code false} otherwise.
+     */
     public boolean isUpdated() {
         final long now = System.currentTimeMillis();
         if (now - lastChecked < checkInterval) {
@@ -152,6 +204,9 @@ public class DynamicProperties extends Properties {
         return true;
     }
 
+    /**
+     * Loads properties from the file.
+     */
     public synchronized void load() {
         final Properties prop = new Properties();
         try (final FileInputStream fis = new FileInputStream(propertiesFile)) {
@@ -163,6 +218,9 @@ public class DynamicProperties extends Properties {
         properties = prop;
     }
 
+    /**
+     * Stores the properties to the file.
+     */
     public synchronized void store() {
         FileOutputStream fos = null;
         try {
@@ -182,6 +240,11 @@ public class DynamicProperties extends Properties {
         lastModified = propertiesFile.lastModified();
     }
 
+    /**
+     * Returns the current properties, reloading them if the file has been updated.
+     *
+     * @return The current {@link Properties} instance.
+     */
     protected Properties getProperties() {
         if (isUpdated()) {
             load();
@@ -370,6 +433,12 @@ public class DynamicProperties extends Properties {
         return getProperties().values();
     }
 
+    /**
+     * Sets the check interval for file modifications.
+     *
+     * @param checkInterval
+     *            The new check interval in milliseconds.
+     */
     public void setCheckInterval(final long checkInterval) {
         this.checkInterval = checkInterval;
     }

--- a/src/main/java/org/codelibs/core/misc/LocaleUtil.java
+++ b/src/main/java/org/codelibs/core/misc/LocaleUtil.java
@@ -26,6 +26,12 @@ import java.util.function.Supplier;
 public abstract class LocaleUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private LocaleUtil() {
+    }
+
+    /**
      * Returns a {@link Locale}.
      *
      * @param localeStr
@@ -50,6 +56,11 @@ public abstract class LocaleUtil {
 
     private static Supplier<Locale> defaultLocaleSupplier;
 
+    /**
+     * Returns the default locale.
+     *
+     * @return the default locale
+     */
     public static Locale getDefault() {
         if (defaultLocaleSupplier != null) {
             return defaultLocaleSupplier.get();
@@ -57,6 +68,12 @@ public abstract class LocaleUtil {
         return Locale.ENGLISH;
     }
 
+    /**
+     * Sets the default locale supplier.
+     *
+     * @param localeSupplier
+     *            the supplier for the default locale
+     */
     public static void setDefault(final Supplier<Locale> localeSupplier) {
         defaultLocaleSupplier = localeSupplier;
     }

--- a/src/main/java/org/codelibs/core/naming/InitialContextUtil.java
+++ b/src/main/java/org/codelibs/core/naming/InitialContextUtil.java
@@ -33,6 +33,12 @@ import org.codelibs.core.exception.NamingRuntimeException;
 public abstract class InitialContextUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private InitialContextUtil() {
+    }
+
+    /**
      * Creates and returns an initial context.
      *
      * @return the initial context

--- a/src/main/java/org/codelibs/core/net/JarURLConnectionUtil.java
+++ b/src/main/java/org/codelibs/core/net/JarURLConnectionUtil.java
@@ -31,6 +31,12 @@ import org.codelibs.core.exception.IORuntimeException;
 public abstract class JarURLConnectionUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private JarURLConnectionUtil() {
+    }
+
+    /**
      * A method that wraps the exception handling of {@link JarURLConnection#getJarFile()}.
      *
      * @param conn

--- a/src/main/java/org/codelibs/core/net/MimeTypeUtil.java
+++ b/src/main/java/org/codelibs/core/net/MimeTypeUtil.java
@@ -33,6 +33,12 @@ import org.codelibs.core.io.ResourceUtil;
 public abstract class MimeTypeUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private MimeTypeUtil() {
+    }
+
+    /**
      * Guesses the content type.
      *
      * @param path

--- a/src/main/java/org/codelibs/core/net/URLUtil.java
+++ b/src/main/java/org/codelibs/core/net/URLUtil.java
@@ -40,6 +40,12 @@ import org.codelibs.core.exception.IORuntimeException;
  */
 public abstract class URLUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private URLUtil() {
+    }
+
     /** Map for normalizing protocols */
     protected static final Map<String, String> CANONICAL_PROTOCOLS = newHashMap();
     static {

--- a/src/main/java/org/codelibs/core/net/UuidUtil.java
+++ b/src/main/java/org/codelibs/core/net/UuidUtil.java
@@ -28,6 +28,12 @@ import org.codelibs.core.lang.StringUtil;
  */
 public abstract class UuidUtil {
 
+    /**
+     * Do not instantiate.
+     */
+    private UuidUtil() {
+    }
+
     private static final byte[] DEFAULT_ADDRESS = new byte[] { (byte) 127, (byte) 0, (byte) 0, (byte) 1 };
 
     private static final SecureRandom RANDOM = new SecureRandom();

--- a/src/main/java/org/codelibs/core/nio/ChannelUtil.java
+++ b/src/main/java/org/codelibs/core/nio/ChannelUtil.java
@@ -33,6 +33,12 @@ import org.codelibs.core.exception.IORuntimeException;
 public abstract class ChannelUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private ChannelUtil() {
+    }
+
+    /**
      * Returns a {@link ByteBuffer} that maps the file channel to memory.
      *
      * @param channel

--- a/src/main/java/org/codelibs/core/security/MessageDigestUtil.java
+++ b/src/main/java/org/codelibs/core/security/MessageDigestUtil.java
@@ -33,6 +33,12 @@ import org.codelibs.core.exception.NoSuchAlgorithmRuntimeException;
 public abstract class MessageDigestUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private MessageDigestUtil() {
+    }
+
+    /**
      * Wraps the exception handling of {@link MessageDigest#getInstance(String)}.
      *
      * @param algorithm

--- a/src/main/java/org/codelibs/core/sql/DriverManagerUtil.java
+++ b/src/main/java/org/codelibs/core/sql/DriverManagerUtil.java
@@ -34,6 +34,12 @@ import org.codelibs.core.lang.ClassUtil;
 public abstract class DriverManagerUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private DriverManagerUtil() {
+    }
+
+    /**
      * Registers a JDBC driver.
      *
      * @param driverClassName

--- a/src/main/java/org/codelibs/core/sql/PreparedStatementUtil.java
+++ b/src/main/java/org/codelibs/core/sql/PreparedStatementUtil.java
@@ -31,6 +31,12 @@ import org.codelibs.core.exception.SQLRuntimeException;
 public abstract class PreparedStatementUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private PreparedStatementUtil() {
+    }
+
+    /**
      * Executes the query.
      *
      * @param ps

--- a/src/main/java/org/codelibs/core/sql/ResultSetUtil.java
+++ b/src/main/java/org/codelibs/core/sql/ResultSetUtil.java
@@ -34,6 +34,12 @@ public abstract class ResultSetUtil {
     private static final Logger logger = Logger.getLogger(ResultSetUtil.class);
 
     /**
+     * Do not instantiate.
+     */
+    private ResultSetUtil() {
+    }
+
+    /**
      * Closes the result set.
      * <p>
      * If {@link ResultSet#close()} throws an exception, an error message is logged. The exception is not rethrown.

--- a/src/main/java/org/codelibs/core/sql/StatementUtil.java
+++ b/src/main/java/org/codelibs/core/sql/StatementUtil.java
@@ -36,6 +36,12 @@ public abstract class StatementUtil {
     private static final Logger logger = Logger.getLogger(StatementUtil.class);
 
     /**
+     * Do not instantiate.
+     */
+    private StatementUtil() {
+    }
+
+    /**
      * Executes the SQL.
      *
      * @param statement

--- a/src/main/java/org/codelibs/core/stream/StreamUtil.java
+++ b/src/main/java/org/codelibs/core/stream/StreamUtil.java
@@ -68,10 +68,20 @@ public class StreamUtil {
         return new StreamOf<>(() -> map != null ? map.entrySet().stream() : Collections.<K, V> emptyMap().entrySet().stream());
     }
 
+    /**
+     * A wrapper class for a {@link Stream} that provides utility methods.
+     *
+     * @param <T> the type of elements in the stream
+     */
     public static class StreamOf<T> {
 
         private final Supplier<Stream<T>> supplier;
 
+        /**
+         * Constructs a new {@link StreamOf} instance with the given supplier.
+         *
+         * @param supplier the supplier of the stream
+         */
         public StreamOf(final Supplier<Stream<T>> supplier) {
             this.supplier = supplier;
         }

--- a/src/main/java/org/codelibs/core/text/DecimalFormatSymbolsUtil.java
+++ b/src/main/java/org/codelibs/core/text/DecimalFormatSymbolsUtil.java
@@ -34,6 +34,12 @@ public abstract class DecimalFormatSymbolsUtil {
     private static final Map<Locale, DecimalFormatSymbols> CACHE = newConcurrentHashMap();
 
     /**
+     * Do not instantiate.
+     */
+    private DecimalFormatSymbolsUtil() {
+    }
+
+    /**
      * Returns {@link DecimalFormatSymbols}.
      *
      * @return {@link DecimalFormatSymbols}

--- a/src/main/java/org/codelibs/core/text/DecimalFormatUtil.java
+++ b/src/main/java/org/codelibs/core/text/DecimalFormatUtil.java
@@ -31,6 +31,12 @@ import org.codelibs.core.misc.LocaleUtil;
 public abstract class DecimalFormatUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private DecimalFormatUtil() {
+    }
+
+    /**
      * Normalizes the string representation of a number.
      *
      * @param s

--- a/src/main/java/org/codelibs/core/text/Tokenizer.java
+++ b/src/main/java/org/codelibs/core/text/Tokenizer.java
@@ -100,8 +100,10 @@ public class Tokenizer {
     }
 
     /**
+     * Sets up the character type array.
+     *
      * @param ctype2
-     *            The array of character types.
+     *            The array of character types to set up.
      */
     protected static void setup(final byte[] ctype2) {
         wordChars(ctype2, 'a', 'z');
@@ -124,6 +126,16 @@ public class Tokenizer {
         whitespaceChars(ctype2, 0, ' ');
     }
 
+    /**
+     * Sets a range of characters as word characters.
+     *
+     * @param ctype2
+     *            The array of character types.
+     * @param low
+     *            The lower bound of the character range (inclusive).
+     * @param hi
+     *            The upper bound of the character range (inclusive).
+     */
     protected static void wordChars(final byte[] ctype2, int low, int hi) {
         if (low < 0) {
             low = 0;

--- a/src/main/java/org/codelibs/core/xml/DocumentBuilderFactoryUtil.java
+++ b/src/main/java/org/codelibs/core/xml/DocumentBuilderFactoryUtil.java
@@ -33,6 +33,12 @@ public abstract class DocumentBuilderFactoryUtil {
     private static final Logger logger = Logger.getLogger(DocumentBuilderFactoryUtil.class);
 
     /**
+     * Do not instantiate.
+     */
+    private DocumentBuilderFactoryUtil() {
+    }
+
+    /**
      * Returns a new instance of {@link DocumentBuilderFactory}.
      *
      * @return A new instance of {@link DocumentBuilderFactory}.
@@ -41,6 +47,13 @@ public abstract class DocumentBuilderFactoryUtil {
         return newInstance(false);
     }
 
+    /**
+     * Returns a new instance of {@link DocumentBuilderFactory}.
+     *
+     * @param external
+     *            If {@code true}, external access is allowed.
+     * @return A new instance of {@link DocumentBuilderFactory}.
+     */
     public static DocumentBuilderFactory newInstance(final boolean external) {
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         if (!external) {

--- a/src/main/java/org/codelibs/core/xml/DocumentBuilderUtil.java
+++ b/src/main/java/org/codelibs/core/xml/DocumentBuilderUtil.java
@@ -35,6 +35,12 @@ import org.xml.sax.SAXException;
 public abstract class DocumentBuilderUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private DocumentBuilderUtil() {
+    }
+
+    /**
      * Parses the XML.
      *
      * @param builder

--- a/src/main/java/org/codelibs/core/xml/DomUtil.java
+++ b/src/main/java/org/codelibs/core/xml/DomUtil.java
@@ -40,6 +40,12 @@ import org.w3c.dom.Text;
 public abstract class DomUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private DomUtil() {
+    }
+
+    /**
      * Retrieves the XML content as an {@link InputStream} using the platform's default encoding.
      *
      * @param contents

--- a/src/main/java/org/codelibs/core/xml/SAXParserFactoryUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SAXParserFactoryUtil.java
@@ -40,6 +40,12 @@ import org.xml.sax.SAXNotSupportedException;
 public abstract class SAXParserFactoryUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private SAXParserFactoryUtil() {
+    }
+
+    /**
      * Creates a new instance of {@link SAXParserFactory}.
      *
      * @return A new instance of {@link SAXParserFactory}.

--- a/src/main/java/org/codelibs/core/xml/SAXParserUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SAXParserUtil.java
@@ -37,6 +37,12 @@ import org.xml.sax.helpers.DefaultHandler;
 public abstract class SAXParserUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private SAXParserUtil() {
+    }
+
+    /**
      * Parses the content of the specified {@link InputSource} as XML using the specified {@link DefaultHandler}.
      *
      * @param parser

--- a/src/main/java/org/codelibs/core/xml/SchemaFactoryUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SchemaFactoryUtil.java
@@ -31,6 +31,12 @@ public abstract class SchemaFactoryUtil {
     private static final Logger logger = Logger.getLogger(SchemaFactoryUtil.class);
 
     /**
+     * Do not instantiate.
+     */
+    private SchemaFactoryUtil() {
+    }
+
+    /**
      * Creates a {@link SchemaFactory} for W3C XML Schema.
      *
      * @return a {@link SchemaFactory} for W3C XML Schema
@@ -39,6 +45,13 @@ public abstract class SchemaFactoryUtil {
         return newW3cXmlSchemaFactory(false);
     }
 
+    /**
+     * Creates a {@link SchemaFactory} for W3C XML Schema.
+     *
+     * @param external
+     *            If {@code true}, external access is allowed.
+     * @return a {@link SchemaFactory} for W3C XML Schema
+     */
     public static SchemaFactory newW3cXmlSchemaFactory(final boolean external) {
         final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         if (!external) {
@@ -56,6 +69,13 @@ public abstract class SchemaFactoryUtil {
         return newRelaxNgSchemaFactory(false);
     }
 
+    /**
+     * Creates a {@link SchemaFactory} for RELAX NG.
+     *
+     * @param external
+     *            If {@code true}, external access is allowed.
+     * @return a {@link SchemaFactory} for RELAX NG
+     */
     public static SchemaFactory newRelaxNgSchemaFactory(final boolean external) {
         final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.RELAXNG_NS_URI);
         if (!external) {

--- a/src/main/java/org/codelibs/core/xml/SchemaUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SchemaUtil.java
@@ -35,6 +35,12 @@ import org.xml.sax.SAXException;
 public abstract class SchemaUtil {
 
     /**
+     * Do not instantiate.
+     */
+    private SchemaUtil() {
+    }
+
+    /**
      * Generates a {@link Schema} for W3C XML Schema from a file.
      *
      * @param schema

--- a/src/main/java/org/codelibs/core/zip/ZipFileUtil.java
+++ b/src/main/java/org/codelibs/core/zip/ZipFileUtil.java
@@ -41,6 +41,12 @@ public abstract class ZipFileUtil {
     private static final Logger logger = Logger.getLogger(ZipFileUtil.class);
 
     /**
+     * Do not instantiate.
+     */
+    private ZipFileUtil() {
+    }
+
+    /**
      * Creates and returns a <code>ZipFile</code> for reading the specified Zip file.
      *
      * @param file

--- a/src/main/java/org/codelibs/core/zip/ZipInputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/zip/ZipInputStreamUtil.java
@@ -35,6 +35,12 @@ public abstract class ZipInputStreamUtil {
     private static final Logger logger = Logger.getLogger(ZipInputStreamUtil.class);
 
     /**
+     * Do not instantiate.
+     */
+    private ZipInputStreamUtil() {
+    }
+
+    /**
      * A method that wraps the exception handling of {@link ZipInputStream#getNextEntry()}.
      *
      * @param zis


### PR DESCRIPTION
This pull request introduces enhancements to the `org.codelibs.core` library, focusing on improving code documentation, enforcing non-instantiability for utility classes, and adding constructors for specific classes. The changes aim to make the codebase more robust and easier to understand.

### Documentation Improvements

* Added detailed Javadoc comments for methods and classes, including descriptions for utility methods such as `copyBeanToBean`, `copyBeanToMap`, and others in `BeanUtil`. These comments clarify functionality and parameter requirements. [[1]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R102-R108) [[2]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R160-R166) [[3]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R210-R216) [[4]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R267-R273) [[5]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R319-R327) [[6]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R364-R372) [[7]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R408-R414) [[8]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R448-R456) [[9]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R493-R499) [[10]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R534-R542) [[11]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R569-R575)

* Enhanced class-level documentation for `LruHashSet`, explaining its purpose and behavior when the maximum capacity is reached.

### Enforcing Non-Instantiability for Utility Classes

* Added private constructors to utility classes such as `BeanDescFactory`, `ParameterizedClassDescFactory`, `BeanUtil`, `CopyOptionsUtil`, `ArrayUtil`, `CollectionsUtil`, and various conversion utility classes (e.g., `BigDecimalConversionUtil`, `DateConversionUtil`). This prevents accidental instantiation and ensures adherence to the utility class design pattern. [[1]](diffhunk://#diff-7ebef7143dc490477989a39d219b329b5c5fde86e4f700cc717acbe749223f17R47-R52) [[2]](diffhunk://#diff-bc23794beff95f1284de08398b7414e8880963fe20b34d0055d5df6c26b0a74eR58-R63) [[3]](diffhunk://#diff-e563687d5b938f7b650d1bedf4a9ecb9b0ef4873a075df06a81e65557468a5d6R83-R88) [[4]](diffhunk://#diff-ed044260f5a9ae93fa3a861e798a301bea784b40bca986cc5c132267326bb537R48-R53) [[5]](diffhunk://#diff-78b5bb575020066769caf769c886b50884c98150027665604039dbe38c74f348R37-R42) [[6]](diffhunk://#diff-5a2557717a1eefac952d105d40f38124a548cc59baa0ee34d38bc7e75956c009R61-R66) [[7]](diffhunk://#diff-4b72bbbc2f002854e9d8168c4ea45b0632fdb824d87c82f0b64e607af10f2d2cR30-R35) [[8]](diffhunk://#diff-e76d2657753daa05311b8384ba3b04760771c00c91578a46acfb276cedd5873fR27-R32) [[9]](diffhunk://#diff-f64e2e56709a65a2ffd46ceb86e88ab6d36bf69645c2050959f0541ce743487dR27-R32) [[10]](diffhunk://#diff-6d04a029e2e7e35a0c8d7c05c311fdfe805e097cb507b4078b4f5683028e3c12R25-R30) [[11]](diffhunk://#diff-e6d11441d3f814b2ff3cc74d8f6044c95fe5ffe6480b59bde0a436fa2a686f38R30-R35) [[12]](diffhunk://#diff-7bfd65dce9b0e64ca7a894071a08b84e6feec25166e8b1273a57439e69ec6ba7R31-R36) [[13]](diffhunk://#diff-8e0ccfc09906ed22815696d8243cc39abdba47c47a4bfd132c942bb2452f2f16R107-R112)

### Constructor Additions

* Added constructors for classes such as `BeanMap`, `CopyOptions`, and `ArrayMapIterator` to improve clarity and ensure proper initialization. [[1]](diffhunk://#diff-f69f3d64e8aea25c419e3967d000521d68f97fb3c1cec77fda925dba7efd7f11R31-R36) [[2]](diffhunk://#diff-72b14418da3002de51f3375d5ca4c964fe41e5d4e10fc6e08dff8da363084ffbR47-R52) [[3]](diffhunk://#diff-d5264feec5ccc0b8e815bd1bf062f60dd400db639ee9847df6cbbe3a85eefc16R566-R571)

### New Constants and Charset Definitions

* Introduced new date format constants (`DATE_FORMAT_ISO_8601_BASIC`, `DATE_FORMAT_ISO_8601_EXTEND`, etc.) and a UTF-8 charset constant in `CoreLibConstants`. These additions provide standardized formats and encoding options for usage across the library.