### PR TITLE
Java 21 review: correctness/security fixes plus java.time, record, and secure-cipher additions

### DIFF
--- a/src/main/java/org/codelibs/core/CoreLibConstants.java
+++ b/src/main/java/org/codelibs/core/CoreLibConstants.java
@@ -16,6 +16,7 @@
 package org.codelibs.core;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Constants class.
@@ -33,7 +34,7 @@ public class CoreLibConstants {
     /**
      * UTF-8 Charset.
      */
-    public static final Charset CHARSET_UTF_8 = Charset.forName(UTF_8);
+    public static final Charset CHARSET_UTF_8 = StandardCharsets.UTF_8;
 
     /**
      * ISO 8601 basic format: yyyyMMdd'T'HHmmss.SSSZ

--- a/src/main/java/org/codelibs/core/beans/factory/BeanDescFactory.java
+++ b/src/main/java/org/codelibs/core/beans/factory/BeanDescFactory.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import org.codelibs.core.beans.BeanDesc;
 import org.codelibs.core.beans.impl.BeanDescImpl;
+import org.codelibs.core.misc.Disposable;
 import org.codelibs.core.misc.DisposableUtil;
 
 /**
@@ -56,6 +57,9 @@ public abstract class BeanDescFactory {
     /** Cache of {@link BeanDesc} */
     private static final ConcurrentMap<Class<?>, BeanDesc> beanDescCache = newConcurrentHashMap(1024);
 
+    /** Disposable that clears the cache; a single stable instance so it can be deregistered. */
+    private static final Disposable DISPOSABLE = BeanDescFactory::clear;
+
     static {
         initialize();
     }
@@ -86,7 +90,7 @@ public abstract class BeanDescFactory {
     public static void initialize() {
         synchronized (BeanDescFactory.class) {
             if (!initialized) {
-                DisposableUtil.add(BeanDescFactory::clear);
+                DisposableUtil.add(DISPOSABLE);
                 initialized = true;
             }
         }
@@ -97,6 +101,7 @@ public abstract class BeanDescFactory {
      */
     public static void clear() {
         beanDescCache.clear();
+        DisposableUtil.remove(DISPOSABLE);
         initialized = false;
     }
 

--- a/src/main/java/org/codelibs/core/beans/impl/BeanDescImpl.java
+++ b/src/main/java/org/codelibs/core/beans/impl/BeanDescImpl.java
@@ -286,7 +286,7 @@ public class BeanDescImpl implements BeanDesc {
         if (methodDescs == null) {
             throw new MethodNotFoundRuntimeException(beanClass, methodName, null);
         }
-        return methodDescs;
+        return methodDescs.clone();
     }
 
     @Override
@@ -404,17 +404,32 @@ public class BeanDescImpl implements BeanDesc {
         if (paramTypes.length != args.length) {
             return false;
         }
-        for (int i = 0; i < args.length; ++i) {
-            if (args[i] == null) {
+        // When number adjustment is enabled, evaluate the match against a copy of the arguments.
+        // This prevents a partially-converted, non-matching candidate from polluting the evaluation
+        // of later candidates or leaving the caller's array modified, and lets a failed conversion be
+        // treated as a non-match instead of being propagated. The successful conversions are copied
+        // back to the caller's array only once a candidate has fully matched.
+        final Object[] work = adjustNumber ? args.clone() : args;
+        for (int i = 0; i < work.length; ++i) {
+            if (work[i] == null) {
                 continue;
             }
-            if (ClassUtil.isAssignableFrom(paramTypes[i], args[i].getClass())) {
+            if (ClassUtil.isAssignableFrom(paramTypes[i], work[i].getClass())) {
                 continue;
             }
-            if (adjustNumber && adjustNumber(paramTypes, args, i)) {
-                continue;
+            if (adjustNumber) {
+                try {
+                    if (adjustNumber(paramTypes, work, i)) {
+                        continue;
+                    }
+                } catch (final RuntimeException e) {
+                    return false;
+                }
             }
             return false;
+        }
+        if (adjustNumber) {
+            System.arraycopy(work, 0, args, 0, args.length);
         }
         return true;
     }

--- a/src/main/java/org/codelibs/core/beans/impl/BeanDescImpl.java
+++ b/src/main/java/org/codelibs/core/beans/impl/BeanDescImpl.java
@@ -29,6 +29,7 @@ import static org.codelibs.core.misc.AssertionUtil.assertArgumentNotNull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
@@ -494,6 +495,9 @@ public class BeanDescImpl implements BeanDesc {
      * Prepares {@link PropertyDesc}.
      */
     protected void setupPropertyDescs() {
+        if (beanClass.isRecord()) {
+            setupRecordPropertyDescs();
+        }
         for (final Method m : beanClass.getMethods()) {
             if (m.isBridge() || m.isSynthetic()) {
                 continue;
@@ -524,6 +528,23 @@ public class BeanDescImpl implements BeanDesc {
             propertyDescCache.remove(name);
         }
         invalidPropertyNames.clear();
+    }
+
+    /**
+     * Prepares read-only {@link PropertyDesc}s for the components of a {@link Record}.
+     * <p>
+     * Each record component is registered as a read-only property whose read method is the component's
+     * accessor (the prefix-less {@code name()} form). Records are immutable, so no write method is set.
+     * </p>
+     */
+    protected void setupRecordPropertyDescs() {
+        for (final RecordComponent component : beanClass.getRecordComponents()) {
+            final Method accessor = component.getAccessor();
+            if (accessor == null) {
+                continue;
+            }
+            setupReadMethod(accessor, component.getName());
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/core/beans/impl/ConstructorDescImpl.java
+++ b/src/main/java/org/codelibs/core/beans/impl/ConstructorDescImpl.java
@@ -84,7 +84,7 @@ public class ConstructorDescImpl implements ConstructorDesc {
 
     @Override
     public Class<?>[] getParameterTypes() {
-        return parameterTypes;
+        return parameterTypes.clone();
     }
 
     @Override
@@ -96,12 +96,12 @@ public class ConstructorDescImpl implements ConstructorDesc {
     public boolean isParameterized(final int index) {
         assertArgumentArrayIndex("index", index, parameterTypes.length);
 
-        return parameterizedClassDescs[index].isParameterizedClass();
+        return parameterizedClassDescs[index] != null && parameterizedClassDescs[index].isParameterizedClass();
     }
 
     @Override
     public ParameterizedClassDesc[] getParameterizedClassDescs() {
-        return parameterizedClassDescs;
+        return parameterizedClassDescs.clone();
     }
 
     @Override

--- a/src/main/java/org/codelibs/core/beans/impl/MethodDescImpl.java
+++ b/src/main/java/org/codelibs/core/beans/impl/MethodDescImpl.java
@@ -98,7 +98,7 @@ public class MethodDescImpl implements MethodDesc {
 
     @Override
     public Class<?>[] getParameterTypes() {
-        return parameterTypes;
+        return parameterTypes.clone();
     }
 
     @SuppressWarnings("unchecked")
@@ -131,17 +131,17 @@ public class MethodDescImpl implements MethodDesc {
     public boolean isParameterized(final int index) {
         assertArgumentArrayIndex("index", index, parameterTypes.length);
 
-        return parameterizedClassDescs[index].isParameterizedClass();
+        return parameterizedClassDescs[index] != null && parameterizedClassDescs[index].isParameterizedClass();
     }
 
     @Override
     public boolean isParameterized() {
-        return parameterizedClassDesc.isParameterizedClass();
+        return parameterizedClassDesc != null && parameterizedClassDesc.isParameterizedClass();
     }
 
     @Override
     public ParameterizedClassDesc[] getParameterizedClassDescs() {
-        return parameterizedClassDescs;
+        return parameterizedClassDescs.clone();
     }
 
     @Override

--- a/src/main/java/org/codelibs/core/beans/impl/ParameterizedClassDescImpl.java
+++ b/src/main/java/org/codelibs/core/beans/impl/ParameterizedClassDescImpl.java
@@ -84,7 +84,7 @@ public class ParameterizedClassDescImpl implements ParameterizedClassDesc {
 
     @Override
     public ParameterizedClassDesc[] getArguments() {
-        return arguments;
+        return arguments == null ? null : arguments.clone();
     }
 
     /**

--- a/src/main/java/org/codelibs/core/beans/impl/PropertyDescImpl.java
+++ b/src/main/java/org/codelibs/core/beans/impl/PropertyDescImpl.java
@@ -154,7 +154,7 @@ public class PropertyDescImpl implements PropertyDesc {
     }
 
     private void setUpParameterizedClassDesc() {
-        final Map<TypeVariable<?>, Type> typeVariables = ((BeanDescImpl) beanDesc).getTypeVariables();
+        final Map<TypeVariable<?>, Type> typeVariables = beanDesc.getTypeVariables();
         if (field != null) {
             parameterizedClassDesc = ParameterizedClassDescFactory.createParameterizedClassDesc(field, typeVariables);
         } else if (readMethod != null) {

--- a/src/main/java/org/codelibs/core/beans/util/CopyOptions.java
+++ b/src/main/java/org/codelibs/core/beans/util/CopyOptions.java
@@ -170,7 +170,7 @@ public class CopyOptions {
      * @return This instance itself
      */
     public CopyOptions prefix(final CharSequence prefix) {
-        assertArgumentNotEmpty("propertyNames", prefix);
+        assertArgumentNotEmpty("prefix", prefix);
 
         this.prefix = prefix.toString();
         return this;

--- a/src/main/java/org/codelibs/core/collection/ArrayIterator.java
+++ b/src/main/java/org/codelibs/core/collection/ArrayIterator.java
@@ -67,6 +67,7 @@ public class ArrayIterator<T> implements Iterator<T> {
      * @param items the array of elements to iterate (must not be {@literal null})
      */
     public ArrayIterator(final T... items) {
+        assertArgumentNotNull("items", items);
         this.items = items;
     }
 

--- a/src/main/java/org/codelibs/core/collection/ArrayMap.java
+++ b/src/main/java/org/codelibs/core/collection/ArrayMap.java
@@ -25,7 +25,6 @@ import java.io.ObjectOutput;
 import java.lang.reflect.Array;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -371,6 +370,9 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
 
                 @Override
                 public boolean contains(final Object o) {
+                    if (!(o instanceof Entry)) {
+                        return false;
+                    }
                     final Entry<K, V> entry = (Entry<K, V>) o;
                     final int index = (entry.hashCode & 0x7FFFFFFF) % mapTable.length;
                     for (Entry<K, V> e = mapTable[index]; e != null; e = e.next) {
@@ -431,11 +433,11 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Map<K, V>, Clon
 
     @Override
     public Object clone() {
-        final ArrayMap<K, V> copy = new ArrayMap<>();
-        copy.threshold = threshold;
-        copy.mapTable = Arrays.copyOf(mapTable, size);
-        copy.listTable = Arrays.copyOf(listTable, size);
-        copy.size = size;
+        final ArrayMap<K, V> copy = new ArrayMap<>(mapTable.length);
+        for (int i = 0; i < size; i++) {
+            final Entry<K, V> entry = listTable[i];
+            copy.put(entry.key, entry.value);
+        }
         return copy;
     }
 

--- a/src/main/java/org/codelibs/core/collection/CaseInsensitiveMap.java
+++ b/src/main/java/org/codelibs/core/collection/CaseInsensitiveMap.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.core.collection;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -80,7 +81,10 @@ public class CaseInsensitiveMap<V> extends ArrayMap<String, V> {
     }
 
     private static String convertKey(final Object key) {
-        return key.toString().toLowerCase();
+        if (key == null) {
+            return null;
+        }
+        return key.toString().toLowerCase(Locale.ROOT);
     }
 
 }

--- a/src/main/java/org/codelibs/core/collection/CaseInsensitiveSet.java
+++ b/src/main/java/org/codelibs/core/collection/CaseInsensitiveSet.java
@@ -15,6 +15,9 @@
  */
 package org.codelibs.core.collection;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.AbstractSet;
 import java.util.Collection;
@@ -94,6 +97,38 @@ public class CaseInsensitiveSet extends AbstractSet<String> implements Set<Strin
     @Override
     public void clear() {
         map.clear();
+    }
+
+    /**
+     * Serializes this set. The backing map is {@code transient} and its values are a
+     * non-serializable sentinel, so only the elements are written.
+     *
+     * @param s the stream to write to
+     * @throws IOException if an I/O error occurs
+     */
+    private void writeObject(final ObjectOutputStream s) throws IOException {
+        s.defaultWriteObject();
+        s.writeInt(map.size());
+        for (final String e : map.keySet()) {
+            s.writeObject(e);
+        }
+    }
+
+    /**
+     * Deserializes this set by rebuilding the backing map from the elements written by
+     * {@link #writeObject(ObjectOutputStream)}.
+     *
+     * @param s the stream to read from
+     * @throws IOException if an I/O error occurs
+     * @throws ClassNotFoundException if the class of a serialized element cannot be found
+     */
+    private void readObject(final ObjectInputStream s) throws IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        map = new CaseInsensitiveMap<>();
+        final int size = s.readInt();
+        for (int i = 0; i < size; i++) {
+            map.put((String) s.readObject(), PRESENT);
+        }
     }
 
 }

--- a/src/main/java/org/codelibs/core/collection/IteratorEnumeration.java
+++ b/src/main/java/org/codelibs/core/collection/IteratorEnumeration.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
  */
 public class IteratorEnumeration<T> implements Enumeration<T> {
 
-    /** 反復子 */
+    /** The iterator */
     protected final Iterator<T> iterator;
 
     /**

--- a/src/main/java/org/codelibs/core/collection/LruHashSet.java
+++ b/src/main/java/org/codelibs/core/collection/LruHashSet.java
@@ -15,6 +15,10 @@
  */
 package org.codelibs.core.collection;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.AbstractSet;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
@@ -29,13 +33,13 @@ import java.util.Set;
  * @author shinsuke
  * @param <E> the type of elements maintained by this set
  */
-public class LruHashSet<E> extends AbstractSet<E> implements Set<E>, java.io.Serializable {
+public class LruHashSet<E> extends AbstractSet<E> implements Set<E>, Serializable {
     private static final long serialVersionUID = 1L;
 
     /**
      * The internal LRU hash map used to store elements.
      */
-    private final LruHashMap<E, Object> map;
+    private transient LruHashMap<E, Object> map;
 
     // Dummy value to associate with an Object in the backing Map
     private static final Object PRESENT = new Object();
@@ -125,6 +129,42 @@ public class LruHashSet<E> extends AbstractSet<E> implements Set<E>, java.io.Ser
     @Override
     public void clear() {
         map.clear();
+    }
+
+    /**
+     * Serializes this set. The backing map is {@code transient} and its values are a
+     * non-serializable sentinel, so only the limit size and the elements are written.
+     *
+     * @param s the stream to write to
+     * @throws IOException if an I/O error occurs
+     */
+    private void writeObject(final ObjectOutputStream s) throws IOException {
+        s.defaultWriteObject();
+        s.writeInt(map.getLimitSize());
+        s.writeInt(map.size());
+        for (final E e : map.keySet()) {
+            s.writeObject(e);
+        }
+    }
+
+    /**
+     * Deserializes this set by rebuilding the backing map from the limit size and the
+     * elements written by {@link #writeObject(ObjectOutputStream)}.
+     *
+     * @param s the stream to read from
+     * @throws IOException if an I/O error occurs
+     * @throws ClassNotFoundException if the class of a serialized element cannot be found
+     */
+    private void readObject(final ObjectInputStream s) throws IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        final int limitSize = s.readInt();
+        map = new LruHashMap<>(limitSize);
+        final int size = s.readInt();
+        for (int i = 0; i < size; i++) {
+            @SuppressWarnings("unchecked")
+            final E e = (E) s.readObject();
+            map.put(e, PRESENT);
+        }
     }
 
 }

--- a/src/main/java/org/codelibs/core/convert/BinaryConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BinaryConversionUtil.java
@@ -17,6 +17,8 @@ package org.codelibs.core.convert;
 
 import static org.codelibs.core.misc.AssertionUtil.assertArgument;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Utility class for conversions related to byte arrays.
  *
@@ -44,7 +46,7 @@ public abstract class BinaryConversionUtil {
             return null;
         } else {
             assertArgument("o", o instanceof String, o.getClass().toString());
-            return ((String) o).getBytes();
+            return ((String) o).getBytes(StandardCharsets.UTF_8);
         }
     }
 

--- a/src/main/java/org/codelibs/core/convert/BooleanConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/BooleanConversionUtil.java
@@ -15,6 +15,8 @@
  */
 package org.codelibs.core.convert;
 
+import java.util.Locale;
+
 /**
  * Utility class for conversions related to {@link Boolean}.
  *
@@ -40,7 +42,7 @@ public abstract class BooleanConversionUtil {
         case null -> null;
         case Boolean b -> b;
         case Number n -> n.intValue() != 0;
-        case String s -> switch (s.toLowerCase()) {
+        case String s -> switch (s.toLowerCase(Locale.ROOT)) {
         case "true" -> Boolean.TRUE;
         case "false", "0" -> Boolean.FALSE;
         default -> Boolean.TRUE;

--- a/src/main/java/org/codelibs/core/convert/TemporalConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/TemporalConversionUtil.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.core.convert;
+
+import static org.codelibs.core.lang.StringUtil.isEmpty;
+import static org.codelibs.core.misc.AssertionUtil.assertArgumentNotNull;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.codelibs.core.exception.ParseRuntimeException;
+
+/**
+ * Utility for converting objects to {@code java.time} types such as {@link LocalDate}, {@link LocalDateTime}, {@link LocalTime},
+ * {@link Instant}, {@link OffsetDateTime}, and {@link ZonedDateTime}.
+ * <p>
+ * This complements {@link DateConversionUtil}, {@link TimeConversionUtil}, and {@link TimestampConversionUtil}, which convert to the legacy
+ * {@link Date}, {@link Calendar}, and {@link java.sql.Timestamp} types.
+ * </p>
+ * <p>
+ * The following source object types are supported:
+ * </p>
+ * <ul>
+ * <li>The target {@code java.time} type itself (returned as-is).</li>
+ * <li>{@link Instant}, treated as an absolute point on the time line.</li>
+ * <li>{@link Date} (including {@link java.sql.Timestamp}, {@link java.sql.Date}, and {@link java.sql.Time}), converted from its millisecond
+ * value. {@link java.sql.Timestamp} additionally preserves nanosecond precision.</li>
+ * <li>{@link Calendar}, converted from its instant.</li>
+ * <li>{@link Number} (for example {@link Long}), interpreted as epoch milliseconds.</li>
+ * <li>{@link String} in ISO-8601 format, parsed with the {@code parse} method of the target type (for example {@link LocalDate#parse}).</li>
+ * </ul>
+ * <p>
+ * A {@literal null} source object is always converted to {@literal null}. Any other unsupported source object is converted from its
+ * {@link Object#toString()} representation, and a {@link ParseRuntimeException} is thrown when it cannot be parsed.
+ * </p>
+ * <p>
+ * Converting from an absolute point on the time line (a {@link Date}, {@link Calendar}, {@link Instant}, or epoch milliseconds) to a
+ * zone-dependent type requires a {@link ZoneId}. The overloads that do not take a {@link ZoneId} use {@link ZoneId#systemDefault()}. The
+ * zone is not used when the source is a {@link String}, because ISO-8601 strings already carry their own zone or offset information (or none
+ * at all).
+ * </p>
+ *
+ * @author shinsuke
+ * @see DateConversionUtil
+ * @see TimeConversionUtil
+ * @see TimestampConversionUtil
+ */
+public abstract class TemporalConversionUtil {
+
+    /**
+     * Do not instantiate.
+     */
+    protected TemporalConversionUtil() {
+    }
+
+    /**
+     * Converts the given object to a {@link LocalDate} using the system default time zone.
+     *
+     * @param src
+     *            The source object to convert.
+     * @return The converted {@link LocalDate}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static LocalDate toLocalDate(final Object src) {
+        return toLocalDate(src, ZoneId.systemDefault());
+    }
+
+    /**
+     * Converts the given object to a {@link LocalDate}.
+     *
+     * @param src
+     *            The source object to convert.
+     * @param zoneId
+     *            The time zone used when the source is an absolute point on the time line. Must not be {@literal null}.
+     * @return The converted {@link LocalDate}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static LocalDate toLocalDate(final Object src, final ZoneId zoneId) {
+        assertArgumentNotNull("zoneId", zoneId);
+        if (src == null) {
+            return null;
+        }
+        if (src instanceof LocalDate) {
+            return (LocalDate) src;
+        }
+        final Instant instant = toEpochInstant(src);
+        if (instant != null) {
+            return instant.atZone(zoneId).toLocalDate();
+        }
+        final String str = src.toString();
+        if (isEmpty(str)) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(str);
+        } catch (final DateTimeParseException e) {
+            throw new ParseRuntimeException(str);
+        }
+    }
+
+    /**
+     * Converts the given object to a {@link LocalDateTime} using the system default time zone.
+     *
+     * @param src
+     *            The source object to convert.
+     * @return The converted {@link LocalDateTime}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static LocalDateTime toLocalDateTime(final Object src) {
+        return toLocalDateTime(src, ZoneId.systemDefault());
+    }
+
+    /**
+     * Converts the given object to a {@link LocalDateTime}.
+     *
+     * @param src
+     *            The source object to convert.
+     * @param zoneId
+     *            The time zone used when the source is an absolute point on the time line. Must not be {@literal null}.
+     * @return The converted {@link LocalDateTime}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static LocalDateTime toLocalDateTime(final Object src, final ZoneId zoneId) {
+        assertArgumentNotNull("zoneId", zoneId);
+        if (src == null) {
+            return null;
+        }
+        if (src instanceof LocalDateTime) {
+            return (LocalDateTime) src;
+        }
+        final Instant instant = toEpochInstant(src);
+        if (instant != null) {
+            return LocalDateTime.ofInstant(instant, zoneId);
+        }
+        final String str = src.toString();
+        if (isEmpty(str)) {
+            return null;
+        }
+        try {
+            return LocalDateTime.parse(str);
+        } catch (final DateTimeParseException e) {
+            throw new ParseRuntimeException(str);
+        }
+    }
+
+    /**
+     * Converts the given object to a {@link LocalTime} using the system default time zone.
+     *
+     * @param src
+     *            The source object to convert.
+     * @return The converted {@link LocalTime}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static LocalTime toLocalTime(final Object src) {
+        return toLocalTime(src, ZoneId.systemDefault());
+    }
+
+    /**
+     * Converts the given object to a {@link LocalTime}.
+     *
+     * @param src
+     *            The source object to convert.
+     * @param zoneId
+     *            The time zone used when the source is an absolute point on the time line. Must not be {@literal null}.
+     * @return The converted {@link LocalTime}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static LocalTime toLocalTime(final Object src, final ZoneId zoneId) {
+        assertArgumentNotNull("zoneId", zoneId);
+        if (src == null) {
+            return null;
+        }
+        if (src instanceof LocalTime) {
+            return (LocalTime) src;
+        }
+        final Instant instant = toEpochInstant(src);
+        if (instant != null) {
+            return instant.atZone(zoneId).toLocalTime();
+        }
+        final String str = src.toString();
+        if (isEmpty(str)) {
+            return null;
+        }
+        try {
+            return LocalTime.parse(str);
+        } catch (final DateTimeParseException e) {
+            throw new ParseRuntimeException(str);
+        }
+    }
+
+    /**
+     * Converts the given object to an {@link Instant}.
+     * <p>
+     * An {@link Instant} is an absolute point on the time line, so no time zone is required.
+     * </p>
+     *
+     * @param src
+     *            The source object to convert.
+     * @return The converted {@link Instant}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static Instant toInstant(final Object src) {
+        if (src == null) {
+            return null;
+        }
+        final Instant instant = toEpochInstant(src);
+        if (instant != null) {
+            return instant;
+        }
+        final String str = src.toString();
+        if (isEmpty(str)) {
+            return null;
+        }
+        try {
+            return Instant.parse(str);
+        } catch (final DateTimeParseException e) {
+            throw new ParseRuntimeException(str);
+        }
+    }
+
+    /**
+     * Converts the given object to an {@link OffsetDateTime} using the system default time zone.
+     *
+     * @param src
+     *            The source object to convert.
+     * @return The converted {@link OffsetDateTime}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static OffsetDateTime toOffsetDateTime(final Object src) {
+        return toOffsetDateTime(src, ZoneId.systemDefault());
+    }
+
+    /**
+     * Converts the given object to an {@link OffsetDateTime}.
+     *
+     * @param src
+     *            The source object to convert.
+     * @param zoneId
+     *            The time zone used when the source is an absolute point on the time line. Must not be {@literal null}.
+     * @return The converted {@link OffsetDateTime}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static OffsetDateTime toOffsetDateTime(final Object src, final ZoneId zoneId) {
+        assertArgumentNotNull("zoneId", zoneId);
+        if (src == null) {
+            return null;
+        }
+        if (src instanceof OffsetDateTime) {
+            return (OffsetDateTime) src;
+        }
+        final Instant instant = toEpochInstant(src);
+        if (instant != null) {
+            return OffsetDateTime.ofInstant(instant, zoneId);
+        }
+        final String str = src.toString();
+        if (isEmpty(str)) {
+            return null;
+        }
+        try {
+            return OffsetDateTime.parse(str);
+        } catch (final DateTimeParseException e) {
+            throw new ParseRuntimeException(str);
+        }
+    }
+
+    /**
+     * Converts the given object to a {@link ZonedDateTime} using the system default time zone.
+     *
+     * @param src
+     *            The source object to convert.
+     * @return The converted {@link ZonedDateTime}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static ZonedDateTime toZonedDateTime(final Object src) {
+        return toZonedDateTime(src, ZoneId.systemDefault());
+    }
+
+    /**
+     * Converts the given object to a {@link ZonedDateTime}.
+     *
+     * @param src
+     *            The source object to convert.
+     * @param zoneId
+     *            The time zone used when the source is an absolute point on the time line. Must not be {@literal null}.
+     * @return The converted {@link ZonedDateTime}, or {@literal null} if the source is {@literal null} or an empty string.
+     */
+    public static ZonedDateTime toZonedDateTime(final Object src, final ZoneId zoneId) {
+        assertArgumentNotNull("zoneId", zoneId);
+        if (src == null) {
+            return null;
+        }
+        if (src instanceof ZonedDateTime) {
+            return (ZonedDateTime) src;
+        }
+        final Instant instant = toEpochInstant(src);
+        if (instant != null) {
+            return ZonedDateTime.ofInstant(instant, zoneId);
+        }
+        final String str = src.toString();
+        if (isEmpty(str)) {
+            return null;
+        }
+        try {
+            return ZonedDateTime.parse(str);
+        } catch (final DateTimeParseException e) {
+            throw new ParseRuntimeException(str);
+        }
+    }
+
+    /**
+     * Returns the {@link Instant} for a source object that represents an absolute point on the time line.
+     * <p>
+     * Handles {@link Instant}, {@link Timestamp} (preserving nanosecond precision), {@link Date} (via its millisecond value, which is safe
+     * for {@link java.sql.Date} and {@link java.sql.Time} whose {@code toInstant} is unsupported), {@link Calendar}, and {@link Number}
+     * (interpreted as epoch milliseconds). Returns {@literal null} for any other type, including {@link String}, so the caller can fall
+     * back to string parsing.
+     * </p>
+     *
+     * @param src
+     *            The source object. Must not be {@literal null}.
+     * @return The corresponding {@link Instant}, or {@literal null} if the source does not represent an absolute point on the time line.
+     */
+    protected static Instant toEpochInstant(final Object src) {
+        if (src instanceof Instant) {
+            return (Instant) src;
+        }
+        if (src instanceof Timestamp) {
+            return ((Timestamp) src).toInstant();
+        }
+        if (src instanceof Date) {
+            return Instant.ofEpochMilli(((Date) src).getTime());
+        }
+        if (src instanceof Calendar) {
+            return ((Calendar) src).toInstant();
+        }
+        if (src instanceof Number) {
+            return Instant.ofEpochMilli(((Number) src).longValue());
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/org/codelibs/core/convert/TimestampConversionUtil.java
+++ b/src/main/java/org/codelibs/core/convert/TimestampConversionUtil.java
@@ -151,6 +151,7 @@ public abstract class TimestampConversionUtil {
      * @return the pattern string for {@link DateFormat#LONG} style
      */
     public static String getLongPattern(final Locale locale) {
+        assertArgumentNotNull("locale", locale);
         return ((SimpleDateFormat) getDateTimeInstance(LONG, LONG, locale)).toPattern();
     }
 
@@ -323,7 +324,7 @@ public abstract class TimestampConversionUtil {
             return null;
         }
         if (isNotEmpty(pattern)) {
-            final SimpleDateFormat format = new SimpleDateFormat(pattern);
+            final SimpleDateFormat format = new SimpleDateFormat(pattern, locale);
             final Date date = toDate(str, format);
             if (date != null) {
                 return toCalendar(date, locale);

--- a/src/main/java/org/codelibs/core/crypto/CachedCipher.java
+++ b/src/main/java/org/codelibs/core/crypto/CachedCipher.java
@@ -15,10 +15,14 @@
  */
 package org.codelibs.core.crypto;
 
+import static org.codelibs.core.misc.AssertionUtil.assertArgumentNotNull;
+
 import java.io.UnsupportedEncodingException;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -26,11 +30,13 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.codelibs.core.CoreLibConstants;
 import org.codelibs.core.exception.BadPaddingRuntimeException;
 import org.codelibs.core.exception.IllegalBlockSizeRuntimeException;
+import org.codelibs.core.exception.InvalidAlgorithmParameterRuntimeException;
 import org.codelibs.core.exception.InvalidKeyRuntimeException;
 import org.codelibs.core.exception.NoSuchAlgorithmRuntimeException;
 import org.codelibs.core.exception.NoSuchPaddingRuntimeException;
@@ -95,6 +101,18 @@ public class CachedCipher {
     private static final String BLOWFISH = "Blowfish";
 
     private static final String AES = "AES";
+
+    /** Transformation used by the authenticated {@link #encryptWithIv}/{@link #decryptWithIv} API. */
+    private static final String AES_GCM_TRANSFORMATION = "AES/GCM/NoPadding";
+
+    /** Standard GCM nonce length in bytes. */
+    private static final int GCM_IV_LENGTH = 12;
+
+    /** GCM authentication tag length in bits. */
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+
+    /** Secure source of randomness for IV generation. */
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     /**
      * The algorithm to use for the cipher.
@@ -333,6 +351,92 @@ public class CachedCipher {
     @Deprecated
     public String decryptoText(final String text) {
         return decryptText(text);
+    }
+
+    /**
+     * Encrypts data using AES in GCM mode (authenticated encryption) with a freshly generated
+     * random IV. The 12-byte IV is prepended to the returned value, followed by the ciphertext
+     * and the GCM authentication tag.
+     * <p>
+     * This is an opt-in, self-contained alternative to the pooled {@code encrypt}/{@code decrypt}
+     * methods (which default to Blowfish in ECB mode and cannot carry an IV). It generates a
+     * unique nonce per call and does not reuse or affect the cipher pool, so it is safe for
+     * confidential data. The instance-level configuration ({@link #setKey(String)},
+     * {@link #setAlgorithm(String)}, {@link #setTransformation(String)}) is not used; the caller
+     * supplies the AES {@link Key} directly.
+     * </p>
+     *
+     * @param data
+     *            the plaintext to encrypt. Must not be {@literal null}.
+     * @param key
+     *            the AES key. Must not be {@literal null}.
+     * @return the 12-byte IV followed by the ciphertext and GCM tag
+     */
+    public byte[] encryptWithIv(final byte[] data, final Key key) {
+        assertArgumentNotNull("data", data);
+        assertArgumentNotNull("key", key);
+
+        final byte[] iv = new byte[GCM_IV_LENGTH];
+        SECURE_RANDOM.nextBytes(iv);
+        try {
+            final Cipher cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            final byte[] encrypted = cipher.doFinal(data);
+            final byte[] result = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, result, 0, iv.length);
+            System.arraycopy(encrypted, 0, result, iv.length, encrypted.length);
+            return result;
+        } catch (final NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmRuntimeException(e);
+        } catch (final NoSuchPaddingException e) {
+            throw new NoSuchPaddingRuntimeException(e);
+        } catch (final InvalidKeyException e) {
+            throw new InvalidKeyRuntimeException(e);
+        } catch (final InvalidAlgorithmParameterException e) {
+            throw new InvalidAlgorithmParameterRuntimeException(e);
+        } catch (final IllegalBlockSizeException e) {
+            throw new IllegalBlockSizeRuntimeException(e);
+        } catch (final BadPaddingException e) {
+            throw new BadPaddingRuntimeException(e);
+        }
+    }
+
+    /**
+     * Decrypts data produced by {@link #encryptWithIv(byte[], Key)}. The 12-byte IV is read from
+     * the front of {@code data} and the remaining bytes are decrypted and authenticated.
+     *
+     * @param data
+     *            the IV followed by the ciphertext and GCM tag. Must not be {@literal null}.
+     * @param key
+     *            the AES key. Must not be {@literal null}.
+     * @return the decrypted plaintext
+     */
+    public byte[] decryptWithIv(final byte[] data, final Key key) {
+        assertArgumentNotNull("data", data);
+        assertArgumentNotNull("key", key);
+        if (data.length <= GCM_IV_LENGTH) {
+            throw new IllegalBlockSizeRuntimeException(new IllegalBlockSizeException("Encrypted data is too short to contain an IV."));
+        }
+
+        final byte[] iv = new byte[GCM_IV_LENGTH];
+        System.arraycopy(data, 0, iv, 0, GCM_IV_LENGTH);
+        try {
+            final Cipher cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            return cipher.doFinal(data, GCM_IV_LENGTH, data.length - GCM_IV_LENGTH);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmRuntimeException(e);
+        } catch (final NoSuchPaddingException e) {
+            throw new NoSuchPaddingRuntimeException(e);
+        } catch (final InvalidKeyException e) {
+            throw new InvalidKeyRuntimeException(e);
+        } catch (final InvalidAlgorithmParameterException e) {
+            throw new InvalidAlgorithmParameterRuntimeException(e);
+        } catch (final IllegalBlockSizeException e) {
+            throw new IllegalBlockSizeRuntimeException(e);
+        } catch (final BadPaddingException e) {
+            throw new BadPaddingRuntimeException(e);
+        }
     }
 
     /**

--- a/src/main/java/org/codelibs/core/crypto/CachedCipher.java
+++ b/src/main/java/org/codelibs/core/crypto/CachedCipher.java
@@ -342,20 +342,21 @@ public class CachedCipher {
      */
     protected Cipher pollEncryptoCipher() {
         Cipher cipher = encryptoQueue.poll();
-        if (cipher == null) {
-            try {
-                final SecretKeySpec sksSpec = new SecretKeySpec(key.getBytes(charsetName), algorithm);
+        try {
+            if (cipher == null) {
                 cipher = Cipher.getInstance(algorithm);
-                cipher.init(Cipher.ENCRYPT_MODE, sksSpec);
-            } catch (final InvalidKeyException e) {
-                throw new InvalidKeyRuntimeException(e);
-            } catch (final NoSuchAlgorithmException e) {
-                throw new NoSuchAlgorithmRuntimeException(e);
-            } catch (final NoSuchPaddingException e) {
-                throw new NoSuchPaddingRuntimeException(e);
-            } catch (final UnsupportedEncodingException e) {
-                throw new UnsupportedEncodingRuntimeException(e);
             }
+            // Always (re-)initialize so a pooled cipher never retains a stale key.
+            final SecretKeySpec sksSpec = new SecretKeySpec(key.getBytes(charsetName), algorithm);
+            cipher.init(Cipher.ENCRYPT_MODE, sksSpec);
+        } catch (final InvalidKeyException e) {
+            throw new InvalidKeyRuntimeException(e);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmRuntimeException(e);
+        } catch (final NoSuchPaddingException e) {
+            throw new NoSuchPaddingRuntimeException(e);
+        } catch (final UnsupportedEncodingException e) {
+            throw new UnsupportedEncodingRuntimeException(e);
         }
         return cipher;
     }
@@ -369,17 +370,18 @@ public class CachedCipher {
      */
     protected Cipher pollEncryptoCipher(final Key key) {
         Cipher cipher = encryptoQueue.poll();
-        if (cipher == null) {
-            try {
+        try {
+            if (cipher == null) {
                 cipher = Cipher.getInstance(transformation);
-                cipher.init(Cipher.ENCRYPT_MODE, key);
-            } catch (final InvalidKeyException e) {
-                throw new InvalidKeyRuntimeException(e);
-            } catch (final NoSuchAlgorithmException e) {
-                throw new NoSuchAlgorithmRuntimeException(e);
-            } catch (final NoSuchPaddingException e) {
-                throw new NoSuchPaddingRuntimeException(e);
             }
+            // Always (re-)initialize with the given key; a pooled cipher may hold a different key.
+            cipher.init(Cipher.ENCRYPT_MODE, key);
+        } catch (final InvalidKeyException e) {
+            throw new InvalidKeyRuntimeException(e);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmRuntimeException(e);
+        } catch (final NoSuchPaddingException e) {
+            throw new NoSuchPaddingRuntimeException(e);
         }
         return cipher;
     }
@@ -401,20 +403,21 @@ public class CachedCipher {
      */
     protected Cipher pollDecryptoCipher() {
         Cipher cipher = decryptoQueue.poll();
-        if (cipher == null) {
-            try {
-                final SecretKeySpec sksSpec = new SecretKeySpec(key.getBytes(charsetName), algorithm);
+        try {
+            if (cipher == null) {
                 cipher = Cipher.getInstance(algorithm);
-                cipher.init(Cipher.DECRYPT_MODE, sksSpec);
-            } catch (final InvalidKeyException e) {
-                throw new InvalidKeyRuntimeException(e);
-            } catch (final NoSuchAlgorithmException e) {
-                throw new NoSuchAlgorithmRuntimeException(e);
-            } catch (final NoSuchPaddingException e) {
-                throw new NoSuchPaddingRuntimeException(e);
-            } catch (final UnsupportedEncodingException e) {
-                throw new UnsupportedEncodingRuntimeException(e);
             }
+            // Always (re-)initialize so a pooled cipher never retains a stale key.
+            final SecretKeySpec sksSpec = new SecretKeySpec(key.getBytes(charsetName), algorithm);
+            cipher.init(Cipher.DECRYPT_MODE, sksSpec);
+        } catch (final InvalidKeyException e) {
+            throw new InvalidKeyRuntimeException(e);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmRuntimeException(e);
+        } catch (final NoSuchPaddingException e) {
+            throw new NoSuchPaddingRuntimeException(e);
+        } catch (final UnsupportedEncodingException e) {
+            throw new UnsupportedEncodingRuntimeException(e);
         }
         return cipher;
     }
@@ -428,17 +431,18 @@ public class CachedCipher {
      */
     protected Cipher pollDecryptoCipher(final Key key) {
         Cipher cipher = decryptoQueue.poll();
-        if (cipher == null) {
-            try {
+        try {
+            if (cipher == null) {
                 cipher = Cipher.getInstance(transformation);
-                cipher.init(Cipher.DECRYPT_MODE, key);
-            } catch (final InvalidKeyException e) {
-                throw new InvalidKeyRuntimeException(e);
-            } catch (final NoSuchAlgorithmException e) {
-                throw new NoSuchAlgorithmRuntimeException(e);
-            } catch (final NoSuchPaddingException e) {
-                throw new NoSuchPaddingRuntimeException(e);
             }
+            // Always (re-)initialize with the given key; a pooled cipher may hold a different key.
+            cipher.init(Cipher.DECRYPT_MODE, key);
+        } catch (final InvalidKeyException e) {
+            throw new InvalidKeyRuntimeException(e);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmRuntimeException(e);
+        } catch (final NoSuchPaddingException e) {
+            throw new NoSuchPaddingRuntimeException(e);
         }
         return cipher;
     }
@@ -451,6 +455,21 @@ public class CachedCipher {
      */
     protected void offerDecryptoCipher(final Cipher cipher) {
         decryptoQueue.offer(cipher);
+    }
+
+    /**
+     * Discards all pooled ciphers so that subsequent operations rebuild them with the
+     * current algorithm/transformation.
+     * <p>
+     * This is required when the algorithm or transformation changes because those values
+     * are fixed on a {@link Cipher} instance at creation time and cannot be changed by
+     * re-initialization. Configuration setters are expected to be called before concurrent
+     * use.
+     * </p>
+     */
+    protected void clearCipherQueues() {
+        encryptoQueue.clear();
+        decryptoQueue.clear();
     }
 
     /**
@@ -470,6 +489,7 @@ public class CachedCipher {
      */
     public void setAlgorithm(final String algorithm) {
         this.algorithm = algorithm;
+        clearCipherQueues();
     }
 
     /**
@@ -489,6 +509,7 @@ public class CachedCipher {
      */
     public void setTransformation(final String transformation) {
         this.transformation = transformation;
+        clearCipherQueues();
     }
 
     /**

--- a/src/main/java/org/codelibs/core/exception/ClUnsupportedOperationException.java
+++ b/src/main/java/org/codelibs/core/exception/ClUnsupportedOperationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/codelibs/core/exception/InvalidAlgorithmParameterRuntimeException.java
+++ b/src/main/java/org/codelibs/core/exception/InvalidAlgorithmParameterRuntimeException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.core.exception;
+
+import static org.codelibs.core.collection.ArrayUtil.asArray;
+
+import java.security.InvalidAlgorithmParameterException;
+
+/**
+ * Exception that wraps {@link InvalidAlgorithmParameterException}.
+ *
+ * @author shinsuke
+ */
+public class InvalidAlgorithmParameterRuntimeException extends ClRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a {@link InvalidAlgorithmParameterRuntimeException}.
+     *
+     * @param cause
+     *            The cause of the exception
+     */
+    public InvalidAlgorithmParameterRuntimeException(final InvalidAlgorithmParameterException cause) {
+        super("ECL0117", asArray(cause), cause);
+    }
+
+}

--- a/src/main/java/org/codelibs/core/io/ClassTraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/ClassTraversalUtil.java
@@ -191,7 +191,11 @@ public abstract class ClassTraversalUtil {
      * @param handler the handler to process classes
      */
     protected static void traverseFileSystem(final File dir, final String packageName, final ClassHandler handler) {
-        for (final File file : dir.listFiles()) {
+        final File[] files = dir.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (final File file : files) {
             final String fileName = file.getName();
             if (file.isDirectory()) {
                 traverseFileSystem(file, ClassUtil.concatName(packageName, fileName), handler);

--- a/src/main/java/org/codelibs/core/io/CloseableUtil.java
+++ b/src/main/java/org/codelibs/core/io/CloseableUtil.java
@@ -20,6 +20,7 @@ import static org.codelibs.core.log.Logger.format;
 import java.io.Closeable;
 import java.io.IOException;
 
+import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.log.Logger;
 
 /**
@@ -81,6 +82,30 @@ public abstract class CloseableUtil {
             closeable.close();
         } catch (final IOException e) {
             // ignore
+        }
+    }
+
+    /**
+     * Closes a {@link Closeable}, propagating any {@link IOException} wrapped in an
+     * {@link IORuntimeException}.
+     * <p>
+     * Unlike {@link #close(Closeable)} and {@link #closeQuietly(Closeable)}, this method does not
+     * suppress the exception. Use it for output streams and writers, where a failure during
+     * {@link Closeable#close()} (which performs the final flush) means the data was not fully
+     * written and must not be silently ignored.
+     * </p>
+     *
+     * @param closeable the closeable object
+     * @throws IORuntimeException if {@link Closeable#close()} throws an {@link IOException}
+     */
+    public static void closeAndRethrow(final Closeable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
         }
     }
 }

--- a/src/main/java/org/codelibs/core/io/FileUtil.java
+++ b/src/main/java/org/codelibs/core/io/FileUtil.java
@@ -104,6 +104,39 @@ public abstract class FileUtil {
     }
 
     /**
+     * Validates that a given path is within the base directory after resolving symbolic links.
+     * <p>
+     * Unlike {@link #isPathSafe(Path, Path)}, which performs only lexical normalization, this
+     * method resolves symbolic links via {@link Path#toRealPath(java.nio.file.LinkOption...)}.
+     * A symbolic link located inside {@code baseDirectory} that points outside of it is therefore
+     * correctly rejected, making this the stronger choice when the file system may contain links.
+     * </p>
+     * <p>
+     * <strong>Note:</strong> {@code toRealPath} requires the paths to exist. If either
+     * {@code pathToCheck} or {@code baseDirectory} does not exist, or an I/O error occurs while
+     * resolving them, this method returns {@code false}. To validate a path that has not been
+     * created yet, resolve the nearest existing ancestor with {@code toRealPath} yourself and
+     * pass the result here.
+     * </p>
+     *
+     * @param pathToCheck the path to validate (must not be {@literal null})
+     * @param baseDirectory the base directory that the path must be within (must not be {@literal null})
+     * @return true if the resolved real path is within the resolved base directory, false otherwise
+     */
+    public static boolean isRealPathSafe(final Path pathToCheck, final Path baseDirectory) {
+        assertArgumentNotNull("pathToCheck", pathToCheck);
+        assertArgumentNotNull("baseDirectory", baseDirectory);
+
+        try {
+            final Path realBase = baseDirectory.toRealPath();
+            final Path realPath = pathToCheck.toRealPath();
+            return realPath.startsWith(realBase);
+        } catch (final IOException e) {
+            return false;
+        }
+    }
+
+    /**
      * Validates that a given file is safe and does not attempt path traversal attacks.
      * <p>
      * This is a convenience method that converts File objects to Path and calls

--- a/src/main/java/org/codelibs/core/io/FileUtil.java
+++ b/src/main/java/org/codelibs/core/io/FileUtil.java
@@ -81,6 +81,14 @@ public abstract class FileUtil {
      *     throw new SecurityException("Path traversal attempt detected");
      * }
      * </pre>
+     * <p>
+     * <strong>Note:</strong> This method performs purely lexical normalization via
+     * {@link Path#normalize()} and does <em>not</em> resolve symbolic links. A symbolic
+     * link located inside {@code baseDirectory} that points outside of it is therefore
+     * still considered safe. If symbolic-link resolution is required, resolve both paths
+     * with {@link Path#toRealPath(java.nio.file.LinkOption...)} before calling this method
+     * (note that {@code toRealPath} requires the paths to exist).
+     * </p>
      *
      * @param pathToCheck the path to validate (must not be {@literal null})
      * @param baseDirectory the base directory that the path must be within (must not be {@literal null})
@@ -190,9 +198,19 @@ public abstract class FileUtil {
                 throw new IORuntimeException(new IOException(
                         "File too large: " + fileSize + " bytes (max: " + maxSize + " bytes). Use streaming APIs for large files."));
             }
+            if (fileSize > Integer.MAX_VALUE) {
+                throw new IORuntimeException(new IOException("File too large: " + fileSize + " bytes (max: " + Integer.MAX_VALUE
+                        + " bytes for a byte array). Use streaming APIs for large files."));
+            }
 
             final ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
-            ChannelUtil.read(channel, buffer);
+            // FileChannel.read may return before the buffer is filled, so keep
+            // reading until the buffer is full or the end of the file is reached.
+            while (buffer.hasRemaining()) {
+                if (ChannelUtil.read(channel, buffer) == -1) {
+                    break;
+                }
+            }
             return buffer.array();
         } finally {
             CloseableUtil.close(is);

--- a/src/main/java/org/codelibs/core/io/ResourceTraversalUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceTraversalUtil.java
@@ -198,7 +198,11 @@ public abstract class ResourceTraversalUtil {
      *            the handler to process resources
      */
     protected static void traverseFileSystem(final File rootDir, final File baseDir, final ResourceHandler handler) {
-        for (final File file : baseDir.listFiles()) {
+        final File[] files = baseDir.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (final File file : files) {
             if (file.isDirectory()) {
                 traverseFileSystem(rootDir, file, handler);
             } else {

--- a/src/main/java/org/codelibs/core/io/ResourceUtil.java
+++ b/src/main/java/org/codelibs/core/io/ResourceUtil.java
@@ -361,7 +361,8 @@ public abstract class ResourceUtil {
         assertArgumentNotNull("url", url);
 
         final String s = url.toExternalForm();
-        return URLUtil.decode(s, "UTF8");
+        // Preserve a literal '+' in the path (URLUtil.decode would turn it into a space).
+        return URLUtil.decode(s.replace("+", "%2B"), "UTF8");
     }
 
     /**
@@ -375,7 +376,8 @@ public abstract class ResourceUtil {
         assertArgumentNotNull("url", url);
 
         final String s = url.getFile();
-        return URLUtil.decode(s, "UTF8");
+        // Preserve a literal '+' in the path (URLUtil.decode would turn it into a space).
+        return URLUtil.decode(s.replace("+", "%2B"), "UTF8");
     }
 
     /**
@@ -389,7 +391,7 @@ public abstract class ResourceUtil {
         assertArgumentNotNull("url", url);
 
         final File file = new File(getFileName(url));
-        if (file != null && file.exists()) {
+        if (file.exists()) {
             return file;
         }
         return null;

--- a/src/main/java/org/codelibs/core/io/SerializeUtil.java
+++ b/src/main/java/org/codelibs/core/io/SerializeUtil.java
@@ -54,6 +54,18 @@ public abstract class SerializeUtil {
 
     private static final int BYTE_ARRAY_SIZE = 8 * 1024;
 
+    /** Maximum object graph depth allowed by the default filter. */
+    private static final long MAX_DEPTH = 100L;
+
+    /** Maximum number of object references allowed by the default filter. */
+    private static final long MAX_REFERENCES = 1_000_000L;
+
+    /** Maximum number of stream bytes allowed by the default filter. */
+    private static final long MAX_STREAM_BYTES = 100L * 1024L * 1024L;
+
+    /** Maximum array length allowed by the default filter. */
+    private static final long MAX_ARRAY_LENGTH = 1_000_000L;
+
     /**
      * Default set of allowed class name patterns for deserialization.
      * This helps prevent deserialization attacks by restricting which classes can be instantiated.
@@ -64,9 +76,22 @@ public abstract class SerializeUtil {
 
     /**
      * Default ObjectInputFilter that only allows safe classes to be deserialized.
+     * <p>
+     * In addition to the class allowlist, this filter enforces resource limits
+     * ({@link #MAX_DEPTH}, {@link #MAX_REFERENCES}, {@link #MAX_STREAM_BYTES},
+     * {@link #MAX_ARRAY_LENGTH}) so that a payload composed solely of allowed
+     * classes cannot exhaust memory or CPU during deserialization.
+     * </p>
      * This filter rejects potentially dangerous classes while allowing common safe types.
      */
     private static final ObjectInputFilter DEFAULT_FILTER = filterInfo -> {
+        // Defense-in-depth: reject payloads that exceed resource limits even when
+        // every class in the payload is otherwise allowed.
+        if (filterInfo.depth() > MAX_DEPTH || filterInfo.references() > MAX_REFERENCES || filterInfo.streamBytes() > MAX_STREAM_BYTES
+                || filterInfo.arrayLength() > MAX_ARRAY_LENGTH) {
+            return ObjectInputFilter.Status.REJECTED;
+        }
+
         final Class<?> serialClass = filterInfo.serialClass();
         if (serialClass == null) {
             return ObjectInputFilter.Status.UNDECIDED;

--- a/src/main/java/org/codelibs/core/jar/JarFileUtil.java
+++ b/src/main/java/org/codelibs/core/jar/JarFileUtil.java
@@ -127,7 +127,8 @@ public abstract class JarFileUtil {
         final String nestedUrlPath = nestedUrl.getPath();
         final int pos = nestedUrlPath.lastIndexOf('!');
         final String jarFilePath = nestedUrlPath.substring(0, pos);
-        final File jarFile = new File(URLUtil.decode(jarFilePath, "UTF8"));
+        // Preserve a literal '+' in the path (URLUtil.decode would turn it into a space).
+        final File jarFile = new File(URLUtil.decode(jarFilePath.replace("+", "%2B"), "UTF8"));
         return FileUtil.getCanonicalPath(jarFile);
     }
 

--- a/src/main/java/org/codelibs/core/lang/ClassUtil.java
+++ b/src/main/java/org/codelibs/core/lang/ClassUtil.java
@@ -21,6 +21,7 @@ import static org.codelibs.core.misc.AssertionUtil.assertArgumentNotNull;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ import org.codelibs.core.exception.ClassNotFoundRuntimeException;
 import org.codelibs.core.exception.EmptyArgumentException;
 import org.codelibs.core.exception.IllegalAccessRuntimeException;
 import org.codelibs.core.exception.InstantiationRuntimeException;
+import org.codelibs.core.exception.InvocationTargetRuntimeException;
 import org.codelibs.core.exception.NoSuchConstructorRuntimeException;
 import org.codelibs.core.exception.NoSuchFieldRuntimeException;
 import org.codelibs.core.exception.NoSuchMethodRuntimeException;
@@ -216,11 +218,15 @@ public abstract class ClassUtil {
         assertArgumentNotNull("clazz", clazz);
 
         try {
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (final InstantiationException e) {
             throw new InstantiationRuntimeException(clazz, e);
         } catch (final IllegalAccessException e) {
             throw new IllegalAccessRuntimeException(clazz, e);
+        } catch (final InvocationTargetException e) {
+            throw new InvocationTargetRuntimeException(clazz, e);
+        } catch (final NoSuchMethodException e) {
+            throw new NoSuchConstructorRuntimeException(clazz, new Class<?>[0], e);
         }
     }
 

--- a/src/main/java/org/codelibs/core/lang/MethodUtil.java
+++ b/src/main/java/org/codelibs/core/lang/MethodUtil.java
@@ -110,6 +110,8 @@ public abstract class MethodUtil {
      * @return <code>abstract</code> if the method is abstract
      */
     public static boolean isAbstract(final Method method) {
+        assertArgumentNotNull("method", method);
+
         return Modifier.isAbstract(method.getModifiers());
     }
 

--- a/src/main/java/org/codelibs/core/lang/StringUtil.java
+++ b/src/main/java/org/codelibs/core/lang/StringUtil.java
@@ -38,7 +38,7 @@ public abstract class StringUtil {
     /**
      * A system line separator.
      */
-    public static final String RETURN_STRING = System.getProperty("line.separator");
+    public static final String RETURN_STRING = System.lineSeparator();
 
     /**
      * An empty string <code>""</code>.
@@ -84,6 +84,9 @@ public abstract class StringUtil {
     public static final String replace(final String text, final String fromText, final String toText) {
         if (text == null || fromText == null || toText == null) {
             return null;
+        }
+        if (fromText.isEmpty()) {
+            return text;
         }
         final StringBuilder buf = new StringBuilder(100);
         int pos = 0;

--- a/src/main/java/org/codelibs/core/lang/SystemUtil.java
+++ b/src/main/java/org/codelibs/core/lang/SystemUtil.java
@@ -40,7 +40,7 @@ public abstract class SystemUtil {
     /**
      * <code>line.separator</code> system property. For example, on Mac OS X: <code>"\n"</code>
      */
-    public static final String LINE_SEPARATOR = System.getProperty("line.separator");
+    public static final String LINE_SEPARATOR = System.lineSeparator();
 
     /**
      * <code>path.separator</code> system property. For example, on Mac OS X: <code>":"</code>
@@ -112,7 +112,7 @@ public abstract class SystemUtil {
     /**
      * Provider for current time in milliseconds. Can be overridden for testing.
      */
-    private static LongSupplier timeProvider = System::currentTimeMillis;
+    private static volatile LongSupplier timeProvider = System::currentTimeMillis;
 
     /**
      * Returns the current time in milliseconds.

--- a/src/main/java/org/codelibs/core/log/Logger.java
+++ b/src/main/java/org/codelibs/core/log/Logger.java
@@ -274,7 +274,7 @@ public class Logger {
      *            Message
      */
     public void warn(final Object message) {
-        log.warn(message.toString());
+        log.warn(toString(message));
     }
 
     /**
@@ -286,7 +286,7 @@ public class Logger {
      *            Exception
      */
     public void error(final Object message, final Throwable throwable) {
-        log.error(message.toString(), throwable);
+        log.error(toString(message), throwable);
     }
 
     /**
@@ -296,7 +296,7 @@ public class Logger {
      *            Message
      */
     public void error(final Object message) {
-        log.error(message.toString());
+        log.error(toString(message));
     }
 
     /**
@@ -308,7 +308,7 @@ public class Logger {
      *            Exception
      */
     public void fatal(final Object message, final Throwable throwable) {
-        log.fatal(message.toString(), throwable);
+        log.fatal(toString(message), throwable);
     }
 
     /**
@@ -318,7 +318,7 @@ public class Logger {
      *            Message
      */
     public void fatal(final Object message) {
-        log.fatal(message.toString());
+        log.fatal(toString(message));
     }
 
     /**

--- a/src/main/java/org/codelibs/core/misc/DynamicProperties.java
+++ b/src/main/java/org/codelibs/core/misc/DynamicProperties.java
@@ -32,6 +32,9 @@ import java.util.InvalidPropertiesFormatException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.codelibs.core.exception.FileAccessException;
 import org.codelibs.core.exception.IORuntimeException;
@@ -138,9 +141,9 @@ public class DynamicProperties extends Properties {
 
         this.propertiesFile = file;
         if (!this.propertiesFile.exists()) {
-            final File parentDir = this.propertiesFile.getParentFile();
+            final File parentDir = this.propertiesFile.getAbsoluteFile().getParentFile();
             if (!parentDir.exists()) {
-                if (!parentDir.mkdir()) {
+                if (!parentDir.mkdirs()) {
                     throw new FileAccessException("ECL0109", new Object[] { file.getAbsolutePath() });
                 }
             } else if (!parentDir.isDirectory()) {
@@ -165,9 +168,9 @@ public class DynamicProperties extends Properties {
     public synchronized void reload(final String path) {
         final File file = new File(path);
         if (!file.exists()) {
-            final File parentDir = file.getParentFile();
+            final File parentDir = file.getAbsoluteFile().getParentFile();
             if (!parentDir.exists()) {
-                if (!parentDir.mkdir()) {
+                if (!parentDir.mkdirs()) {
                     throw new FileAccessException("ECL0109", new Object[] { path });
                 }
             } else if (!parentDir.isDirectory()) {
@@ -191,7 +194,6 @@ public class DynamicProperties extends Properties {
     public boolean isUpdated() {
         final long now = System.currentTimeMillis();
         if (now - lastChecked < checkInterval) {
-            lastChecked = now;
             return false;
         }
         lastChecked = now;
@@ -431,6 +433,62 @@ public class DynamicProperties extends Properties {
     @Override
     public Collection<Object> values() {
         return getProperties().values();
+    }
+
+    @Override
+    public Object getOrDefault(final Object key, final Object defaultValue) {
+        return getProperties().getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public void forEach(final BiConsumer<? super Object, ? super Object> action) {
+        getProperties().forEach(action);
+    }
+
+    @Override
+    public void replaceAll(final BiFunction<? super Object, ? super Object, ? extends Object> function) {
+        getProperties().replaceAll(function);
+    }
+
+    @Override
+    public Object putIfAbsent(final Object key, final Object value) {
+        return getProperties().putIfAbsent(key, value);
+    }
+
+    @Override
+    public boolean remove(final Object key, final Object value) {
+        return getProperties().remove(key, value);
+    }
+
+    @Override
+    public boolean replace(final Object key, final Object oldValue, final Object newValue) {
+        return getProperties().replace(key, oldValue, newValue);
+    }
+
+    @Override
+    public Object replace(final Object key, final Object value) {
+        return getProperties().replace(key, value);
+    }
+
+    @Override
+    public Object computeIfAbsent(final Object key, final Function<? super Object, ? extends Object> mappingFunction) {
+        return getProperties().computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public Object computeIfPresent(final Object key, final BiFunction<? super Object, ? super Object, ? extends Object> remappingFunction) {
+        return getProperties().computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public Object compute(final Object key, final BiFunction<? super Object, ? super Object, ? extends Object> remappingFunction) {
+        return getProperties().compute(key, remappingFunction);
+    }
+
+    @Override
+    public Object merge(final Object key, final Object value,
+            final BiFunction<? super Object, ? super Object, ? extends Object> remappingFunction) {
+        return getProperties().merge(key, value, remappingFunction);
     }
 
     /**

--- a/src/main/java/org/codelibs/core/misc/LocaleUtil.java
+++ b/src/main/java/org/codelibs/core/misc/LocaleUtil.java
@@ -49,17 +49,17 @@ public abstract class LocaleUtil {
 
         switch (parts.length) {
         case 1:
-            return new Locale(parts[0]);
+            return Locale.of(parts[0]);
         case 2:
-            return new Locale(parts[0], parts[1]);
+            return Locale.of(parts[0], parts[1]);
         case 3:
-            return new Locale(parts[0], parts[1], parts[2]);
+            return Locale.of(parts[0], parts[1], parts[2]);
         default:
             return LocaleUtil.getDefault();
         }
     }
 
-    private static Supplier<Locale> defaultLocaleSupplier;
+    private static volatile Supplier<Locale> defaultLocaleSupplier;
 
     /**
      * Returns the default locale.

--- a/src/main/java/org/codelibs/core/misc/ValueHolder.java
+++ b/src/main/java/org/codelibs/core/misc/ValueHolder.java
@@ -64,7 +64,7 @@ public class ValueHolder<T> {
 
     @Override
     public String toString() {
-        return value.toString();
+        return String.valueOf(value);
     }
 
 }

--- a/src/main/java/org/codelibs/core/net/MimeTypeUtil.java
+++ b/src/main/java/org/codelibs/core/net/MimeTypeUtil.java
@@ -17,6 +17,7 @@ package org.codelibs.core.net;
 
 import static org.codelibs.core.misc.AssertionUtil.assertArgumentNotEmpty;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
@@ -48,7 +49,9 @@ public abstract class MimeTypeUtil {
     public static String guessContentType(final String path) {
         assertArgumentNotEmpty("path", path);
 
-        final InputStream is = ResourceUtil.getResourceAsStream(path);
+        // Wrap in a BufferedInputStream so that guessContentTypeFromStream can always
+        // mark/reset the stream, regardless of the underlying stream implementation.
+        final InputStream is = new BufferedInputStream(ResourceUtil.getResourceAsStream(path));
         try {
             final String mimetype = URLConnection.guessContentTypeFromStream(is);
             if (mimetype != null) {

--- a/src/main/java/org/codelibs/core/net/URLUtil.java
+++ b/src/main/java/org/codelibs/core/net/URLUtil.java
@@ -198,7 +198,9 @@ public abstract class URLUtil {
         assertArgumentNotNull("fileUrl", fileUrl);
 
         try {
-            final String path = URLDecoder.decode(fileUrl.getPath(), "UTF-8");
+            // A '+' in a URL path is a literal '+', but URLDecoder would decode it to a
+            // space. Pre-encode it as %2B so that a literal '+' in the path is preserved.
+            final String path = URLDecoder.decode(fileUrl.getPath().replace("+", "%2B"), "UTF-8");
             return new File(path).getAbsoluteFile();
         } catch (final Exception e) {
             throw new ClRuntimeException("ECL0091", asArray(fileUrl), e);

--- a/src/main/java/org/codelibs/core/nio/ChannelUtil.java
+++ b/src/main/java/org/codelibs/core/nio/ChannelUtil.java
@@ -173,7 +173,18 @@ public abstract class ChannelUtil {
         assertArgumentNotNull("to", to);
 
         try {
-            return from.transferTo(0, from.size(), to);
+            // FileChannel.transferTo may transfer fewer bytes than requested,
+            // so loop until the whole source has been transferred.
+            final long size = from.size();
+            long position = 0;
+            while (position < size) {
+                final long transferred = from.transferTo(position, size - position, to);
+                if (transferred <= 0) {
+                    break;
+                }
+                position += transferred;
+            }
+            return position;
         } catch (final IOException e) {
             throw new IORuntimeException(e);
         }

--- a/src/main/java/org/codelibs/core/security/MessageDigestUtil.java
+++ b/src/main/java/org/codelibs/core/security/MessageDigestUtil.java
@@ -17,11 +17,10 @@ package org.codelibs.core.security;
 
 import static org.codelibs.core.misc.AssertionUtil.assertArgumentNotEmpty;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import org.codelibs.core.exception.ClIllegalStateException;
 import org.codelibs.core.exception.NoSuchAlgorithmRuntimeException;
 
 /**
@@ -75,11 +74,7 @@ public abstract class MessageDigestUtil {
         }
 
         final MessageDigest msgDigest = getInstance(algorithm);
-        try {
-            msgDigest.update(text.getBytes("UTF-8"));
-        } catch (final UnsupportedEncodingException e) {
-            throw new ClIllegalStateException(e);
-        }
+        msgDigest.update(text.getBytes(StandardCharsets.UTF_8));
         final byte[] digest = msgDigest.digest();
 
         final StringBuilder buffer = new StringBuilder(200);

--- a/src/main/java/org/codelibs/core/text/DecimalFormatSymbolsUtil.java
+++ b/src/main/java/org/codelibs/core/text/DecimalFormatSymbolsUtil.java
@@ -63,7 +63,8 @@ public abstract class DecimalFormatSymbolsUtil {
             symbols = new DecimalFormatSymbols(locale);
             CACHE.put(locale, symbols);
         }
-        return symbols;
+        // Return a defensive copy so that callers cannot mutate the shared cached instance.
+        return (DecimalFormatSymbols) symbols.clone();
     }
 
 }

--- a/src/main/java/org/codelibs/core/text/JsonUtil.java
+++ b/src/main/java/org/codelibs/core/text/JsonUtil.java
@@ -24,7 +24,7 @@ package org.codelibs.core.text;
 public class JsonUtil {
 
     /**
-     * Defualt constructor.
+     * Default constructor.
      */
     protected JsonUtil() {
     }

--- a/src/main/java/org/codelibs/core/text/Tokenizer.java
+++ b/src/main/java/org/codelibs/core/text/Tokenizer.java
@@ -237,6 +237,9 @@ public class Tokenizer {
      * @return The string that has already been read.
      */
     public String getReadString() {
+        if (colno == 0) {
+            return "";
+        }
         return str.substring(0, colno - 1);
     }
 

--- a/src/main/java/org/codelibs/core/timer/TimeoutManager.java
+++ b/src/main/java/org/codelibs/core/timer/TimeoutManager.java
@@ -177,7 +177,13 @@ public class TimeoutManager implements Runnable {
             if (logger.isDebugEnabled()) {
                 logger.debug("TimeoutManagerThread stopped.");
             }
-            thread = null;
+            synchronized (this) {
+                // Only clear the reference if it still points to this thread; a concurrent
+                // stop()/start() may have already replaced it with a new worker thread.
+                if (thread == Thread.currentThread()) {
+                    thread = null;
+                }
+            }
             try {
                 executorService.shutdown();
                 executorService.awaitTermination(60, TimeUnit.SECONDS);

--- a/src/main/java/org/codelibs/core/timer/TimeoutTask.java
+++ b/src/main/java/org/codelibs/core/timer/TimeoutTask.java
@@ -37,9 +37,9 @@ public class TimeoutTask {
 
     private final boolean permanent;
 
-    private long startTime;
+    private volatile long startTime;
 
-    private int status = ACTIVE;
+    private volatile int status = ACTIVE;
 
     TimeoutTask(final TimeoutTarget timeoutTarget, final int timeout, final boolean permanent) {
         this.timeoutTarget = timeoutTarget;

--- a/src/main/java/org/codelibs/core/xml/SchemaFactoryUtil.java
+++ b/src/main/java/org/codelibs/core/xml/SchemaFactoryUtil.java
@@ -92,5 +92,12 @@ public abstract class SchemaFactoryUtil {
                 logger.debug("Failed to set a property.", e);
             }
         }
+        try {
+            schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (final Exception e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to set a feature.", e);
+            }
+        }
     }
 }

--- a/src/main/java/org/codelibs/core/zip/ZipFileUtil.java
+++ b/src/main/java/org/codelibs/core/zip/ZipFileUtil.java
@@ -126,7 +126,8 @@ public abstract class ZipFileUtil {
         final String urlString = zipUrl.getPath();
         final int pos = urlString.lastIndexOf('!');
         final String zipFilePath = urlString.substring(0, pos);
-        final File zipFile = new File(URLUtil.decode(zipFilePath, "UTF8"));
+        // Preserve a literal '+' in the path (URLUtil.decode would turn it into a space).
+        final File zipFile = new File(URLUtil.decode(zipFilePath.replace("+", "%2B"), "UTF8"));
         return FileUtil.getCanonicalPath(zipFile);
     }
 

--- a/src/main/resources/CLMessages.properties
+++ b/src/main/resources/CLMessages.properties
@@ -56,6 +56,7 @@ ECL0113=NoSuchPaddingException occurred, because {0}
 ECL0114=NoSuchAlgorithmException occurred, because {0}
 ECL0115=Failed to set accessible to the field: {0}
 ECL0116=Failed to set accessible to the method: {0}
+ECL0117=InvalidAlgorithmParameterException occurred, because {0}
 
 WCL0013=Protocol of URL({1}) corresponding to route package({0}) is unknown.
 WCL0014=resource corresponding to route package({0}) was not found from the class path.

--- a/src/test/java/org/codelibs/core/beans/impl/BeanDescImplTest.java
+++ b/src/test/java/org/codelibs/core/beans/impl/BeanDescImplTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -142,6 +143,20 @@ public class BeanDescImplTest {
         assertThat(methodDesc.getMethodName(), is("getAaa"));
         methodDesc = beanDesc.getMethodDescNoException("getaaa");
         assertThat(methodDesc, is(nullValue()));
+    }
+
+    /**
+     * Regression: when number adjustment fails for a candidate method, the failure must be
+     * reported as {@link MethodNotFoundRuntimeException} (not the underlying conversion
+     * exception) and the caller's argument array must be left unchanged.
+     */
+    @Test
+    public void testGetSuitableMethodDescDoesNotMutateArgsOnFailure() {
+        final BeanDesc beanDesc = new BeanDescImpl(MyBean.class);
+        final Object[] args = { "1", "notanumber" };
+        assertThrows(MethodNotFoundRuntimeException.class, () -> beanDesc.getSuitableMethodDesc("add2", args));
+        assertThat(args[0], is((Object) "1"));
+        assertThat(args[1], is((Object) "notanumber"));
     }
 
     /**

--- a/src/test/java/org/codelibs/core/beans/impl/RecordBeanDescTest.java
+++ b/src/test/java/org/codelibs/core/beans/impl/RecordBeanDescTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.core.beans.impl;
+
+import static org.codelibs.core.TestUtil.sameClass;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.codelibs.core.beans.BeanDesc;
+import org.codelibs.core.beans.PropertyDesc;
+import org.codelibs.core.beans.factory.BeanDescFactory;
+import org.junit.Test;
+
+/**
+ * Tests {@link BeanDescImpl} support for Java {@link Record} types.
+ */
+public class RecordBeanDescTest {
+
+    /** A record with primitive components. */
+    public record Point(int x, int y) {
+    }
+
+    /** A record mixing a reference-type component and a primitive component. */
+    public record Person(String name, int age) {
+    }
+
+    /** A conventional JavaBean used to confirm non-record behavior is unchanged. */
+    public static class Hello {
+        private String message;
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(final String message) {
+            this.message = message;
+        }
+    }
+
+    /**
+     * Record accessors ({@code name()} form, without get/is/set prefixes) are detected as read-only properties.
+     */
+    @Test
+    public void testRecordPropertyDetection() throws Exception {
+        final BeanDesc beanDesc = BeanDescFactory.getBeanDesc(Point.class);
+        // Only x and y; the record branch must not double-register alongside the get/is/set scan.
+        assertThat(beanDesc.getPropertyDescSize(), is(2));
+
+        final PropertyDesc x = beanDesc.getPropertyDesc("x");
+        assertThat(x.getPropertyName(), is("x"));
+        assertThat(x.getPropertyType(), is(sameClass(int.class)));
+        assertThat(x.getReadMethod(), is(notNullValue()));
+        assertThat(x.getReadMethod().getName(), is("x"));
+        assertThat(x.getWriteMethod(), is(nullValue()));
+        assertThat(x.isReadable(), is(true));
+        assertThat(x.isWritable(), is(false));
+        assertThat(x.hasWriteMethod(), is(false));
+
+        assertThat(beanDesc.hasPropertyDesc("y"), is(true));
+    }
+
+    /**
+     * The property value is read through the record accessor.
+     */
+    @Test
+    public void testRecordGetValue() throws Exception {
+        final BeanDesc beanDesc = BeanDescFactory.getBeanDesc(Point.class);
+        final Point point = new Point(10, 20);
+        assertThat(beanDesc.getPropertyDesc("x").getValue(point), is(10));
+        assertThat(beanDesc.getPropertyDesc("y").getValue(point), is(20));
+    }
+
+    /**
+     * A record component of reference type is read correctly.
+     */
+    @Test
+    public void testRecordReferenceComponent() throws Exception {
+        final BeanDesc beanDesc = BeanDescFactory.getBeanDesc(Person.class);
+        final PropertyDesc name = beanDesc.getPropertyDesc("name");
+        assertThat(name.getPropertyType(), is(sameClass(String.class)));
+        final Person person = new Person("Alice", 30);
+        assertThat(name.getValue(person), is("Alice"));
+        assertThat(beanDesc.getPropertyDesc("age").getValue(person), is(30));
+    }
+
+    /**
+     * A record is instantiated through its canonical constructor, which is discovered via the existing
+     * constructor scan; arguments are matched in declaration order.
+     */
+    @Test
+    public void testRecordNewInstance() throws Exception {
+        final BeanDesc beanDesc = BeanDescFactory.getBeanDesc(Point.class);
+        final Point point = beanDesc.newInstance(3, 4);
+        assertThat(point, is(notNullValue()));
+        assertThat(point.x(), is(3));
+        assertThat(point.y(), is(4));
+    }
+
+    /**
+     * A conventional JavaBean with getter/setter continues to expose a readable and writable property.
+     */
+    @Test
+    public void testRegularBeanUnchanged() throws Exception {
+        final BeanDesc beanDesc = BeanDescFactory.getBeanDesc(Hello.class);
+        final PropertyDesc message = beanDesc.getPropertyDesc("message");
+        assertThat(message.getPropertyType(), is(sameClass(String.class)));
+        assertThat(message.getReadMethod(), is(notNullValue()));
+        assertThat(message.getWriteMethod(), is(notNullValue()));
+        assertThat(message.isReadable(), is(true));
+        assertThat(message.isWritable(), is(true));
+
+        final Hello hello = new Hello();
+        message.setValue(hello, "world");
+        assertThat(message.getValue(hello), is("world"));
+    }
+}

--- a/src/test/java/org/codelibs/core/collection/ArrayMapTest.java
+++ b/src/test/java/org/codelibs/core/collection/ArrayMapTest.java
@@ -225,6 +225,39 @@ public class ArrayMapTest {
     }
 
     /**
+     * Verifies that {@link ArrayMap#clone()} produces an independent copy whose hash
+     * buckets resolve correctly and whose entries are not shared with the original.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testClone() throws Exception {
+        @SuppressWarnings("unchecked")
+        final ArrayMap<String, String> copy = (ArrayMap<String, String>) map.clone();
+        assertThat(copy.size(), is(3));
+        // Keys must resolve through the rebuilt bucket table, not a truncated one.
+        assertThat(copy.get(null), is(nullValue()));
+        assertThat(copy.get("1"), is("test"));
+        assertThat(copy.get("2"), is("test2"));
+        // Insertion order must be preserved.
+        assertThat(copy.getAt(0), is(nullValue()));
+        assertThat(copy.getAt(1), is("test"));
+        assertThat(copy.getAt(2), is("test2"));
+        // put on the clone must not throw and must not modify the original.
+        copy.put("3", "test3");
+        copy.put("4", "test4");
+        assertThat(copy.get("3"), is("test3"));
+        assertThat(copy.get("4"), is("test4"));
+        assertThat(map.containsKey("3"), is(not(true)));
+        assertThat(map.size(), is(3));
+        // remove on the clone must not corrupt the original's entries.
+        assertThat(copy.remove("1"), is("test"));
+        assertThat(copy.containsKey("1"), is(not(true)));
+        assertThat(map.get("1"), is("test"));
+        assertThat(map.containsKey("1"), is(true));
+    }
+
+    /**
      * @throws Exception
      */
     @Test

--- a/src/test/java/org/codelibs/core/collection/CaseInsensitiveMapTest.java
+++ b/src/test/java/org/codelibs/core/collection/CaseInsensitiveMapTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.After;
@@ -103,6 +104,40 @@ public class CaseInsensitiveMapTest {
         assertThat(map.get("THREE"), is("3"));
         assertThat(map.get("FOUR"), is("4"));
         assertThat(map.size(), is(4));
+    }
+
+    /**
+     * A {@literal null} key must be supported the same way the parent {@link ArrayMap} supports it.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testNullKey() throws Exception {
+        assertThat(map.put(null, "nullValue"), is(nullValue()));
+        assertThat(map.containsKey(null), is(true));
+        assertThat(map.get(null), is("nullValue"));
+        assertThat(map.remove(null), is("nullValue"));
+        assertThat(map.containsKey(null), is(not(true)));
+    }
+
+    /**
+     * Key folding must be locale-independent (e.g. the Turkish dotless-i must not break
+     * case-insensitive lookups of ASCII keys).
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLocaleIndependentKey() throws Exception {
+        final Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+            final CaseInsensitiveMap<String> m = new CaseInsensitiveMap<String>();
+            m.put("ID", "value");
+            assertThat(m.get("id"), is("value"));
+            assertThat(m.containsKey("id"), is(true));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     /**

--- a/src/test/java/org/codelibs/core/collection/CaseInsensitiveSetTest.java
+++ b/src/test/java/org/codelibs/core/collection/CaseInsensitiveSetTest.java
@@ -16,10 +16,12 @@
 package org.codelibs.core.collection;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
 import java.util.Set;
 
+import org.codelibs.core.io.SerializeUtil;
 import org.junit.Test;
 
 /**
@@ -35,6 +37,23 @@ public class CaseInsensitiveSetTest {
         final Set<String> set = new CaseInsensitiveSet();
         set.add("one");
         assertThat(set.contains("ONE"), is(true));
+    }
+
+    /**
+     * The set must survive serialization even though the backing map is {@code transient}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSerialize() throws Exception {
+        final CaseInsensitiveSet set = new CaseInsensitiveSet();
+        set.add("one");
+        set.add("two");
+        final CaseInsensitiveSet copy = (CaseInsensitiveSet) SerializeUtil.serialize(set);
+        assertThat(copy.size(), is(2));
+        assertThat(copy.contains("ONE"), is(true));
+        assertThat(copy.contains("Two"), is(true));
+        assertThat(copy.contains("three"), is(not(true)));
     }
 
 }

--- a/src/test/java/org/codelibs/core/collection/LruHashSetTest.java
+++ b/src/test/java/org/codelibs/core/collection/LruHashSetTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.core.collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.codelibs.core.io.SerializeUtil;
+import org.junit.Test;
+
+/**
+ * @author shinsuke
+ */
+public class LruHashSetTest {
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testLimit() throws Exception {
+        final LruHashSet<String> set = new LruHashSet<>(2);
+        set.add("aaa");
+        set.add("bbb");
+        set.add("ccc");
+        assertThat(set.size(), is(2));
+        assertThat(set.contains("aaa"), is(not(true)));
+        assertThat(set.contains("bbb"), is(true));
+        assertThat(set.contains("ccc"), is(true));
+    }
+
+    /**
+     * The set stores a non-serializable sentinel as the backing map value, so it must
+     * serialize the elements (and the limit size) itself rather than the map values.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSerialize() throws Exception {
+        final LruHashSet<String> set = new LruHashSet<>(3);
+        set.add("aaa");
+        set.add("bbb");
+        @SuppressWarnings("unchecked")
+        final LruHashSet<String> copy = (LruHashSet<String>) SerializeUtil.serialize(set);
+        assertThat(copy.size(), is(2));
+        assertThat(copy.contains("aaa"), is(true));
+        assertThat(copy.contains("bbb"), is(true));
+        assertThat(copy.contains("ccc"), is(not(true)));
+        // The limit size must survive serialization.
+        copy.add("ccc");
+        copy.add("ddd");
+        assertThat(copy.size(), is(3));
+    }
+
+}

--- a/src/test/java/org/codelibs/core/convert/BinaryConversionUtilTest.java
+++ b/src/test/java/org/codelibs/core/convert/BinaryConversionUtilTest.java
@@ -19,6 +19,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import java.nio.charset.StandardCharsets;
+
 import org.codelibs.core.exception.ClIllegalArgumentException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,6 +49,16 @@ public class BinaryConversionUtilTest {
         final byte[] b = { 0x00, 0x01 };
         assertThat(BinaryConversionUtil.toBinary(b), is(b));
         assertThat(BinaryConversionUtil.toBinary("hoge"), is("hoge".getBytes()));
+    }
+
+    /**
+     * A {@link String} must be encoded with a fixed charset (UTF-8) so the result does not
+     * depend on the platform default charset.
+     */
+    @Test
+    public void testToBinaryUtf8() {
+        final String value = "あいう"; // Japanese hiragana
+        assertThat(BinaryConversionUtil.toBinary(value), is(value.getBytes(StandardCharsets.UTF_8)));
     }
 
     /**

--- a/src/test/java/org/codelibs/core/convert/TemporalConversionUtilTest.java
+++ b/src/test/java/org/codelibs/core/convert/TemporalConversionUtilTest.java
@@ -1,0 +1,496 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.core.convert;
+
+import static org.codelibs.core.convert.TemporalConversionUtil.toInstant;
+import static org.codelibs.core.convert.TemporalConversionUtil.toLocalDate;
+import static org.codelibs.core.convert.TemporalConversionUtil.toLocalDateTime;
+import static org.codelibs.core.convert.TemporalConversionUtil.toLocalTime;
+import static org.codelibs.core.convert.TemporalConversionUtil.toOffsetDateTime;
+import static org.codelibs.core.convert.TemporalConversionUtil.toZonedDateTime;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.codelibs.core.exception.NullArgumentException;
+import org.codelibs.core.exception.ParseRuntimeException;
+import org.junit.Test;
+
+/**
+ * @author shinsuke
+ */
+public class TemporalConversionUtilTest {
+
+    /** Fixed reference instant used across the tests: 2010-09-07T06:05:04Z. */
+    private static final Instant INSTANT = Instant.parse("2010-09-07T06:05:04Z");
+
+    /** Epoch milliseconds of {@link #INSTANT}. */
+    private static final long MILLIS = INSTANT.toEpochMilli();
+
+    /** Fixed time zone used to keep zone-dependent assertions environment independent. */
+    private static final ZoneId UTC = ZoneOffset.UTC;
+
+    // -----------------------------------------------------------------
+    // toLocalDate
+    // -----------------------------------------------------------------
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDate_Null() throws Exception {
+        assertThat(toLocalDate(null), is(nullValue()));
+        assertThat(toLocalDate(null, UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDate_EmptyString() throws Exception {
+        assertThat(toLocalDate("", UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDate_Passthrough() throws Exception {
+        final LocalDate src = LocalDate.of(2010, 9, 7);
+        assertThat(toLocalDate(src, UTC), is(src));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDate_Date() throws Exception {
+        assertThat(toLocalDate(new Date(MILLIS), UTC), is(LocalDate.of(2010, 9, 7)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDate_EpochMillis() throws Exception {
+        assertThat(toLocalDate(MILLIS, UTC), is(LocalDate.of(2010, 9, 7)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDate_String() throws Exception {
+        assertThat(toLocalDate("2010-09-07", UTC), is(LocalDate.of(2010, 9, 7)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDate_DefaultZone() throws Exception {
+        assertThat(toLocalDate(new Date(MILLIS)), is(INSTANT.atZone(ZoneId.systemDefault()).toLocalDate()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test(expected = ParseRuntimeException.class)
+    public void testToLocalDate_InvalidString() throws Exception {
+        toLocalDate("invalid", UTC);
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test(expected = NullArgumentException.class)
+    public void testToLocalDate_NullZone() throws Exception {
+        toLocalDate(new Date(MILLIS), null);
+    }
+
+    // -----------------------------------------------------------------
+    // toLocalDateTime
+    // -----------------------------------------------------------------
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDateTime_Null() throws Exception {
+        assertThat(toLocalDateTime(null), is(nullValue()));
+        assertThat(toLocalDateTime(null, UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDateTime_EmptyString() throws Exception {
+        assertThat(toLocalDateTime("", UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDateTime_Passthrough() throws Exception {
+        final LocalDateTime src = LocalDateTime.of(2010, 9, 7, 6, 5, 4);
+        assertThat(toLocalDateTime(src, UTC), is(src));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDateTime_Date() throws Exception {
+        assertThat(toLocalDateTime(new Date(MILLIS), UTC), is(LocalDateTime.of(2010, 9, 7, 6, 5, 4)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDateTime_EpochMillis() throws Exception {
+        assertThat(toLocalDateTime(MILLIS, UTC), is(LocalDateTime.of(2010, 9, 7, 6, 5, 4)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDateTime_String() throws Exception {
+        assertThat(toLocalDateTime("2010-09-07T06:05:04", UTC), is(LocalDateTime.of(2010, 9, 7, 6, 5, 4)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalDateTime_DefaultZone() throws Exception {
+        assertThat(toLocalDateTime(new Date(MILLIS)), is(LocalDateTime.ofInstant(INSTANT, ZoneId.systemDefault())));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test(expected = ParseRuntimeException.class)
+    public void testToLocalDateTime_InvalidString() throws Exception {
+        toLocalDateTime("invalid", UTC);
+    }
+
+    // -----------------------------------------------------------------
+    // toLocalTime
+    // -----------------------------------------------------------------
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalTime_Null() throws Exception {
+        assertThat(toLocalTime(null), is(nullValue()));
+        assertThat(toLocalTime(null, UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalTime_EmptyString() throws Exception {
+        assertThat(toLocalTime("", UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalTime_Passthrough() throws Exception {
+        final LocalTime src = LocalTime.of(6, 5, 4);
+        assertThat(toLocalTime(src, UTC), is(src));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalTime_Date() throws Exception {
+        assertThat(toLocalTime(new Date(MILLIS), UTC), is(LocalTime.of(6, 5, 4)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalTime_EpochMillis() throws Exception {
+        assertThat(toLocalTime(MILLIS, UTC), is(LocalTime.of(6, 5, 4)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalTime_String() throws Exception {
+        assertThat(toLocalTime("06:05:04", UTC), is(LocalTime.of(6, 5, 4)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToLocalTime_DefaultZone() throws Exception {
+        assertThat(toLocalTime(new Date(MILLIS)), is(INSTANT.atZone(ZoneId.systemDefault()).toLocalTime()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test(expected = ParseRuntimeException.class)
+    public void testToLocalTime_InvalidString() throws Exception {
+        toLocalTime("invalid", UTC);
+    }
+
+    // -----------------------------------------------------------------
+    // toInstant
+    // -----------------------------------------------------------------
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToInstant_Null() throws Exception {
+        assertThat(toInstant(null), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToInstant_EmptyString() throws Exception {
+        assertThat(toInstant(""), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToInstant_Passthrough() throws Exception {
+        assertThat(toInstant(INSTANT), is(INSTANT));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToInstant_Date() throws Exception {
+        assertThat(toInstant(new Date(MILLIS)), is(INSTANT));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToInstant_Calendar() throws Exception {
+        final Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(MILLIS);
+        assertThat(toInstant(calendar), is(INSTANT));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToInstant_Timestamp_PreservesNanos() throws Exception {
+        final Instant withNanos = INSTANT.plusNanos(123456789);
+        final Timestamp timestamp = Timestamp.from(withNanos);
+        assertThat(toInstant(timestamp), is(withNanos));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToInstant_EpochMillis() throws Exception {
+        assertThat(toInstant(MILLIS), is(INSTANT));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToInstant_String() throws Exception {
+        assertThat(toInstant("2010-09-07T06:05:04Z"), is(INSTANT));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test(expected = ParseRuntimeException.class)
+    public void testToInstant_InvalidString() throws Exception {
+        toInstant("invalid");
+    }
+
+    // -----------------------------------------------------------------
+    // toOffsetDateTime
+    // -----------------------------------------------------------------
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToOffsetDateTime_Null() throws Exception {
+        assertThat(toOffsetDateTime(null), is(nullValue()));
+        assertThat(toOffsetDateTime(null, UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToOffsetDateTime_EmptyString() throws Exception {
+        assertThat(toOffsetDateTime("", UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToOffsetDateTime_Passthrough() throws Exception {
+        final OffsetDateTime src = OffsetDateTime.of(2010, 9, 7, 6, 5, 4, 0, ZoneOffset.UTC);
+        assertThat(toOffsetDateTime(src, UTC), is(src));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToOffsetDateTime_Date() throws Exception {
+        assertThat(toOffsetDateTime(new Date(MILLIS), UTC), is(OffsetDateTime.of(2010, 9, 7, 6, 5, 4, 0, ZoneOffset.UTC)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToOffsetDateTime_EpochMillis() throws Exception {
+        assertThat(toOffsetDateTime(MILLIS, UTC), is(OffsetDateTime.of(2010, 9, 7, 6, 5, 4, 0, ZoneOffset.UTC)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToOffsetDateTime_String() throws Exception {
+        assertThat(toOffsetDateTime("2010-09-07T06:05:04+00:00", UTC), is(OffsetDateTime.of(2010, 9, 7, 6, 5, 4, 0, ZoneOffset.UTC)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToOffsetDateTime_DefaultZone() throws Exception {
+        assertThat(toOffsetDateTime(new Date(MILLIS)), is(OffsetDateTime.ofInstant(INSTANT, ZoneId.systemDefault())));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test(expected = ParseRuntimeException.class)
+    public void testToOffsetDateTime_InvalidString() throws Exception {
+        toOffsetDateTime("invalid", UTC);
+    }
+
+    // -----------------------------------------------------------------
+    // toZonedDateTime
+    // -----------------------------------------------------------------
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToZonedDateTime_Null() throws Exception {
+        assertThat(toZonedDateTime(null), is(nullValue()));
+        assertThat(toZonedDateTime(null, UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToZonedDateTime_EmptyString() throws Exception {
+        assertThat(toZonedDateTime("", UTC), is(nullValue()));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToZonedDateTime_Passthrough() throws Exception {
+        final ZonedDateTime src = ZonedDateTime.of(2010, 9, 7, 6, 5, 4, 0, UTC);
+        assertThat(toZonedDateTime(src, UTC), is(src));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToZonedDateTime_Date() throws Exception {
+        assertThat(toZonedDateTime(new Date(MILLIS), UTC), is(ZonedDateTime.ofInstant(INSTANT, UTC)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToZonedDateTime_EpochMillis() throws Exception {
+        assertThat(toZonedDateTime(MILLIS, UTC), is(ZonedDateTime.ofInstant(INSTANT, UTC)));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToZonedDateTime_String() throws Exception {
+        assertThat(toZonedDateTime("2010-09-07T06:05:04Z", UTC), is(ZonedDateTime.parse("2010-09-07T06:05:04Z")));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToZonedDateTime_DefaultZone() throws Exception {
+        assertThat(toZonedDateTime(new Date(MILLIS)), is(ZonedDateTime.ofInstant(INSTANT, ZoneId.systemDefault())));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test(expected = ParseRuntimeException.class)
+    public void testToZonedDateTime_InvalidString() throws Exception {
+        toZonedDateTime("invalid", UTC);
+    }
+
+}

--- a/src/test/java/org/codelibs/core/convert/TimestampConversionUtilTest.java
+++ b/src/test/java/org/codelibs/core/convert/TimestampConversionUtilTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.core.convert;
 
+import static org.codelibs.core.convert.TimestampConversionUtil.getLongPattern;
 import static org.codelibs.core.convert.TimestampConversionUtil.toCalendar;
 import static org.codelibs.core.convert.TimestampConversionUtil.toDate;
 import static org.codelibs.core.convert.TimestampConversionUtil.toPlainPattern;
@@ -30,6 +31,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import org.codelibs.core.exception.NullArgumentException;
 import org.codelibs.core.misc.LocaleUtil;
 import org.junit.After;
 import org.junit.Before;
@@ -235,6 +237,19 @@ public class TimestampConversionUtilTest {
     }
 
     /**
+     * The locale passed to {@code toCalendar} must be honored when parsing the pattern.
+     * The default locale is {@link Locale#JAPANESE} (see {@link #setUp()}), so the English
+     * month name only parses when the explicitly supplied {@link Locale#US} is used.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testToCalendar_SpecificPatternWithLocale() throws Exception {
+        final Calendar calendar = toCalendar("Sep 7, 2010 11:49:10", "MMM d, yyyy HH:mm:ss", Locale.US);
+        assertThat(new SimpleDateFormat("yyyy/MM/dd HH:mm:ss").format(calendar.getTime()), is("2010/09/07 11:49:10"));
+    }
+
+    /**
      * @throws Exception
      */
     @Test
@@ -332,6 +347,17 @@ public class TimestampConversionUtilTest {
     @Test
     public void testToPlainPattern() throws Exception {
         assertThat(toPlainPattern("y/M/d H:m:s"), is("yyMMdd HHmmss"));
+    }
+
+    /**
+     * {@code getLongPattern} must reject a {@code null} locale, consistent with the other
+     * {@code getXxxPattern(Locale)} methods.
+     *
+     * @throws Exception
+     */
+    @Test(expected = NullArgumentException.class)
+    public void testGetLongPattern_NullLocale() throws Exception {
+        getLongPattern(null);
     }
 
 }

--- a/src/test/java/org/codelibs/core/crypto/CachedCipherTest.java
+++ b/src/test/java/org/codelibs/core/crypto/CachedCipherTest.java
@@ -183,6 +183,32 @@ public class CachedCipherTest {
     }
 
     @Test
+    public void testEncryptDecryptWithIv() {
+        final CachedCipher cipher = new CachedCipher();
+        final Key key = new SecretKeySpec("0123456789abcdef".getBytes(), "AES");
+        final byte[] original = "Hello World".getBytes();
+
+        final byte[] encrypted1 = cipher.encryptWithIv(original, key);
+        final byte[] encrypted2 = cipher.encryptWithIv(original, key);
+
+        // A fresh random IV per call means the same plaintext yields different ciphertext.
+        assertThat(encrypted1, is(not(encrypted2)));
+        assertArrayEquals(original, cipher.decryptWithIv(encrypted1, key));
+        assertArrayEquals(original, cipher.decryptWithIv(encrypted2, key));
+    }
+
+    @Test(expected = org.codelibs.core.exception.BadPaddingRuntimeException.class)
+    public void testDecryptWithIvRejectsTamperedData() {
+        final CachedCipher cipher = new CachedCipher();
+        final Key key = new SecretKeySpec("0123456789abcdef".getBytes(), "AES");
+        final byte[] encrypted = cipher.encryptWithIv("Hello World".getBytes(), key);
+
+        // Flip a bit in the ciphertext; GCM authentication must reject it.
+        encrypted[encrypted.length - 1] ^= 0x01;
+        cipher.decryptWithIv(encrypted, key);
+    }
+
+    @Test
     public void testStringKeyChangeInvalidatesPooledCipher() {
         // Regression: changing the key on a reused instance must take effect. Before the fix,
         // the pooled cipher retained the previous key and encrypted with it.

--- a/src/test/java/org/codelibs/core/crypto/CachedCipherTest.java
+++ b/src/test/java/org/codelibs/core/crypto/CachedCipherTest.java
@@ -20,6 +20,10 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 
+import java.security.Key;
+
+import javax.crypto.spec.SecretKeySpec;
+
 import org.junit.Test;
 
 /**
@@ -157,5 +161,41 @@ public class CachedCipherTest {
         final String decrypted = cipher.decryptText(encrypted);
 
         assertThat(decrypted, is(original));
+    }
+
+    @Test
+    public void testKeyBasedCipherReinitializedPerKey() {
+        // Regression: a pooled cipher must be re-initialized with the given key on every
+        // operation. Before the fix, encrypt(data, keyB) reused the cipher still initialized
+        // with keyA, so keyB was silently ignored (encA == encB) and decrypt(encB, keyB) failed.
+        final CachedCipher cipher = new CachedCipher();
+        final Key keyA = new SecretKeySpec("0123456789abcdef".getBytes(), "Blowfish");
+        final Key keyB = new SecretKeySpec("fedcba9876543210".getBytes(), "Blowfish");
+
+        final byte[] data = "Hello World".getBytes();
+
+        final byte[] encA = cipher.encrypt(data, keyA);
+        final byte[] encB = cipher.encrypt(data, keyB);
+
+        assertThat(encA, is(not(encB)));
+        assertArrayEquals(data, cipher.decrypt(encA, keyA));
+        assertArrayEquals(data, cipher.decrypt(encB, keyB));
+    }
+
+    @Test
+    public void testStringKeyChangeInvalidatesPooledCipher() {
+        // Regression: changing the key on a reused instance must take effect. Before the fix,
+        // the pooled cipher retained the previous key and encrypted with it.
+        final CachedCipher cipher = new CachedCipher();
+
+        cipher.setKey("keyOne");
+        final byte[] data = "Hello World".getBytes();
+        final byte[] encOne = cipher.encrypt(data);
+
+        cipher.setKey("keyTwo");
+        final byte[] encTwo = cipher.encrypt(data);
+
+        assertThat(encOne, is(not(encTwo)));
+        assertArrayEquals(data, cipher.decrypt(encTwo));
     }
 }

--- a/src/test/java/org/codelibs/core/io/CloseableUtilTest.java
+++ b/src/test/java/org/codelibs/core/io/CloseableUtilTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.codelibs.core.exception.IORuntimeException;
 import org.junit.Test;
 
 /**
@@ -53,6 +54,32 @@ public class CloseableUtilTest {
     public void testClose_noThrowIOException() throws Exception {
         final OutputStream out = new IOExceptionOccurOutputStream();
         CloseableUtil.close(out);
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testCloseAndRethrow() throws Exception {
+        final NotifyOutputStream out = new NotifyOutputStream();
+        CloseableUtil.closeAndRethrow(out);
+        assertThat(out.getNotify(), is("closed"));
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testCloseAndRethrowNull() throws Exception {
+        CloseableUtil.closeAndRethrow((OutputStream) null);
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test(expected = IORuntimeException.class)
+    public void testCloseAndRethrow_propagatesIOException() throws Exception {
+        CloseableUtil.closeAndRethrow(new IOExceptionOccurOutputStream());
     }
 
     private static class NotifyOutputStream extends OutputStream {

--- a/src/test/java/org/codelibs/core/io/CopyUtilTest.java
+++ b/src/test/java/org/codelibs/core/io/CopyUtilTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThat;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -162,6 +163,34 @@ public class CopyUtilTest {
 
         result = copy(outputFile, "UTF-8", writer);
         assertThat(writer.toString(), is(urlString));
+    }
+
+    /**
+     * Copying a multi-megabyte file must transfer every byte, even when the
+     * underlying channel transfer completes in more than one step.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFileToFile_LargeContentIsComplete() throws Exception {
+        final File src = File.createTempFile("copyutil-src", ".dat");
+        final File dest = File.createTempFile("copyutil-dest", ".dat");
+        try {
+            final byte[] expected = new byte[3 * 1024 * 1024 + 123]; // ~3MB, not buffer-aligned
+            for (int i = 0; i < expected.length; i++) {
+                expected[i] = (byte) (i * 31 + 7);
+            }
+            try (FileOutputStream fos = new FileOutputStream(src)) {
+                fos.write(expected);
+            }
+
+            final int result = copy(src, dest);
+            assertThat(result, is(expected.length));
+            assertThat(FileUtil.readBytes(dest, expected.length), is(expected));
+        } finally {
+            src.delete();
+            dest.delete();
+        }
     }
 
 }

--- a/src/test/java/org/codelibs/core/io/FileUtilTest.java
+++ b/src/test/java/org/codelibs/core/io/FileUtilTest.java
@@ -339,6 +339,28 @@ public class FileUtilTest {
         assertThat(new String(bytes, "UTF-8"), is(content));
     }
 
+    /**
+     * Test readBytes returns the complete content for a multi-megabyte file, so
+     * that a partial channel read cannot leave the trailing bytes zero-filled.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testReadBytes_LargeContentIsComplete() throws Exception {
+        final File file = tempFolder.newFile("large_complete.dat");
+        final byte[] expected = new byte[3 * 1024 * 1024 + 123]; // ~3MB, not buffer-aligned
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = (byte) (i * 31 + 7);
+        }
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(expected);
+        }
+
+        final byte[] actual = FileUtil.readBytes(file, expected.length);
+        assertThat(actual.length, is(expected.length));
+        assertThat(actual, is(expected));
+    }
+
     private String getPath(final String fileName) {
         return getClass().getName().replace('.', '/').replaceFirst(getClass().getSimpleName(), fileName);
     }

--- a/src/test/java/org/codelibs/core/io/FileUtilTest.java
+++ b/src/test/java/org/codelibs/core/io/FileUtilTest.java
@@ -80,6 +80,45 @@ public class FileUtilTest {
     }
 
     /**
+     * Test isRealPathSafe with an existing file inside the base and a non-existent path.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testIsRealPathSafe_ExistingInsideAndMissing() throws Exception {
+        final Path baseDir = tempFolder.getRoot().toPath();
+        final File inside = tempFolder.newFile("inside.txt");
+
+        assertTrue("Existing file inside base should be allowed", FileUtil.isRealPathSafe(inside.toPath(), baseDir));
+        assertFalse("Non-existent path should be rejected", FileUtil.isRealPathSafe(baseDir.resolve("missing.txt"), baseDir));
+    }
+
+    /**
+     * Test that isRealPathSafe rejects a symbolic link inside the base that escapes it,
+     * whereas the lexical isPathSafe is fooled.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testIsRealPathSafe_SymlinkEscapingBaseIsRejected() throws Exception {
+        final Path root = tempFolder.getRoot().toPath();
+        final Path baseDir = Files.createDirectory(root.resolve("base"));
+        final Path outsideDir = Files.createDirectory(root.resolve("outside"));
+        final Path secret = Files.createFile(outsideDir.resolve("secret.txt"));
+
+        final Path link = baseDir.resolve("link");
+        try {
+            Files.createSymbolicLink(link, secret);
+        } catch (final UnsupportedOperationException | IOException e) {
+            // Symbolic links may be unsupported (e.g. Windows without privilege); skip the test.
+            org.junit.Assume.assumeNoException(e);
+        }
+
+        assertTrue("Lexical check is fooled by the link", FileUtil.isPathSafe(link, baseDir));
+        assertFalse("Real-path check resolves the escape", FileUtil.isRealPathSafe(link, baseDir));
+    }
+
+    /**
      * Test isPathSafe with path traversal attempt
      *
      * @throws Exception

--- a/src/test/java/org/codelibs/core/io/SerializeUtilTest.java
+++ b/src/test/java/org/codelibs/core/io/SerializeUtilTest.java
@@ -207,6 +207,31 @@ public class SerializeUtilTest extends TestCase {
     }
 
     /**
+     * Test that the default filter rejects a payload whose object-graph depth
+     * exceeds the resource limit, even though every class is on the allowlist.
+     *
+     * @throws Exception
+     */
+    public void testFromBinaryToObject_DefaultFilter_RejectsDeepGraph() throws Exception {
+        final ArrayList<Object> root = new ArrayList<>();
+        ArrayList<Object> current = root;
+        // Nest well beyond MAX_DEPTH (100) but not deep enough to risk a
+        // StackOverflowError during serialization.
+        for (int i = 0; i < 150; i++) {
+            final ArrayList<Object> child = new ArrayList<>();
+            current.add(child);
+            current = child;
+        }
+        final byte[] binary = SerializeUtil.fromObjectToBinary(root);
+        try {
+            SerializeUtil.fromBinaryToObject(binary);
+            fail("Expected IORuntimeException for a deeply nested object graph");
+        } catch (final IORuntimeException e) {
+            // Expected: rejected by the resource limit in the default filter.
+        }
+    }
+
+    /**
      * Test helper class for serialization tests
      */
     public static class TestSerializableClass implements Serializable {

--- a/src/test/java/org/codelibs/core/lang/ClassUtilTest.java
+++ b/src/test/java/org/codelibs/core/lang/ClassUtilTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import org.codelibs.core.exception.EmptyArgumentException;
+import org.codelibs.core.exception.InstantiationRuntimeException;
+import org.codelibs.core.exception.InvocationTargetRuntimeException;
 import org.codelibs.core.exception.NoSuchConstructorRuntimeException;
 import org.codelibs.core.exception.NoSuchFieldRuntimeException;
 import org.junit.Test;
@@ -196,6 +198,42 @@ public class ClassUtilTest {
     public void testConvertClass() {
         assertThat(ClassUtil.convertClass("int"), is(sameClass(int.class)));
         assertThat(ClassUtil.convertClass("java.lang.String"), is(sameClass(String.class)));
+    }
+
+    /**
+     * A class with an accessible no-arg constructor is instantiated.
+     */
+    @Test
+    public void testNewInstance() {
+        assertThat(ClassUtil.newInstance(StringBuilder.class), is(not(nullValue())));
+    }
+
+    /**
+     * An abstract class is still reported as {@link InstantiationRuntimeException}.
+     */
+    @Test(expected = InstantiationRuntimeException.class)
+    public void testNewInstance_abstract() {
+        ClassUtil.newInstance(AbstractHoge.class);
+    }
+
+    /**
+     * An exception raised by the constructor is wrapped in {@link InvocationTargetRuntimeException}.
+     */
+    @Test(expected = InvocationTargetRuntimeException.class)
+    public void testNewInstance_throwingConstructor() {
+        ClassUtil.newInstance(ThrowingHoge.class);
+    }
+
+    /** Abstract class used by {@link #testNewInstance_abstract()}. */
+    public abstract static class AbstractHoge {
+    }
+
+    /** Class whose constructor always throws, used by {@link #testNewInstance_throwingConstructor()}. */
+    public static class ThrowingHoge {
+        /** Always throws to exercise the constructor failure path. */
+        public ThrowingHoge() {
+            throw new IllegalStateException("boom");
+        }
     }
 
 }

--- a/src/test/java/org/codelibs/core/lang/StringUtilTest.java
+++ b/src/test/java/org/codelibs/core/lang/StringUtilTest.java
@@ -47,6 +47,18 @@ public class StringUtilTest {
     }
 
     /**
+     * An empty {@code fromText} must return the text unchanged instead of looping forever.
+     *
+     * @throws Exception
+     */
+    @Test(timeout = 5000)
+    public void testReplace_emptyFromText() throws Exception {
+        assertEquals("abc", StringUtil.replace("abc", "", "x"));
+        assertEquals("", StringUtil.replace("", "", "x"));
+        assertNull(StringUtil.replace(null, "", "x"));
+    }
+
+    /**
      * @throws Exception
      */
     @Test

--- a/src/test/java/org/codelibs/core/misc/DynamicPropertiesTest.java
+++ b/src/test/java/org/codelibs/core/misc/DynamicPropertiesTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.core.misc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link DynamicProperties}.
+ */
+public class DynamicPropertiesTest {
+
+    private File tempDir;
+
+    /**
+     * @throws Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("dynprops").toFile();
+    }
+
+    /**
+     * @throws Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+        deleteRecursively(tempDir);
+    }
+
+    private static void deleteRecursively(final File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        final File[] children = file.listFiles();
+        if (children != null) {
+            for (final File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+
+    private DynamicProperties newProps() {
+        return new DynamicProperties(new File(tempDir, "test.properties"));
+    }
+
+    /**
+     * Repeated calls faster than the check interval must not slide the throttle window and
+     * suppress the modification check forever.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testIsUpdated_throttleWindowDoesNotSlide() throws Exception {
+        final DynamicProperties props = newProps();
+        props.checkInterval = 2000L;
+        // Force the real check to report "updated" whenever it actually runs.
+        props.lastModified = 0L;
+        // Place the last check just inside the throttle window.
+        props.lastChecked = System.currentTimeMillis() - 1800L;
+
+        // Inside the throttle window: returns false without advancing lastChecked.
+        assertFalse(props.isUpdated());
+
+        // Once the interval elapses the real check must run, even though calls kept coming.
+        Thread.sleep(400L);
+        assertTrue(props.isUpdated());
+    }
+
+    /**
+     * {@link DynamicProperties#forEach} must operate on the backing properties, not the empty super class.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForEachDelegatesToInternalProperties() throws Exception {
+        final DynamicProperties props = newProps();
+        props.setProperty("a", "1");
+        props.setProperty("b", "2");
+
+        final Map<Object, Object> collected = new HashMap<>();
+        props.forEach(collected::put);
+
+        assertEquals(2, collected.size());
+        assertEquals("1", collected.get("a"));
+        assertEquals("2", collected.get("b"));
+    }
+
+    /**
+     * {@link DynamicProperties#getOrDefault} must read from the backing properties.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetOrDefaultDelegatesToInternalProperties() throws Exception {
+        final DynamicProperties props = newProps();
+        props.setProperty("a", "1");
+
+        assertEquals("1", props.getOrDefault("a", "z"));
+        assertEquals("z", props.getOrDefault("missing", "z"));
+    }
+
+    /**
+     * {@link DynamicProperties#computeIfAbsent} must write to the backing properties so that
+     * {@link DynamicProperties#getProperty} can read the value back.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testComputeIfAbsentDelegatesToInternalProperties() throws Exception {
+        final DynamicProperties props = newProps();
+
+        props.computeIfAbsent("k", k -> "v");
+
+        assertEquals("v", props.getProperty("k"));
+    }
+
+    /**
+     * A path whose intermediate directories do not exist must be created.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConstructorCreatesMissingNestedDirectories() throws Exception {
+        final File nested = new File(tempDir, "a/b/c/test.properties");
+
+        new DynamicProperties(nested);
+
+        assertTrue(nested.exists());
+    }
+
+    /**
+     * A bare file name (no parent directory component) must not raise a {@link NullPointerException}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConstructorWithBareFilenameDoesNotThrowNpe() throws Exception {
+        final File bare = new File("dynprops_" + System.nanoTime() + ".properties");
+        try {
+            new DynamicProperties(bare);
+            assertTrue(bare.exists());
+        } finally {
+            bare.delete();
+        }
+    }
+}

--- a/src/test/java/org/codelibs/core/misc/ValueHolderTest.java
+++ b/src/test/java/org/codelibs/core/misc/ValueHolderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.core.misc;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link ValueHolder}.
+ */
+public class ValueHolderTest {
+
+    /**
+     * A null value must not raise a {@link NullPointerException} from {@link ValueHolder#toString()}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testToString_nullValue() throws Exception {
+        assertEquals("null", new ValueHolder<String>().toString());
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testToString_nonNullValue() throws Exception {
+        assertEquals("abc", new ValueHolder<>("abc").toString());
+    }
+}

--- a/src/test/java/org/codelibs/core/net/URLUtilTest.java
+++ b/src/test/java/org/codelibs/core/net/URLUtilTest.java
@@ -60,4 +60,16 @@ public class URLUtilTest extends TestCase {
         assertEquals(file.getAbsoluteFile(), URLUtil.toFile(new URL("file:Program%20Files/hoge.txt")));
     }
 
+    /**
+     * A literal '+' in a file path must be preserved (not decoded to a space).
+     *
+     * @throws Exception
+     */
+    public void testToFileWithPlus() throws Exception {
+        final File file = new File("my+project/hoge.txt");
+        assertEquals(file.getAbsoluteFile(), URLUtil.toFile(new URL("file:my+project/hoge.txt")));
+        // Encoded space (%20) must still decode to a space.
+        assertEquals(new File("my project/hoge.txt").getAbsoluteFile(), URLUtil.toFile(new URL("file:my%20project/hoge.txt")));
+    }
+
 }

--- a/src/test/java/org/codelibs/core/text/DecimalFormatSymbolsUtilTest.java
+++ b/src/test/java/org/codelibs/core/text/DecimalFormatSymbolsUtilTest.java
@@ -34,4 +34,19 @@ public class DecimalFormatSymbolsUtilTest extends TestCase {
         System.out.println("DecimalSeparator:" + symbols.getDecimalSeparator());
         System.out.println("GroupingSeparator:" + symbols.getGroupingSeparator());
     }
+
+    /**
+     * The returned {@link DecimalFormatSymbols} must be a defensive copy so that mutating it
+     * does not corrupt the shared cached instance.
+     *
+     * @throws Exception
+     */
+    public void testGetDecimalFormatSymbolsReturnsDefensiveCopy() throws Exception {
+        final DecimalFormatSymbols first = DecimalFormatSymbolsUtil.getDecimalFormatSymbols(Locale.US);
+        final char originalDecimalSeparator = first.getDecimalSeparator();
+        first.setDecimalSeparator('#');
+        final DecimalFormatSymbols second = DecimalFormatSymbolsUtil.getDecimalFormatSymbols(Locale.US);
+        assertFalse(first == second);
+        assertEquals(originalDecimalSeparator, second.getDecimalSeparator());
+    }
 }

--- a/src/test/java/org/codelibs/core/text/TokenizerTest.java
+++ b/src/test/java/org/codelibs/core/text/TokenizerTest.java
@@ -37,6 +37,17 @@ public class TokenizerTest {
     }
 
     /**
+     * {@code getReadString} must not throw when called before any token has been read.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetReadStringBeforeNextToken() throws Exception {
+        final Tokenizer tokenizer = new Tokenizer("abc");
+        assertThat(tokenizer.getReadString(), is(""));
+    }
+
+    /**
      * @throws Exception
      */
     @Test


### PR DESCRIPTION
## Summary

Java 21 review of the core utilities. Two commits:

1. **`fix(core)`** — correctness, thread-safety, and security bug fixes (backward-compatible only), with regression tests.
2. **`feat(core)`** — additive enhancements: `java.time` conversions, record support, and opt-in secure APIs. No existing behavior or defaults change.

`mvn clean test` → **707 tests, 0 failures**.

## Fixes (backward-compatible)

**collection**
- `ArrayMap.clone()` rebuilds the hash table instead of truncating it to the element count (corrupted `get`/`remove`, could throw `ArrayIndexOutOfBoundsException` on a later `put`).
- `LruHashSet` / `CaseInsensitiveSet` implement `writeObject`/`readObject` (were unserializable / restored to a `null` map).
- `CaseInsensitiveMap` accepts `null` keys and lowercases with `Locale.ROOT`.

**misc / lang**
- `DynamicProperties`: fixed a reload-throttle bug that disabled change detection under frequent access; delegated the `Map` default methods to the backing store; used `mkdirs()`.
- `SystemUtil` / `LocaleUtil` use `volatile` suppliers; `ClassUtil.newInstance` uses `getDeclaredConstructor()`; `StringUtil.replace` guards an empty search string; plus small modernizations.

**io / nio / net**
- `FileUtil.readBytes` reads until the buffer is filled or EOF (a short `FileChannel.read` returned zero-padded data); added a 2 GB guard.
- `ChannelUtil` loops `transferTo` until the whole source is copied.
- `SerializeUtil`'s default deserialization filter enforces depth / reference / stream-byte / array-length limits.
- Preserve a literal `+` when decoding URL / resource / jar / zip paths.

**crypto / convert / beans / timer / xml / log / security**
- `CachedCipher` re-initializes a pooled cipher with the current key on every operation and clears the pool on config change.
- `TimestampConversionUtil` honors the `Locale`; `DecimalFormatSymbolsUtil` returns a clone.
- `BeanDescImpl` no longer mutates the caller's args during overload resolution; `BeanDescFactory` deregisters its cache disposable on `clear()`.
- `TimeoutManager` fixes a thread-clear race; `TimeoutTask` fields are `volatile`; `SchemaFactoryUtil` enables secure processing; `Logger` is null-safe.

## Enhancements (additive — no behavior change)

- **`convert`**: new `TemporalConversionUtil` converts `Date` / `Calendar` / epoch-millis / ISO-8601 strings and `java.time` values to `LocalDate` / `LocalDateTime` / `LocalTime` / `Instant` / `OffsetDateTime` / `ZonedDateTime` (system-default zone, or an explicit `ZoneId`).
- **`beans`**: `BeanDescImpl` detects record components as read-only properties and instantiates records through their canonical constructor. Non-record beans are unchanged.
- **`crypto`**: `CachedCipher.encryptWithIv` / `decryptWithIv` provide AES/GCM authenticated encryption with a fresh random IV per call, as an opt-in alternative to the pooled Blowfish/ECB methods (which are unchanged). The caller supplies the AES `Key`.
- **`io`**: `CloseableUtil.closeAndRethrow` propagates close failures (for output streams, where a swallowed close = data loss); `FileUtil.isRealPathSafe` resolves symbolic links via `toRealPath`. Existing `close`/`closeQuietly` and `isPathSafe` are unchanged.
- **`exception`**: `InvalidAlgorithmParameterRuntimeException` (message `ECL0117`).

## Deferred (not in this PR — would change observable behavior or public API)

Left out to preserve backward compatibility; each needs a deliberate decision, ideally under a major version bump:

- **CachedCipher default mode** (ECB) — changing it would break decryption of existing ciphertext (the new opt-in AES/GCM API above is the compatible path).
- **`StringUtil.appendHex(int)` zero-padding** — an existing test and `UuidUtil` depend on the current output.
- **`UuidUtil` uniqueness** — the generated random part is effectively 32 bits; strengthening it changes the string format.
- **`Logger` SLF4J backend**, **`ArrayMap` `equals`/`hashCode` contract**, **`URLUtil` `new URL(...)` → `URI.toURL()`**, **`SLinkedList.remove(int)` return type**, **`CloseableUtil.close` semantics** — behavior/API changes for follow-up.

## Testing

Regression tests were added for the high-severity fixes and for every new API. `mvn clean test` passes with 707 tests.
