### PR TITLE
docs(util): add Javadoc to protected utility constructors

### DIFF
--- a/src/main/java/org/codelibs/core/concurrent/CommonPoolUtil.java
+++ b/src/main/java/org/codelibs/core/concurrent/CommonPoolUtil.java
@@ -25,6 +25,9 @@ import org.codelibs.core.log.Logger;
 public abstract class CommonPoolUtil {
     private static final Logger logger = Logger.getLogger(CommonPoolUtil.class);
 
+    /**
+     * Do not instantiate.
+     */
     protected CommonPoolUtil() {
         // nothing
     }

--- a/src/main/java/org/codelibs/core/stream/StreamUtil.java
+++ b/src/main/java/org/codelibs/core/stream/StreamUtil.java
@@ -27,6 +27,9 @@ import java.util.stream.Stream;
  * Utility class for {@link Stream}.
  */
 public abstract class StreamUtil {
+    /**
+     * Do not instantiate.
+     */
     protected StreamUtil() {
         // nothing
     }


### PR DESCRIPTION
## Summary
Adds Javadoc to the protected constructors of two utility classes so the generated API docs no longer leave them undocumented.

## Changes Made
- `CommonPoolUtil`: documented the `protected` constructor with a brief `Do not instantiate.` note.
- `StreamUtil`: documented the `protected` constructor with the same note.

Both follow the existing utility-class convention (abstract class + protected constructor that is never meant to be called).

## Testing
- Docs-only change with no behavioral impact. Existing `mvn test` suite still applies and was unaffected.

## Breaking Changes
- None.

## Additional Notes
- Purely a documentation improvement; no runtime code paths were touched.