### PR TITLE
Change utility and factory class constructors from private to protected

### DIFF
--- a/src/main/java/org/codelibs/core/beans/factory/BeanDescFactory.java
+++ b/src/main/java/org/codelibs/core/beans/factory/BeanDescFactory.java
@@ -47,7 +47,7 @@ public abstract class BeanDescFactory {
     /**
      * Do not instantiate.
      */
-    private BeanDescFactory() {
+    protected BeanDescFactory() {
     }
 
     /** True if initialized */

--- a/src/main/java/org/codelibs/core/beans/factory/ParameterizedClassDescFactory.java
+++ b/src/main/java/org/codelibs/core/beans/factory/ParameterizedClassDescFactory.java
@@ -58,7 +58,7 @@ public abstract class ParameterizedClassDescFactory {
     /**
      * Do not instantiate.
      */
-    private ParameterizedClassDescFactory() {
+    protected ParameterizedClassDescFactory() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/beans/util/BeanUtil.java
+++ b/src/main/java/org/codelibs/core/beans/util/BeanUtil.java
@@ -83,7 +83,7 @@ public abstract class BeanUtil {
     /**
      * Do not instantiate.
      */
-    private BeanUtil() {
+    protected BeanUtil() {
     }
 
     /** Default options */

--- a/src/main/java/org/codelibs/core/beans/util/CopyOptionsUtil.java
+++ b/src/main/java/org/codelibs/core/beans/util/CopyOptionsUtil.java
@@ -48,7 +48,7 @@ public abstract class CopyOptionsUtil {
     /**
      * Do not instantiate.
      */
-    private CopyOptionsUtil() {
+    protected CopyOptionsUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/collection/ArrayUtil.java
+++ b/src/main/java/org/codelibs/core/collection/ArrayUtil.java
@@ -37,7 +37,7 @@ public abstract class ArrayUtil {
     /**
      * Do not instantiate.
      */
-    private ArrayUtil() {
+    protected ArrayUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/collection/CollectionsUtil.java
+++ b/src/main/java/org/codelibs/core/collection/CollectionsUtil.java
@@ -63,7 +63,7 @@ public abstract class CollectionsUtil {
     /**
      * Do not instantiate.
      */
-    private CollectionsUtil() {
+    protected CollectionsUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/concurrent/CommonPoolUtil.java
+++ b/src/main/java/org/codelibs/core/concurrent/CommonPoolUtil.java
@@ -22,7 +22,7 @@ import org.codelibs.core.log.Logger;
 /**
  * Utility for common pool operations.
  */
-public class CommonPoolUtil {
+public abstract class CommonPoolUtil {
     private static final Logger logger = Logger.getLogger(CommonPoolUtil.class);
 
     protected CommonPoolUtil() {

--- a/src/main/java/org/codelibs/core/concurrent/CommonPoolUtil.java
+++ b/src/main/java/org/codelibs/core/concurrent/CommonPoolUtil.java
@@ -25,7 +25,7 @@ import org.codelibs.core.log.Logger;
 public class CommonPoolUtil {
     private static final Logger logger = Logger.getLogger(CommonPoolUtil.class);
 
-    private CommonPoolUtil() {
+    protected CommonPoolUtil() {
         // nothing
     }
 

--- a/src/main/java/org/codelibs/core/convert/BigDecimalConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BigDecimalConversionUtil.java
@@ -30,7 +30,7 @@ public abstract class BigDecimalConversionUtil {
     /**
      * Do not instantiate.
      */
-    private BigDecimalConversionUtil() {
+    protected BigDecimalConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/BigIntegerConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BigIntegerConversionUtil.java
@@ -27,7 +27,7 @@ public abstract class BigIntegerConversionUtil {
     /**
      * Do not instantiate.
      */
-    private BigIntegerConversionUtil() {
+    protected BigIntegerConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/BinaryConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BinaryConversionUtil.java
@@ -27,7 +27,7 @@ public abstract class BinaryConversionUtil {
     /**
      * Do not instantiate.
      */
-    private BinaryConversionUtil() {
+    protected BinaryConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/BooleanConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BooleanConversionUtil.java
@@ -25,7 +25,7 @@ public abstract class BooleanConversionUtil {
     /**
      * Do not instantiate.
      */
-    private BooleanConversionUtil() {
+    protected BooleanConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/ByteConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/ByteConversionUtil.java
@@ -30,7 +30,7 @@ public abstract class ByteConversionUtil {
     /**
      * Do not instantiate.
      */
-    private ByteConversionUtil() {
+    protected ByteConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/CalendarConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/CalendarConversionUtil.java
@@ -31,7 +31,7 @@ public abstract class CalendarConversionUtil {
     /**
      * Do not instantiate.
      */
-    private CalendarConversionUtil() {
+    protected CalendarConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/DateConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/DateConversionUtil.java
@@ -107,7 +107,7 @@ public abstract class DateConversionUtil {
     /**
      * Do not instantiate.
      */
-    private DateConversionUtil() {
+    protected DateConversionUtil() {
     }
 
     /** Array of styles held by {@link DateFormat}. */

--- a/src/main/java/org/codelibs/core/convert/DoubleConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/DoubleConversionUtil.java
@@ -30,7 +30,7 @@ public abstract class DoubleConversionUtil {
     /**
      * Do not instantiate.
      */
-    private DoubleConversionUtil() {
+    protected DoubleConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/FloatConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/FloatConversionUtil.java
@@ -30,7 +30,7 @@ public abstract class FloatConversionUtil {
     /**
      * Do not instantiate.
      */
-    private FloatConversionUtil() {
+    protected FloatConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/IntegerConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/IntegerConversionUtil.java
@@ -30,7 +30,7 @@ public abstract class IntegerConversionUtil {
     /**
      * Do not instantiate.
      */
-    private IntegerConversionUtil() {
+    protected IntegerConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/LongConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/LongConversionUtil.java
@@ -30,7 +30,7 @@ public abstract class LongConversionUtil {
     /**
      * Do not instantiate.
      */
-    private LongConversionUtil() {
+    protected LongConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/NumberConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/NumberConversionUtil.java
@@ -33,7 +33,7 @@ public abstract class NumberConversionUtil {
     /**
      * Do not instantiate.
      */
-    private NumberConversionUtil() {
+    protected NumberConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/ShortConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/ShortConversionUtil.java
@@ -30,7 +30,7 @@ public abstract class ShortConversionUtil {
     /**
      * Do not instantiate.
      */
-    private ShortConversionUtil() {
+    protected ShortConversionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/convert/StringConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/StringConversionUtil.java
@@ -32,7 +32,7 @@ public abstract class StringConversionUtil {
     /**
      * Do not instantiate.
      */
-    private StringConversionUtil() {
+    protected StringConversionUtil() {
     }
 
     /** WAVE DASH */

--- a/src/main/java/org/codelibs/core/convert/TimeConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/TimeConversionUtil.java
@@ -110,7 +110,7 @@ public abstract class TimeConversionUtil {
     /**
      * Do not instantiate.
      */
-    private TimeConversionUtil() {
+    protected TimeConversionUtil() {
     }
 
     /** Array of styles held by {@link DateFormat} */

--- a/src/main/java/org/codelibs/core/convert/TimestampConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/TimestampConversionUtil.java
@@ -86,7 +86,7 @@ public abstract class TimestampConversionUtil {
     /**
      * Do not instantiate.
      */
-    private TimestampConversionUtil() {
+    protected TimestampConversionUtil() {
     }
 
     /** Array of styles held by {@link DateFormat} */

--- a/src/main/java/org/codelibs/core/io/ClassTraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/ClassTraversalUtil.java
@@ -39,7 +39,7 @@ public abstract class ClassTraversalUtil {
     /**
      * Do not instantiate.
      */
-    private ClassTraversalUtil() {
+    protected ClassTraversalUtil() {
     }
 
     /** The file extension for class files. */

--- a/src/main/java/org/codelibs/core/io/CloseableUtil.java
+++ b/src/main/java/org/codelibs/core/io/CloseableUtil.java
@@ -32,7 +32,7 @@ public abstract class CloseableUtil {
     /**
      * Do not instantiate.
      */
-    private CloseableUtil() {
+    protected CloseableUtil() {
     }
 
     private static final Logger logger = Logger.getLogger(CloseableUtil.class);

--- a/src/main/java/org/codelibs/core/io/CopyUtil.java
+++ b/src/main/java/org/codelibs/core/io/CopyUtil.java
@@ -119,7 +119,7 @@ public abstract class CopyUtil {
     /**
      * Do not instantiate.
      */
-    private CopyUtil() {
+    protected CopyUtil() {
     }
 
     /** Buffer size used for copying. */

--- a/src/main/java/org/codelibs/core/io/FileUtil.java
+++ b/src/main/java/org/codelibs/core/io/FileUtil.java
@@ -46,7 +46,7 @@ public abstract class FileUtil {
     /**
      * Do not instantiate.
      */
-    private FileUtil() {
+    protected FileUtil() {
     }
 
     /** The encoding name for UTF-8. */

--- a/src/main/java/org/codelibs/core/io/InputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/io/InputStreamUtil.java
@@ -35,7 +35,7 @@ public abstract class InputStreamUtil {
     /**
      * Do not instantiate.
      */
-    private InputStreamUtil() {
+    protected InputStreamUtil() {
     }
 
     /** Default buffer size. */

--- a/src/main/java/org/codelibs/core/io/OutputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/io/OutputStreamUtil.java
@@ -34,7 +34,7 @@ public abstract class OutputStreamUtil {
     /**
      * Do not instantiate.
      */
-    private OutputStreamUtil() {
+    protected OutputStreamUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/io/PropertiesUtil.java
+++ b/src/main/java/org/codelibs/core/io/PropertiesUtil.java
@@ -41,7 +41,7 @@ public abstract class PropertiesUtil {
     /**
      * Do not instantiate.
      */
-    private PropertiesUtil() {
+    protected PropertiesUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/io/ReaderUtil.java
+++ b/src/main/java/org/codelibs/core/io/ReaderUtil.java
@@ -39,7 +39,7 @@ public abstract class ReaderUtil {
     /**
      * Do not instantiate.
      */
-    private ReaderUtil() {
+    protected ReaderUtil() {
     }
 
     /** Default buffer size */

--- a/src/main/java/org/codelibs/core/io/ResourceBundleUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceBundleUtil.java
@@ -37,7 +37,7 @@ public abstract class ResourceBundleUtil {
     /**
      * Do not instantiate.
      */
-    private ResourceBundleUtil() {
+    protected ResourceBundleUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/io/ResourceTraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceTraversalUtil.java
@@ -42,7 +42,7 @@ public abstract class ResourceTraversalUtil {
     /**
      * Do not instantiate.
      */
-    private ResourceTraversalUtil() {
+    protected ResourceTraversalUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/io/ResourceUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceUtil.java
@@ -39,7 +39,7 @@ public abstract class ResourceUtil {
     /**
      * Do not instantiate.
      */
-    private ResourceUtil() {
+    protected ResourceUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/io/SerializeUtil.java
+++ b/src/main/java/org/codelibs/core/io/SerializeUtil.java
@@ -37,7 +37,7 @@ public abstract class SerializeUtil {
     /**
      * Do not instantiate.
      */
-    private SerializeUtil() {
+    protected SerializeUtil() {
     }
 
     private static final int BYTE_ARRAY_SIZE = 8 * 1024;

--- a/src/main/java/org/codelibs/core/io/TraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/TraversalUtil.java
@@ -69,7 +69,7 @@ public abstract class TraversalUtil {
     /**
      * Do not instantiate.
      */
-    private TraversalUtil() {
+    protected TraversalUtil() {
     }
 
     /** An empty array of {@link Traverser}. */

--- a/src/main/java/org/codelibs/core/io/WriterUtil.java
+++ b/src/main/java/org/codelibs/core/io/WriterUtil.java
@@ -38,7 +38,7 @@ public abstract class WriterUtil {
     /**
      * Do not instantiate.
      */
-    private WriterUtil() {
+    protected WriterUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/jar/JarFileUtil.java
+++ b/src/main/java/org/codelibs/core/jar/JarFileUtil.java
@@ -43,7 +43,7 @@ public abstract class JarFileUtil {
     /**
      * Do not instantiate.
      */
-    private JarFileUtil() {
+    protected JarFileUtil() {
     }
 
     private static final Logger logger = Logger.getLogger(JarFileUtil.class);

--- a/src/main/java/org/codelibs/core/jar/JarInputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/jar/JarInputStreamUtil.java
@@ -34,7 +34,7 @@ public abstract class JarInputStreamUtil {
     /**
      * Do not instantiate.
      */
-    private JarInputStreamUtil() {
+    protected JarInputStreamUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/AnnotationUtil.java
+++ b/src/main/java/org/codelibs/core/lang/AnnotationUtil.java
@@ -35,7 +35,7 @@ public abstract class AnnotationUtil {
     /**
      * Do not instantiate.
      */
-    private AnnotationUtil() {
+    protected AnnotationUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/ClassLoaderUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ClassLoaderUtil.java
@@ -40,7 +40,7 @@ public abstract class ClassLoaderUtil {
     /**
      * Do not instantiate.
      */
-    private ClassLoaderUtil() {
+    protected ClassLoaderUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/ClassUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ClassUtil.java
@@ -42,7 +42,7 @@ public abstract class ClassUtil {
     /**
      * Do not instantiate.
      */
-    private ClassUtil() {
+    protected ClassUtil() {
     }
 
     /** Map from wrapper types to primitive types */

--- a/src/main/java/org/codelibs/core/lang/ConstructorUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ConstructorUtil.java
@@ -35,7 +35,7 @@ public abstract class ConstructorUtil {
     /**
      * Do not instantiate.
      */
-    private ConstructorUtil() {
+    protected ConstructorUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/FieldUtil.java
+++ b/src/main/java/org/codelibs/core/lang/FieldUtil.java
@@ -35,7 +35,7 @@ public abstract class FieldUtil {
     /**
      * Do not instantiate.
      */
-    private FieldUtil() {
+    protected FieldUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/GenericsUtil.java
+++ b/src/main/java/org/codelibs/core/lang/GenericsUtil.java
@@ -42,7 +42,7 @@ public abstract class GenericsUtil {
     /**
      * Do not instantiate.
      */
-    private GenericsUtil() {
+    protected GenericsUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/MethodUtil.java
+++ b/src/main/java/org/codelibs/core/lang/MethodUtil.java
@@ -36,7 +36,7 @@ public abstract class MethodUtil {
     /**
      * Do not instantiate.
      */
-    private MethodUtil() {
+    protected MethodUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/ModifierUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ModifierUtil.java
@@ -31,7 +31,7 @@ public abstract class ModifierUtil {
     /**
      * Do not instantiate.
      */
-    private ModifierUtil() {
+    protected ModifierUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/ObjectUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ObjectUtil.java
@@ -25,7 +25,7 @@ public abstract class ObjectUtil {
     /**
      * Do not instantiate.
      */
-    private ObjectUtil() {
+    protected ObjectUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/StringUtil.java
+++ b/src/main/java/org/codelibs/core/lang/StringUtil.java
@@ -32,7 +32,7 @@ public abstract class StringUtil {
     /**
      * Do not instantiate.
      */
-    private StringUtil() {
+    protected StringUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/SystemUtil.java
+++ b/src/main/java/org/codelibs/core/lang/SystemUtil.java
@@ -27,7 +27,7 @@ public abstract class SystemUtil {
     /**
      * Do not instantiate.
      */
-    private SystemUtil() {
+    protected SystemUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/lang/ThreadUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ThreadUtil.java
@@ -31,7 +31,7 @@ public abstract class ThreadUtil {
     /**
      * Do not instantiate.
      */
-    private ThreadUtil() {
+    protected ThreadUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/message/MessageFormatter.java
+++ b/src/main/java/org/codelibs/core/message/MessageFormatter.java
@@ -34,7 +34,7 @@ public abstract class MessageFormatter {
     /**
      * Do not instantiate.
      */
-    private MessageFormatter() {
+    protected MessageFormatter() {
     }
 
     /** Length of the numeric part of the message code */

--- a/src/main/java/org/codelibs/core/misc/AssertionUtil.java
+++ b/src/main/java/org/codelibs/core/misc/AssertionUtil.java
@@ -38,7 +38,7 @@ public abstract class AssertionUtil {
     /**
      * Do not instantiate.
      */
-    private AssertionUtil() {
+    protected AssertionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/misc/Base64Util.java
+++ b/src/main/java/org/codelibs/core/misc/Base64Util.java
@@ -28,7 +28,7 @@ public abstract class Base64Util {
     /**
      * Do not instantiate.
      */
-    private Base64Util() {
+    protected Base64Util() {
     }
 
     private static final char[] ENCODE_TABLE = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',

--- a/src/main/java/org/codelibs/core/misc/DisposableUtil.java
+++ b/src/main/java/org/codelibs/core/misc/DisposableUtil.java
@@ -35,7 +35,7 @@ public abstract class DisposableUtil {
     /**
      * Do not instantiate.
      */
-    private DisposableUtil() {
+    protected DisposableUtil() {
     }
 
     /** Registered {@link Disposable} */

--- a/src/main/java/org/codelibs/core/misc/LocaleUtil.java
+++ b/src/main/java/org/codelibs/core/misc/LocaleUtil.java
@@ -28,7 +28,7 @@ public abstract class LocaleUtil {
     /**
      * Do not instantiate.
      */
-    private LocaleUtil() {
+    protected LocaleUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/naming/InitialContextUtil.java
+++ b/src/main/java/org/codelibs/core/naming/InitialContextUtil.java
@@ -35,7 +35,7 @@ public abstract class InitialContextUtil {
     /**
      * Do not instantiate.
      */
-    private InitialContextUtil() {
+    protected InitialContextUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/net/JarURLConnectionUtil.java
+++ b/src/main/java/org/codelibs/core/net/JarURLConnectionUtil.java
@@ -33,7 +33,7 @@ public abstract class JarURLConnectionUtil {
     /**
      * Do not instantiate.
      */
-    private JarURLConnectionUtil() {
+    protected JarURLConnectionUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/net/MimeTypeUtil.java
+++ b/src/main/java/org/codelibs/core/net/MimeTypeUtil.java
@@ -35,7 +35,7 @@ public abstract class MimeTypeUtil {
     /**
      * Do not instantiate.
      */
-    private MimeTypeUtil() {
+    protected MimeTypeUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/net/URLUtil.java
+++ b/src/main/java/org/codelibs/core/net/URLUtil.java
@@ -43,7 +43,7 @@ public abstract class URLUtil {
     /**
      * Do not instantiate.
      */
-    private URLUtil() {
+    protected URLUtil() {
     }
 
     /** Map for normalizing protocols */

--- a/src/main/java/org/codelibs/core/net/UuidUtil.java
+++ b/src/main/java/org/codelibs/core/net/UuidUtil.java
@@ -31,7 +31,7 @@ public abstract class UuidUtil {
     /**
      * Do not instantiate.
      */
-    private UuidUtil() {
+    protected UuidUtil() {
     }
 
     private static final byte[] DEFAULT_ADDRESS = new byte[] { (byte) 127, (byte) 0, (byte) 0, (byte) 1 };

--- a/src/main/java/org/codelibs/core/nio/ChannelUtil.java
+++ b/src/main/java/org/codelibs/core/nio/ChannelUtil.java
@@ -35,7 +35,7 @@ public abstract class ChannelUtil {
     /**
      * Do not instantiate.
      */
-    private ChannelUtil() {
+    protected ChannelUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/security/MessageDigestUtil.java
+++ b/src/main/java/org/codelibs/core/security/MessageDigestUtil.java
@@ -35,7 +35,7 @@ public abstract class MessageDigestUtil {
     /**
      * Do not instantiate.
      */
-    private MessageDigestUtil() {
+    protected MessageDigestUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/sql/DriverManagerUtil.java
+++ b/src/main/java/org/codelibs/core/sql/DriverManagerUtil.java
@@ -36,7 +36,7 @@ public abstract class DriverManagerUtil {
     /**
      * Do not instantiate.
      */
-    private DriverManagerUtil() {
+    protected DriverManagerUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/sql/PreparedStatementUtil.java
+++ b/src/main/java/org/codelibs/core/sql/PreparedStatementUtil.java
@@ -33,7 +33,7 @@ public abstract class PreparedStatementUtil {
     /**
      * Do not instantiate.
      */
-    private PreparedStatementUtil() {
+    protected PreparedStatementUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/sql/ResultSetUtil.java
+++ b/src/main/java/org/codelibs/core/sql/ResultSetUtil.java
@@ -36,7 +36,7 @@ public abstract class ResultSetUtil {
     /**
      * Do not instantiate.
      */
-    private ResultSetUtil() {
+    protected ResultSetUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/sql/StatementUtil.java
+++ b/src/main/java/org/codelibs/core/sql/StatementUtil.java
@@ -38,7 +38,7 @@ public abstract class StatementUtil {
     /**
      * Do not instantiate.
      */
-    private StatementUtil() {
+    protected StatementUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/stream/StreamUtil.java
+++ b/src/main/java/org/codelibs/core/stream/StreamUtil.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 /**
  * Utility class for {@link Stream}.
  */
-public class StreamUtil {
+public abstract class StreamUtil {
     protected StreamUtil() {
         // nothing
     }

--- a/src/main/java/org/codelibs/core/stream/StreamUtil.java
+++ b/src/main/java/org/codelibs/core/stream/StreamUtil.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * Utility class for {@link Stream}.
  */
 public class StreamUtil {
-    private StreamUtil() {
+    protected StreamUtil() {
         // nothing
     }
 

--- a/src/main/java/org/codelibs/core/text/DecimalFormatSymbolsUtil.java
+++ b/src/main/java/org/codelibs/core/text/DecimalFormatSymbolsUtil.java
@@ -36,7 +36,7 @@ public abstract class DecimalFormatSymbolsUtil {
     /**
      * Do not instantiate.
      */
-    private DecimalFormatSymbolsUtil() {
+    protected DecimalFormatSymbolsUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/text/DecimalFormatUtil.java
+++ b/src/main/java/org/codelibs/core/text/DecimalFormatUtil.java
@@ -33,7 +33,7 @@ public abstract class DecimalFormatUtil {
     /**
      * Do not instantiate.
      */
-    private DecimalFormatUtil() {
+    protected DecimalFormatUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/xml/DocumentBuilderFactoryUtil.java
+++ b/src/main/java/org/codelibs/core/xml/DocumentBuilderFactoryUtil.java
@@ -35,7 +35,7 @@ public abstract class DocumentBuilderFactoryUtil {
     /**
      * Do not instantiate.
      */
-    private DocumentBuilderFactoryUtil() {
+    protected DocumentBuilderFactoryUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/xml/DocumentBuilderUtil.java
+++ b/src/main/java/org/codelibs/core/xml/DocumentBuilderUtil.java
@@ -37,7 +37,7 @@ public abstract class DocumentBuilderUtil {
     /**
      * Do not instantiate.
      */
-    private DocumentBuilderUtil() {
+    protected DocumentBuilderUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/xml/DomUtil.java
+++ b/src/main/java/org/codelibs/core/xml/DomUtil.java
@@ -42,7 +42,7 @@ public abstract class DomUtil {
     /**
      * Do not instantiate.
      */
-    private DomUtil() {
+    protected DomUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/xml/SAXParserFactoryUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SAXParserFactoryUtil.java
@@ -38,7 +38,7 @@ public abstract class SAXParserFactoryUtil {
     /**
      * Do not instantiate.
      */
-    private SAXParserFactoryUtil() {
+    protected SAXParserFactoryUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/xml/SAXParserUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SAXParserUtil.java
@@ -39,7 +39,7 @@ public abstract class SAXParserUtil {
     /**
      * Do not instantiate.
      */
-    private SAXParserUtil() {
+    protected SAXParserUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/xml/SchemaFactoryUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SchemaFactoryUtil.java
@@ -32,7 +32,7 @@ public abstract class SchemaFactoryUtil {
     /**
      * Do not instantiate.
      */
-    private SchemaFactoryUtil() {
+    protected SchemaFactoryUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/xml/SchemaUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SchemaUtil.java
@@ -37,7 +37,7 @@ public abstract class SchemaUtil {
     /**
      * Do not instantiate.
      */
-    private SchemaUtil() {
+    protected SchemaUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/zip/ZipFileUtil.java
+++ b/src/main/java/org/codelibs/core/zip/ZipFileUtil.java
@@ -43,7 +43,7 @@ public abstract class ZipFileUtil {
     /**
      * Do not instantiate.
      */
-    private ZipFileUtil() {
+    protected ZipFileUtil() {
     }
 
     /**

--- a/src/main/java/org/codelibs/core/zip/ZipInputStreamUtil.java
+++ b/src/main/java/org/codelibs/core/zip/ZipInputStreamUtil.java
@@ -37,7 +37,7 @@ public abstract class ZipInputStreamUtil {
     /**
      * Do not instantiate.
      */
-    private ZipInputStreamUtil() {
+    protected ZipInputStreamUtil() {
     }
 
     /**


### PR DESCRIPTION
This pull request updates the visibility of no-argument constructors in various abstract and utility classes from private to protected. Since these classes are not intended to be instantiated directly, the change maintains that guarantee while allowing subclassing in client code or for testing purposes.
