### PR TITLE
chore(build): bump Maven plugins and move GPG signing to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.0</version>
+				<version>3.15.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<release>21</release>
@@ -50,7 +50,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.12.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
@@ -59,7 +59,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.4.2</version>
+				<version>3.5.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -70,12 +70,12 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.5</version>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -116,7 +116,7 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.26.0</version>
+				<version>2.29.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -129,23 +129,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.10.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>
@@ -153,6 +139,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -163,7 +175,7 @@
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
-			<version>1.3.5</version>
+			<version>1.3.6</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
## Summary
Routine maintenance PR to bump Maven build plugin versions and the `commons-logging` dependency, and to move GPG signing into a dedicated `release` profile so regular builds don't require a signing key.

## Changes Made
- Bumped Maven plugin versions:
  - `maven-compiler-plugin` 3.14.0 -> 3.15.0
  - `maven-javadoc-plugin` 3.11.2 -> 3.12.0
  - `maven-jar-plugin` 3.4.2 -> 3.5.0
  - `maven-surefire-plugin` 3.5.3 -> 3.5.5
  - `jacoco-maven-plugin` 0.8.13 -> 0.8.14
  - `formatter-maven-plugin` 2.26.0 -> 2.29.0
  - `central-publishing-maven-plugin` 0.7.0 -> 0.10.0
- Bumped `commons-logging` 1.3.5 -> 1.3.6
- Moved `maven-gpg-plugin` out of the default build and into a new `release` profile:
  - Bumped version 3.2.7 -> 3.2.8
  - Enabled `<bestPractices>true</bestPractices>` as recommended by the plugin
  - Regular `mvn verify` no longer requires a GPG key; releases use `-Prelease`

## Testing
- `mvn test` (local) — unit tests pass against the upgraded plugins
- CI will exercise the full build on the PR

## Breaking Changes
- Release workflows must now pass `-Prelease` to activate GPG signing. Any release automation that relied on GPG running unconditionally during `verify` needs to be updated.

## Additional Notes
- No source code changes; this is build configuration only.
- Please confirm the release pipeline invokes Maven with `-Prelease` before merging if we intend to cut a release off this branch.