### PR TITLE
build(pom): pin maven-source-plugin to 3.2.1 to avoid duplicate sources jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>3.3.1</version>
+						<version>3.2.1</version><!-- https://issues.apache.org/jira/browse/MSOURCES-143 -->
 						<executions>
 							<execution>
 								<id>attach-sources</id>


### PR DESCRIPTION
## Summary
The Jenkins deploy job started failing with `We have duplicated artifacts attached` after #20/#21 added an `attach-sources` execution (maven-source-plugin 3.3.1) to the `release` profile. The Jenkins job also invokes `source:jar` on the command line, so the sources jar gets attached twice in the same build. Since 3.3.0, maven-source-plugin fails on duplicate attachment instead of silently overwriting ([MSOURCES-143](https://issues.apache.org/jira/browse/MSOURCES-143)).

## Changes Made
- Pin `maven-source-plugin` to 3.2.1 in the `release` profile, with a comment pointing to MSOURCES-143
- This matches the workaround already in place in `fess-parent`

## Testing
- Reproduced the Jenkins failure locally with `mvn clean source:jar package -Prelease` on master (fails with the same error)
- With this change, the same command succeeds and `corelib-0.7.2-SNAPSHOT-sources.jar` is built and attached correctly

## Additional Notes
- Alternative fixes would be removing the `attach-sources` execution from the POM or dropping `source:jar` from the Jenkins job goals; pinning 3.2.1 keeps the POM self-contained for releases and is consistent with other CodeLibs repositories.